### PR TITLE
Local deploy

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -61,6 +61,10 @@ service in your local cluster.`,
 		//Deploy image name is also project name
 		deployImage := getProjectName()
 
+		// We're not pushing to a repository, so we need to use dev.local for Knative to be able to find it
+		if (push == false) {
+			tag = "dev.local/" + deployImage
+		}
 		//Tagging the image if necessary and using the tag as the deployImage for KNative
 		if tag != "" {
 			err = DockerTag(deployImage, tag)
@@ -72,7 +76,7 @@ service in your local cluster.`,
 		}
 		//Generating the KNative yaml file
 		Debug.logf("Calling GenKnativeYaml with parms: %s %d %s %s \n", knativeTempl, port, serviceName, deployImage)
-		yamlFileName, err := GenKnativeYaml(knativeTempl, port, serviceName, deployImage)
+		yamlFileName, err := GenKnativeYaml(knativeTempl, port, serviceName, deployImage, push)
 		if err != nil {
 			Error.log("Could not generate the KNative YAML file: ", err)
 			os.Exit(1)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -62,7 +62,7 @@ service in your local cluster.`,
 		deployImage := getProjectName()
 
 		// We're not pushing to a repository, so we need to use dev.local for Knative to be able to find it
-		if (push == false) {
+		if !push {
 			tag = "dev.local/" + deployImage
 		}
 		//Tagging the image if necessary and using the tag as the deployImage for KNative

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -348,7 +348,7 @@ func getExposedPorts() []string {
 }
 
 //GenKnativeYaml generates a simple yaml for KNative serving
-func GenKnativeYaml(yamlTemplate string, deployPort int, serviceName string, deployImage string) (fileName string, yamlErr error) {
+func GenKnativeYaml(yamlTemplate string, deployPort int, serviceName string, deployImage string, pullImage bool) (fileName string, yamlErr error) {
 	// KNative serving YAML representation in a struct
 	type Y struct {
 		APIVersion string `yaml:"apiVersion"`
@@ -381,6 +381,10 @@ func GenKnativeYaml(yamlTemplate string, deployPort int, serviceName string, dep
 	yamlMap.Metadata.Name = serviceName
 	//Set the image
 	yamlMap.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Image = deployImage
+	//Set the image pull policy to Never if we're not pushing an image to a registry
+	if (pullImage == false) {
+		yamlMap.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.ImagePullPolicy = "Never"
+	}
 	//Set the containerPort
 	ports := yamlMap.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Ports
 	if len(ports) > 1 {
@@ -470,7 +474,7 @@ spec:
         spec:
           container:
             image: myimage
-            imagePullPolicy: Always
+            imagePullPolicy: IfNotPresent 
             ports:
             - containerPort: 8080
 `

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -382,7 +382,7 @@ func GenKnativeYaml(yamlTemplate string, deployPort int, serviceName string, dep
 	//Set the image
 	yamlMap.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Image = deployImage
 	//Set the image pull policy to Never if we're not pushing an image to a registry
-	if pullImage == false {
+	if !pullImage {
 		yamlMap.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.ImagePullPolicy = "Never"
 	}
 	//Set the containerPort

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -382,7 +382,7 @@ func GenKnativeYaml(yamlTemplate string, deployPort int, serviceName string, dep
 	//Set the image
 	yamlMap.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.Image = deployImage
 	//Set the image pull policy to Never if we're not pushing an image to a registry
-	if (pullImage == false) {
+	if pullImage == false {
 		yamlMap.Spec.RunLatest.Configuration.RevisionTemplate.Spec.Container.ImagePullPolicy = "Never"
 	}
 	//Set the containerPort
@@ -474,7 +474,7 @@ spec:
         spec:
           container:
             image: myimage
-            imagePullPolicy: IfNotPresent 
+            imagePullPolicy: Always
             ports:
             - containerPort: 8080
 `

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -13,9 +13,11 @@ var yamlGenTests = []struct {
 	testImageName      string
 	testPortNum        int
 	testServiceName    string
+	testPullPolicy     bool
 }{
-	{getKNativeTemplate1, "TESTIMAGE", 9091, "TESTSERVICE"},
-	{getKNativeTemplateNoports, "TESTIMAGE", 9091, "TESTSERVICE"},
+	{getKNativeTemplate1, "TESTIMAGE", 9091, "TESTSERVICE", false},
+	{getKNativeTemplate2, "TESTIMAGE", 9091, "TESTSERVICE", true},
+	{getKNativeTemplateNoports, "TESTIMAGE", 9091, "TESTSERVICE", true},
 }
 
 // requires clean dir
@@ -27,7 +29,8 @@ func TestGenYAML(t *testing.T) {
 			testImageName := test.testImageName
 			testPortNum := test.testPortNum
 			testGetter := test.yamlTemplateGetter
-			yamlFileName, err := cmd.GenKnativeYaml(testGetter(), testPortNum, testServiceName, testImageName)
+			testPullPolicy := test.testPullPolicy
+			yamlFileName, err := cmd.GenKnativeYaml(testGetter(), testPortNum, testServiceName, testImageName, testPullPolicy)
 			if err != nil {
 				t.Fatal("Can't generate the YAML for KNative serving deploy. Error: ", err)
 			}
@@ -58,6 +61,27 @@ spec:
 `
 	return yamltempl
 }
+
+func getKNativeTemplate2() string {
+	yamltempl := `
+apiVersion: serving.knative.dev/v1alpha1
+kind: Service
+metadata:
+  name: test
+spec:
+  runLatest:
+    configuration:
+      revisionTemplate:
+        spec:
+          container:
+            image: myimage
+            imagePullPolicy: Never
+            ports:
+            - containerPort: 8080
+`
+	return yamltempl
+}
+
 func getKNativeTemplateNoports() string {
 	yamltempl := `
 apiVersion: serving.knative.dev/v1alpha1


### PR DESCRIPTION
This updates `appsody deploy` so that the local Docker cache will be used if the `--push` option is not provided.

To do this, the image must be tagged as `dev.local/<name>`, and the `ImagePullPolicy` needs to be something other than `Always`.