### PR TITLE
add go as a build prereq to build.md

### DIFF
--- a/build.md
+++ b/build.md
@@ -5,6 +5,7 @@ Prerequisites:
 
 * docker is installed and running
 * wget is installed
+* go is installed
 
 After setting the `GOPATH` env var correctly, just run `make <action...>` from the command line, within the same directory where `Makefile` resides. For example `make package clean` will run the `package` and then the `clean` actions.
 


### PR DESCRIPTION
Documentation does not list go as being a prerequsite on the host system for building appsody CLI

Signed-off-by: Stewart Addison <sxa@uk.ibm.com>