### PR TITLE
doc: specify the minimum go version

### DIFF
--- a/build.md
+++ b/build.md
@@ -3,6 +3,7 @@
 
 Prerequisites:
 
+* go version 1.12 or higher is installed and in the path
 * docker is installed and running
 * wget is installed
 


### PR DESCRIPTION
Currently the CLI fails to build if the version
is lower than 1.12.  Specify that level as one
of the pre-reqs.