### PR TITLE
Allow appsody to build projects with capital letters in their folder name

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ stages:
   - name: lint
   - name: test
   - name: deploy
-    if: branch = master AND tag IS present
+    if: tag IS present
 
 install-controller: &install-controller
   install:

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -32,20 +32,24 @@ var buildCmd = &cobra.Command{
 
 		extractCmd.Run(cmd, args)
 
-		projectDir := getProjectDir()
-		projectName := filepath.Base(projectDir)
+		projectName := getProjectName()
 		extractDir := filepath.Join(getHome(), "extract", projectName)
 		dockerfile := filepath.Join(extractDir, "Dockerfile")
-
+		buildImage := projectName //Lowercased
+		// If a tag is specified, change the buildImage
+		if tag != "" {
+			buildImage = tag
+		}
 		cmdName := "docker"
-		cmdArgs := []string{"build", "-t", projectName, "-f", dockerfile, extractDir}
+		cmdArgs := []string{"build", "-t", buildImage, "-f", dockerfile, extractDir}
 		execAndWait(cmdName, cmdArgs, DockerLog)
 		if !dryrun {
-			Info.log("Built docker image ", projectName)
+			Info.log("Built docker image ", buildImage)
 		}
 	},
 }
 
 func init() {
 	rootCmd.AddCommand(buildCmd)
+	buildCmd.PersistentFlags().StringVarP(&tag, "tag", "t", "", "Docker image name and optionally a tag in the 'name:tag' format")
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -227,7 +227,7 @@ func getProjectConfig() ProjectConfig {
 }
 func getProjectName() string {
 	projectDir := getProjectDir()
-	projectName := filepath.Base(projectDir)
+	projectName := strings.ToLower(filepath.Base(projectDir))
 	return projectName
 }
 func execAndListen(command string, args []string, logger appsodylogger) (*exec.Cmd, error) {


### PR DESCRIPTION
`appsody build` would fail if the project directory has capital letters in it. This happens because Appsody uses the folder name as the image name to build. Since Docker doesn't support capital letters, `appsody build` fails in these circumstances.

The current PR introduces two main changes:
1) In case you run `appsody build` with no flags, the project name is lowercased and used as the image name.
2) There's a new `-t <tag>` flag that you can use to specify an arbitrary tag name. If you use this flag, you shouldn't be using capital letters in the tag (we'll just pass it on to Docker as is). 

Now - these changes (and this issue) have some repercussions on `appsody deploy` as well. This command has two flags:
1) `-t <tag>` which is passed on to the `appsody build` command if it is present
2) `--push`, which is only used by `appsody deploy`. If present, the image will be pushed to Docker Hub (or to whatever Docker registry you are currently logged into).
Now - if you **do not** specify `--push`, the deploy command will also tag the image as `local.dev/<project folder name lowercased>` - this happens to allow Knative to access the local Docker cache. In other words, if you run (notice the absence of `--push`):
```
appsody deploy -t my-image-tag
```
what happens is the following:
1) `appsody build` will run and the image will be tagged as `my-image-tag`
2) The image also gets tagged as `dev.local/<project folder name>`
3) The Knative service that gets deployed will reference the `dev.local` image

If you run: 
```
appsody deploy -t my-image-tag --push
```
what happens is the following:
1) `appsody build` will run and the image will be tagged as `my-image-tag`
2) The image is pushed to the Docker registry, using `my-image-tag`
3) The Knative service that gets deployed will reference `my-image-tag`, and will attempt to download the image from the remote registry.
