### PR TITLE
Http proxy fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ stages:
   - name: lint
   - name: test
   - name: deploy
-    if: branch = master AND tag IS present
+    if: tag IS present
 
 install-controller: &install-controller
   install:

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -168,7 +168,10 @@ func ensureConfig() {
 func downloadFile(href string, writer io.Writer) error {
 
 	// allow file:// scheme
-	t := &http.Transport{}
+	t := &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+	}
+	Debug.log("Proxy function for HTTP transport set to: ", &t.Proxy)
 	if runtime.GOOS == "windows" {
 		// For Windows, remove the root url. It seems to work fine with an empty string.
 		t.RegisterProtocol("file", http.NewFileTransport(http.Dir("")))
@@ -187,6 +190,7 @@ func downloadFile(href string, writer io.Writer) error {
 	if err != nil {
 		return err
 	}
+
 	defer resp.Body.Close()
 	if resp.StatusCode != 200 {
 		buf, err := ioutil.ReadAll(resp.Body)


### PR DESCRIPTION
Modified the transport creation in repo.go to include the http(s) proxy from the environment.
Now - clients who set the HTTPS_PROXY or HTTP_PROXY env var will go through the proxy.
This fixes #90.