### PR TITLE
Adding support for multiple disk devices

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ stages:
   - name: lint
   - name: test
   - name: deploy
-    if: branch = master AND tag IS present
+    if: tag IS present
 
 install-controller: &install-controller
   install:

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -156,10 +156,9 @@ in preparation to build the final docker image.`,
 			if dryrun {
 				Info.log("Dry Run - Skip moving ", extractDir, " to ", targetDir)
 			} else {
-				Debug.log("Moving ", extractDir, " to ", targetDir)
-				err = os.Rename(extractDir, targetDir)
+				err = MoveDir(extractDir, targetDir)
 				if err != nil {
-					Error.log("Could not move ", extractDir, " to ", targetDir, " ", err)
+					Error.log("Extract failed when moving ", extractDir, " to ", targetDir, " ", err)
 					os.Exit(1)
 				}
 				Info.log("Project extracted to ", targetDir)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -287,6 +287,58 @@ func CopyFile(source string, dest string) error {
 	return nil
 }
 
+// MoveDir moves a directory to another directory, even if they are on different partitions
+func MoveDir(fromDir string, toDir string) error {
+	Debug.log("Moving ", fromDir, " to ", toDir)
+	// Let's try os.Rename first
+	err := os.Rename(fromDir, toDir)
+	if err == nil {
+		// We did it - returning
+		//Error.log("Could not move ", extractDir, " to ", targetDir, " ", err)
+		return nil
+	}
+	// If we are here, we need to use copy
+	Debug.log("os.Rename did not work to move directories... attempting copy. From dir:", fromDir, " target dir: ", toDir)
+	err = copyDir(fromDir, toDir)
+	if err != nil {
+		Error.log("Could not move ", fromDir, " to ", toDir)
+		return err
+	}
+	return nil
+}
+
+func copyDir(fromDir string, toDir string) error {
+	_, err := os.Stat(fromDir)
+	if err != nil {
+		Error.logf("Cannot find source directory %s to copy", fromDir)
+		return err
+	}
+
+	var execCmd string
+	var execArgs = []string{fromDir, toDir}
+
+	if runtime.GOOS == "windows" {
+		execCmd = "CMD"
+		winArgs := []string{"/C", "XCOPY", "/I", "/E", "/H", "/K"}
+		execArgs = append(winArgs[0:], execArgs...)
+
+	} else {
+		execCmd = "cp"
+		bashArgs := []string{"-rf"}
+		execArgs = append(bashArgs[0:], execArgs...)
+	}
+	Debug.log("About to run: ", execCmd, execArgs)
+	copyCmd := exec.Command(execCmd, execArgs...)
+	cmdOutput, cmdErr := copyCmd.Output()
+	_, err = os.Stat(toDir)
+	if err != nil {
+		Error.logf("Could not copy %s to %s - output of copy command %s %s\n", fromDir, toDir, cmdOutput, cmdErr)
+		return errors.New("Error in copy: " + cmdErr.Error())
+	}
+	Debug.logf("Directory copy of %s to %s was successful \n", fromDir, toDir)
+	return nil
+}
+
 // CheckPrereqs checks the prerequisites to run the CLI
 func CheckPrereqs() error {
 	dockerCmd := "docker"


### PR DESCRIPTION
Caught os.Rename() error and added logic to copy dirs and their contents.
Tested with java-microprofile on both Windows (C:\ and D:\ drives) and Linux (multiple disks). 
This fixes #82.