### PR TITLE
Ensure CLI always updates the appsody-controller

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ stages:
   - name: lint
   - name: test
   - name: deploy
-    if: branch = master AND tag IS present
+    if: tag IS present
 
 install-controller: &install-controller
   install:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,8 @@ all: lint test package ## Run lint, test, build, and package
 
 .PHONY: test
 test: ## Run the all the automated tests
-	$(GO_TEST_COMMAND_WITH_ENV)
+	export APPSODY_MOUNT_CONTROLLER=~/.appsody/appsody-controller
+	$(GO_TEST_COMMAND) ./...
 
 .PHONY: unittest
 unittest: ## Run the automated unit tests
@@ -42,7 +43,8 @@ unittest: ## Run the automated unit tests
 
 .PHONY: functest
 functest: ## Run the automated functional tests
-	$(GO_FUNC_TEST_COMMAND_WITH_ENV) 
+	export APPSODY_MOUNT_CONTROLLER=~/.appsody/appsody-controller
+	$(GO_TEST_COMMAND) ./functest
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT_BINARY) ## Run the static code analyzers

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 #### Constant variables
 # use -count=1 to disable cache and -p=1 to stream output live
-GO_TEST_COMMAND := go test -v -count=1 -p=1
+GO_TEST_COMMAND := export APPSODY_MOUNT_CONTROLLER=~/.appsody/appsody-controller && go test -v -count=1 -p=1
 # Set a default VERSION only if it is not already set
 VERSION ?= 0.0.0
 COMMAND := appsody
@@ -17,8 +17,6 @@ BINARY_EXT_windows := .exe
 DOCKER_IMAGE_RPM := alectolytic/rpmbuilder
 DOCKER_IMAGE_DEB := appsody/debian-builder
 CONTROLLER_BASE_URL := https://github.com/${GH_ORG}/controller/releases/download/0.2.1
-GO_TEST_COMMAND_WITH_ENV := APPSODY_MOUNT_CONTROLLER=~/.appsody/appsody-controller bash -c '$(GO_TEST_COMMAND) ./...'
-GO_FUNC_TEST_COMMAND_WITH_ENV := APPSODY_MOUNT_CONTROLLER=~/.appsody/appsody-controller bash -c '$(GO_TEST_COMMAND) ./functest'
 
 #### Dynamic variables. These change depending on the target name.
 # Gets the current os from the target name, e.g. the 'build-linux' target will result in os = 'linux'
@@ -34,7 +32,6 @@ all: lint test package ## Run lint, test, build, and package
 
 .PHONY: test
 test: ## Run the all the automated tests
-	export APPSODY_MOUNT_CONTROLLER=~/.appsody/appsody-controller
 	$(GO_TEST_COMMAND) ./...
 
 .PHONY: unittest
@@ -43,7 +40,6 @@ unittest: ## Run the automated unit tests
 
 .PHONY: functest
 functest: ## Run the automated functional tests
-	export APPSODY_MOUNT_CONTROLLER=~/.appsody/appsody-controller
 	$(GO_TEST_COMMAND) ./functest
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,8 @@ BINARY_EXT_windows := .exe
 DOCKER_IMAGE_RPM := alectolytic/rpmbuilder
 DOCKER_IMAGE_DEB := appsody/debian-builder
 CONTROLLER_BASE_URL := https://github.com/${GH_ORG}/controller/releases/download/0.2.1
-
+GO_TEST_COMMAND_WITH_ENV := APPSODY_MOUNT_CONTROLLER=~/.appsody/appsody-controller bash -c '$(GO_TEST_COMMAND) ./...'
+GO_FUNC_TEST_COMMAND_WITH_ENV := APPSODY_MOUNT_CONTROLLER=~/.appsody/appsody-controller bash -c '$(GO_TEST_COMMAND) ./functest'
 
 #### Dynamic variables. These change depending on the target name.
 # Gets the current os from the target name, e.g. the 'build-linux' target will result in os = 'linux'
@@ -33,8 +34,7 @@ all: lint test package ## Run lint, test, build, and package
 
 .PHONY: test
 test: ## Run the all the automated tests
-    cp ~/.appsody/appsody-controller .
-	$(GO_TEST_COMMAND) ./...
+	$(GO_TEST_COMMAND_WITH_ENV)
 
 .PHONY: unittest
 unittest: ## Run the automated unit tests
@@ -42,8 +42,7 @@ unittest: ## Run the automated unit tests
 
 .PHONY: functest
 functest: ## Run the automated functional tests
-	cp ~/.appsody/appsody-controller .
-	$(GO_TEST_COMMAND) ./functest
+	$(GO_FUNC_TEST_COMMAND_WITH_ENV) 
 
 .PHONY: lint
 lint: $(GOLANGCI_LINT_BINARY) ## Run the static code analyzers

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ BINARY_EXT_windows := .exe
 DOCKER_IMAGE_RPM := alectolytic/rpmbuilder
 DOCKER_IMAGE_DEB := appsody/debian-builder
 CONTROLLER_BASE_URL := https://github.com/${GH_ORG}/controller/releases/download/0.2.1
+APPSODY_MOUNT_CONTROLLER := ~/.appsody/appsody-controller
 
 #### Dynamic variables. These change depending on the target name.
 # Gets the current os from the target name, e.g. the 'build-linux' target will result in os = 'linux'

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,7 @@ BINARY_EXT_windows := .exe
 DOCKER_IMAGE_RPM := alectolytic/rpmbuilder
 DOCKER_IMAGE_DEB := appsody/debian-builder
 CONTROLLER_BASE_URL := https://github.com/${GH_ORG}/controller/releases/download/0.2.1
-APPSODY_MOUNT_CONTROLLER := ~/.appsody/appsody-controller
+
 
 #### Dynamic variables. These change depending on the target name.
 # Gets the current os from the target name, e.g. the 'build-linux' target will result in os = 'linux'
@@ -33,6 +33,7 @@ all: lint test package ## Run lint, test, build, and package
 
 .PHONY: test
 test: ## Run the all the automated tests
+    cp ~/.appsody/appsody-controller .
 	$(GO_TEST_COMMAND) ./...
 
 .PHONY: unittest
@@ -41,6 +42,7 @@ unittest: ## Run the automated unit tests
 
 .PHONY: functest
 functest: ## Run the automated functional tests
+	cp ~/.appsody/appsody-controller .
 	$(GO_TEST_COMMAND) ./functest
 
 .PHONY: lint

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@
 
 #### Constant variables
 # use -count=1 to disable cache and -p=1 to stream output live
-GO_TEST_COMMAND := export APPSODY_MOUNT_CONTROLLER=~/.appsody/appsody-controller && go test -v -count=1 -p=1
+GO_TEST_COMMAND := export APPSODY_MOUNT_CONTROLLER=${HOME}/.appsody/appsody-controller && go test -v -count=1 -p=1
 # Set a default VERSION only if it is not already set
 VERSION ?= 0.0.0
 COMMAND := appsody

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -129,7 +129,7 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) {
 		//if _, err := os.Stat(destController); os.IsNotExist(err) {
 		// Always copy it from the executable dir
 		//Retrieving the path of the binaries appsody and appsody-controller
-		Debug.log("Didn't find the controller in .appsody - copying from the binary directory...")
+		//Debug.log("Didn't find the controller in .appsody - copying from the binary directory...")
 		executable, _ := os.Executable()
 		binaryLocation, err := filepath.Abs(filepath.Dir(executable))
 		Debug.log("Binary location ", binaryLocation)


### PR DESCRIPTION
This PR addresses #100, by removing the check on the presence of an `appsody-controller` file in the $HOME/.appsody directory. Now, the CLI always copies the controller from the binary directory, ensuring that the user is working with the correct level of the controller, even after an upgrade of the CLI.
One ramification of this change is that it broke the automated tests. Therefore, we had to pass the `APPSODY_MOUNT_CONTROLLER` env var to the `go test` commands for full and functional testing, so that the copy would be skipped in test mode.