### PR TITLE
CLI Extract: project directory mixed case fix

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ stages:
   - name: lint
   - name: test
   - name: deploy
-    if: branch = master AND tag IS present
+    if: tag IS present
 
 install-controller: &install-controller
   install:

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -32,9 +32,7 @@ var extractCmd = &cobra.Command{
 	Long: `This copies the full project, stack plus app, into a local directory
 in preparation to build the final docker image.`,
 	Run: func(cmd *cobra.Command, args []string) {
-		// Make sure we are in an Appsody project
-		projectDir, perr := getProjectDir()
-
+		projectName, perr := getProjectName()
 		if perr != nil {
 			Error.log(perr)
 			os.Exit(1)
@@ -85,7 +83,7 @@ in preparation to build the final docker image.`,
 				}
 			}
 		}
-		extractDir = filepath.Join(extractDir, filepath.Base(projectDir))
+		extractDir = filepath.Join(extractDir, projectName)
 		extractDirExists, err = exists(extractDir)
 		if err != nil {
 			Error.log("Error checking directory: ", err)


### PR DESCRIPTION
Mixed case still present in the project extract directory, which causes issues on Linux (but not on Mac or Windows, where Docker seems to be tolerant of mixed case in paths). 
Fixes https://github.com/eclipse/codewind/issues/33.
Fixes #107 