### PR TITLE
Remove os.exit from docs.go and list.go #3

### DIFF
--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -14,12 +14,12 @@
 package cmd
 
 import (
-	"errors"
 	"os"
 	"path"
 	"path/filepath"
 	"strings"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
 	flag "github.com/spf13/pflag"
@@ -79,15 +79,16 @@ func generateDoc(commandDocFile string) error {
 var docsCmd = &cobra.Command{
 	Use:    "docs",
 	Hidden: true,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 
 		Debug.log("Running appsody docs command.")
 		err := generateDoc(docFile)
 		if err != nil {
-			Error.log("appsody docs command failed with error: ", err)
-			os.Exit(1)
+			return errors.Errorf("appsody docs command failed with error: %v", err)
+
 		}
 		Debug.log("appsody docs command completed successfully.")
+		return nil
 	},
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -15,8 +15,7 @@
 package cmd
 
 import (
-	"os"
-
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -25,15 +24,16 @@ var listCmd = &cobra.Command{
 	Use:   "list",
 	Short: "List the Appsody stacks available to init",
 	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 
 		var index RepoIndex
 		err := index.getIndex()
 		if err != nil {
-			Error.log("Could not read index: ", err)
-			os.Exit(1)
+			return errors.Errorf("Could not read index: %v", err)
+
 		}
 		Info.log("\n", index.listProjects())
+		return nil
 	},
 }
 

--- a/cmd/repo_remove.go
+++ b/cmd/repo_remove.go
@@ -16,8 +16,8 @@ package cmd
 
 import (
 	"log"
-	"os"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -26,10 +26,9 @@ var removeCmd = &cobra.Command{
 	Use:   "remove <name>",
 	Short: "Remove a configured Appsody repository",
 	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) < 1 {
-			Error.log("Error, you must specify repository name")
-			os.Exit(1)
+			return errors.New("Error, you must specify repository name")
 		}
 		var repoName = args[0]
 
@@ -48,6 +47,7 @@ var removeCmd = &cobra.Command{
 				log.Fatalf("Failed to write file repository location: %v", err)
 			}
 		}
+		return nil
 	},
 }
 

--- a/cmd/repo_remove_test.go
+++ b/cmd/repo_remove_test.go
@@ -1,0 +1,34 @@
+// Copyright © 2019 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/appsody/appsody/cmd/cmdtest"
+)
+
+func TestRepoRemoveError(t *testing.T) {
+
+	args := []string{"repo", "remove"}
+	output, err := cmdtest.RunAppsodyCmdExec(args, ".")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(output, "Error, you must specify repository name") {
+		t.Error("String \"Error, you must specify repository name\" not found in output")
+	}
+
+}

--- a/cmd/repo_remove_test.go
+++ b/cmd/repo_remove_test.go
@@ -23,12 +23,13 @@ import (
 func TestRepoRemoveError(t *testing.T) {
 
 	args := []string{"repo", "remove"}
-	output, err := cmdtest.RunAppsodyCmdExec(args, ".")
-	if err != nil {
-		t.Fatal(err)
-	}
+	output, _ := cmdtest.RunAppsodyCmdExec(args, ".")
+
 	if !strings.Contains(output, "Error, you must specify repository name") {
 		t.Error("String \"Error, you must specify repository name\" not found in output")
+
+	} else {
+		t.Log("Found the correct error string")
 	}
 
 }


### PR DESCRIPTION
Partial fulfillment of #36
Removed os.exit calls.