### PR TITLE
CLI deploy: handle namespace flag appropriately

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ stages:
   - name: lint
   - name: test
   - name: deploy
-    if: branch = master AND tag IS present
+    if: tag IS present
 
 install-controller: &install-controller
   install:

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -615,7 +615,7 @@ func KubeApply(fileToApply string) error {
 	kcmd := "kubectl"
 	kargs := []string{"apply", "-f", fileToApply}
 	if namespace != "" {
-		kargs = append(kargs, "--name", namespace)
+		kargs = append(kargs, "--namespace", namespace)
 	}
 
 	if dryrun {
@@ -639,7 +639,7 @@ func KubeGetRouteURL(service string) (url string, err error) {
 	kargs := append([]string{"get", "rt"}, service)
 	kargs = append(kargs, "-o", "jsonpath=\"{.status.url}\"")
 	if namespace != "" {
-		kargs = append(kargs, "--name", namespace)
+		kargs = append(kargs, "--namespace", namespace)
 	}
 
 	if dryrun {


### PR DESCRIPTION
The CLI was using the incorrect flag for `--namespace` in the `kubectl` command. Replaced the incorrect `--name` flag with `--namespace`.
Fixes #109 