### PR TITLE
removed os.exit from build and deploy commands

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -15,9 +15,9 @@
 package cmd
 
 import (
-	"os"
 	"path/filepath"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -26,7 +26,7 @@ var buildCmd = &cobra.Command{
 	Use:   "build",
 	Short: "Locally build a docker image of your appsody project",
 	Long:  `This allows you to build a local Docker image from your Appsody project. Extract is run before the docker build.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// This needs to do:
 		// 1. appsody Extract
 		// 2. docker build -t <project name> -f Dockerfile ./extracted
@@ -35,8 +35,7 @@ var buildCmd = &cobra.Command{
 
 		projectName, perr := getProjectName()
 		if perr != nil {
-			Error.log(perr)
-			os.Exit(1)
+			return errors.Errorf("%v", perr)
 		}
 		extractDir := filepath.Join(getHome(), "extract", projectName)
 		dockerfile := filepath.Join(extractDir, "Dockerfile")
@@ -51,6 +50,7 @@ var buildCmd = &cobra.Command{
 		if !dryrun {
 			Info.log("Built docker image ", buildImage)
 		}
+		return nil
 	},
 }
 

--- a/cmd/build_delete.go
+++ b/cmd/build_delete.go
@@ -18,8 +18,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"net/http"
-	"os"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -30,18 +30,18 @@ var deleteCmd = &cobra.Command{
 	Hidden: true,
 	Short:  "Delete a Githook and build pipeline for your Appsody project",
 	Long:   `This allows you to delete a Githook for your Appsody project.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// projectDir := getProjectDir()
 		// projectName := filepath.Base(projectDir)
 		projectName, perr := getProjectName()
 		if perr != nil {
-			Error.log(perr)
-			os.Exit(1)
+			return errors.Errorf("%v", perr)
+
 		}
 		tektonServer := cliConfig.GetString("tektonserver")
 		if tektonServer == "" {
-			Error.log("No target Tekton server specified in the configuration.")
-			os.Exit(1)
+			return errors.New("no target Tekton server specified in the configuration")
+
 		}
 		url := fmt.Sprintf("%s/v1/namespaces/default/githubsource/%s", tektonServer, projectName)
 		if dryrun {
@@ -54,22 +54,22 @@ var deleteCmd = &cobra.Command{
 			Info.log("Making request to ", url)
 			resp, err := client.Do(req)
 			if err != nil {
-				Error.log(err)
-				os.Exit(1)
+				return errors.Errorf("%v", err)
+
 			}
 			defer resp.Body.Close()
 			body, _ := ioutil.ReadAll(resp.Body)
 			bodyStr := string(body)
 
 			if resp.StatusCode >= 300 {
-				Error.log(resp.Status)
-				Error.log(string(bodyStr))
-				os.Exit(1)
-			} else {
-				Info.log(resp.Status)
-				Info.log(string(bodyStr))
+
+				return errors.Errorf("Bad Status Code: %s with message: %s", resp.Status, string(bodyStr))
 			}
+			Info.log(resp.Status)
+			Info.log(string(bodyStr))
+
 		}
+		return nil
 	},
 }
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -15,9 +15,9 @@
 package cmd
 
 import (
-	"os"
 	"strconv"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -30,9 +30,12 @@ var deployCmd = &cobra.Command{
 	Long: `This command extracts the code from your project, builds a local Docker image for deployment,
 generates a KNative serving deployment manifest (yaml) file, and deploys your image as a KNative
 service in your local cluster.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		// Extract code and build the image - and tags it if -t is specified
-		buildCmd.Run(cmd, args)
+		buildErr := buildCmd.RunE(cmd, args)
+		if buildErr != nil {
+			return errors.Errorf("%v", buildErr)
+		}
 		//Generate the KNative yaml
 		//Get the container port first
 		port, err := getEnvVarInt("PORT")
@@ -60,8 +63,7 @@ service in your local cluster.`,
 		//Retrieve the project name and lowercase it
 		projectName, perr := getProjectName()
 		if perr != nil {
-			Error.log(perr)
-			os.Exit(1)
+			return errors.Errorf("%v", perr)
 		}
 		//Get the project name and make it the KNative service name
 		serviceName := projectName
@@ -75,8 +77,7 @@ service in your local cluster.`,
 			// Tagging the image using the tag as the deployImage for KNative
 			err = DockerTag(deployImage, localtag)
 			if err != nil {
-				Error.log("Tagging the image failed - exiting. Error: ", err)
-				os.Exit(1)
+				return errors.Errorf("Tagging the image failed - exiting. Error: %v", err)
 			}
 			deployImage = localtag // And forcing deployimage to be localtag
 		}
@@ -84,30 +85,29 @@ service in your local cluster.`,
 		Debug.logf("Calling GenKnativeYaml with parms: %s %d %s %s \n", knativeTempl, port, serviceName, deployImage)
 		yamlFileName, err := GenKnativeYaml(knativeTempl, port, serviceName, deployImage, push)
 		if err != nil {
-			Error.log("Could not generate the KNative YAML file: ", err)
-			os.Exit(1)
+			return errors.Errorf("Could not generate the KNative YAML file: %v", err)
 		}
 		Info.log("Generated KNative serving deploy file: ", yamlFileName)
 		// Pushing the docker image if necessary
 		if push {
 			err = DockerPush(deployImage)
 			if err != nil {
-				Error.log("Could not push the docker image - exiting. Error: ", err)
+				return errors.Errorf("Could not push the docker image - exiting. Error: %v", err)
 			}
 		}
 		err = KubeApply(yamlFileName)
 		// Performing the kubectl apply
 		if err != nil {
-			Error.log("Failed to deploy to your Kubernetes cluster: ", err)
-		} else {
-			Info.log("Deployment succeeded.")
-			url, err := KubeGetRouteURL(serviceName)
-			if err != nil {
-				Error.log("Failed to find deployed service in your Kubernetes cluster: ", err)
-			} else {
-				Info.log("Your deployed service is available at the following URL: ", url)
-			}
+			return errors.Errorf("Failed to deploy to your Kubernetes cluster: %v", err)
 		}
+		Info.log("Deployment succeeded.")
+		url, err := KubeGetRouteURL(serviceName)
+		if err != nil {
+			return errors.Errorf("Failed to find deployed service in your Kubernetes cluster: %v", err)
+		}
+		Info.log("Your deployed service is available at the following URL: ", url)
+
+		return nil
 	},
 }
 


### PR DESCRIPTION
Partial fulfillment of #36 
Removed os.exit from build.go, deploy.go, build_setup.go, build_delete.go