### PR TITLE
removed os.exit(1) from extract

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -31,7 +31,10 @@ var buildCmd = &cobra.Command{
 		// 1. appsody Extract
 		// 2. docker build -t <project name> -f Dockerfile ./extracted
 
-		extractCmd.Run(cmd, args)
+		extractErr := extractCmd.RunE(cmd, args)
+		if extractErr != nil {
+			return extractErr
+		}
 
 		projectName, perr := getProjectName()
 		if perr != nil {

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -114,9 +114,8 @@ in preparation to build the final docker image.`,
 			err = execAndWaitReturnErr(cmdName, cmdArgs, Debug)
 			if err != nil {
 
-				Error.log("docker create command failed: ", err)
 				dockerRemove(extractContainerName)
-				return err
+				return errors.Errorf("docker create command failed: %v", err)
 
 			}
 			appDir = extractContainerName + ":" + containerProjectDir

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -31,11 +32,10 @@ var extractCmd = &cobra.Command{
 	Short: "Extract the stack and your Appsody project to a local directory",
 	Long: `This copies the full project, stack plus app, into a local directory
 in preparation to build the final docker image.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectName, perr := getProjectName()
 		if perr != nil {
-			Error.log(perr)
-			os.Exit(1)
+			return errors.Errorf("%v", perr)
 		}
 		projectConfig := getProjectConfig()
 		Info.log("Extracting project from development environment")
@@ -46,30 +46,26 @@ in preparation to build the final docker image.`,
 			Debug.log("Checking if target-dir exists: ", targetDir)
 			targetExists, err := exists(targetDir)
 			if err != nil {
-				Error.log("Error checking target directory: ", err)
-				os.Exit(1)
+				return errors.Errorf("Error checking target directory: %v", err)
 			}
 			if targetExists {
-				Error.log("Cannot extract to an existing target-dir: ", targetDir)
-				os.Exit(1)
+				return errors.Errorf("Cannot extract to an existing target-dir: %s", targetDir)
+
 			}
 			targetDirParent := filepath.Dir(targetDir)
 			targetDirParentExists, err := exists(targetDirParent)
 			if err != nil {
-				Error.log("Error checking directory: ", err)
-				os.Exit(1)
+				return errors.Errorf("Error checking directory: %v", err)
 			}
 			if !targetDirParentExists {
-				Error.log(targetDirParent, " does not exist")
-				os.Exit(1)
+				return errors.Errorf("%s does not exist", targetDirParent)
 			}
 		}
 
 		extractDir := filepath.Join(getHome(), "extract")
 		extractDirExists, err := exists(extractDir)
 		if err != nil {
-			Error.log("Error checking directory: ", err)
-			os.Exit(1)
+			return errors.Errorf("Error checking directory: %v", err)
 		}
 		if !extractDirExists {
 			if dryrun {
@@ -78,16 +74,14 @@ in preparation to build the final docker image.`,
 				Debug.log("Creating extract dir: ", extractDir)
 				err = os.MkdirAll(extractDir, os.ModePerm)
 				if err != nil {
-					Error.log("Error creating directories ", extractDir, " ", err)
-					os.Exit(1)
+					return errors.Errorf("Error creating directories %s %v", extractDir, err)
 				}
 			}
 		}
 		extractDir = filepath.Join(extractDir, projectName)
 		extractDirExists, err = exists(extractDir)
 		if err != nil {
-			Error.log("Error checking directory: ", err)
-			os.Exit(1)
+			return errors.Errorf("Error checking directory: %v", err)
 		}
 		if extractDirExists {
 			if dryrun {
@@ -104,6 +98,7 @@ in preparation to build the final docker image.`,
 
 		containerProjectDir := "/project"
 		Debug.log("Container project dir: ", containerProjectDir)
+
 		volumeMaps := getVolumeArgs()
 		cmdName := "docker"
 		var appDir string
@@ -117,11 +112,12 @@ in preparation to build the final docker image.`,
 			cmdArgs = append([]string{"create"}, cmdArgs...)
 			cmdArgs = append(cmdArgs, stackImage)
 			err = execAndWaitReturnErr(cmdName, cmdArgs, Debug)
-
 			if err != nil {
+
 				Error.log("docker create command failed: ", err)
 				dockerRemove(extractContainerName)
-				os.Exit(1)
+				return err
+
 			}
 			appDir = extractContainerName + ":" + containerProjectDir
 
@@ -136,20 +132,22 @@ in preparation to build the final docker image.`,
 			_, err = DockerRunBashCmd(cmdArgs, stackImage, bashCmd)
 			if err != nil {
 				Debug.log("Error attempting to run copy command ", bashCmd, " on image ", stackImage)
+
 				dockerRemove(extractContainerName)
-				os.Exit(1)
+				return errors.Errorf("Error attempting to run copy command %s on image %s", bashCmd, stackImage)
+
 			}
 			//If everything went fine, we need to set the source project directory to /tmp/...
 			appDir = extractContainerName + ":" + filepath.Join("/tmp", containerProjectDir)
 		}
 		cmdArgs = []string{"cp", appDir, extractDir}
 		err = execAndWaitReturnErr(cmdName, cmdArgs, Debug)
-
 		if err != nil {
 			Error.log("docker cp command failed: ", err)
 			dockerRemove(extractContainerName)
-			os.Exit(1)
+			return errors.Errorf("docker cp command failed: %v", err)
 		}
+
 		dockerRemove(extractContainerName)
 		if targetDir == "" {
 			if !dryrun {
@@ -161,12 +159,13 @@ in preparation to build the final docker image.`,
 			} else {
 				err = MoveDir(extractDir, targetDir)
 				if err != nil {
-					Error.log("Extract failed when moving ", extractDir, " to ", targetDir, " ", err)
-					os.Exit(1)
+					return errors.Errorf("Extract failed when moving %s to %s %v", extractDir, targetDir, err)
+
 				}
 				Info.log("Project extracted to ", targetDir)
 			}
 		}
+		return nil
 	},
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -401,7 +401,10 @@ func extractAndInitialize() error {
 		}
 		// set the --target-dir flag for extract
 		targetDir = workdir
-		extractCmd.Run(extractCmd, nil)
+		extractErr := extractCmd.RunE(extractCmd, nil)
+		if extractErr != nil {
+			return extractErr
+		}
 
 	} else {
 		Info.log("Dry Run skipping extract.")


### PR DESCRIPTION
Partial fulfillment of #36 
Removed os.exit from extract.go
Changed init.go and build.go to use extractCmd.RunE.