### PR TITLE
Remove os exit from utils.go and parent callers

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -49,7 +49,10 @@ var buildCmd = &cobra.Command{
 		}
 		cmdName := "docker"
 		cmdArgs := []string{"build", "-t", buildImage, "-f", dockerfile, extractDir}
-		execAndWait(cmdName, cmdArgs, DockerLog)
+		execError := execAndWait(cmdName, cmdArgs, DockerLog)
+		if execError != nil {
+			return execError
+		}
 		if !dryrun {
 			Info.log("Built docker image ", buildImage)
 		}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -31,7 +31,10 @@ var buildCmd = &cobra.Command{
 		// 1. appsody Extract
 		// 2. docker build -t <project name> -f Dockerfile ./extracted
 
-		extractCmd.Run(cmd, args)
+		extractErr := extractCmd.RunE(cmd, args)
+		if extractErr != nil {
+			return extractErr
+		}
 
 		projectName, perr := getProjectName()
 		if perr != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -34,7 +34,7 @@ service in your local cluster.`,
 		// Extract code and build the image - and tags it if -t is specified
 		buildErr := buildCmd.RunE(cmd, args)
 		if buildErr != nil {
-			return errors.Errorf("%v", buildErr)
+			return buildErr
 		}
 		//Generate the KNative yaml
 		//Get the container port first
@@ -42,7 +42,10 @@ service in your local cluster.`,
 		if err != nil {
 			//try and get the exposed ports and use the first one
 			Warning.log("Could not detect a container port (PORT env var).")
-			portsStr := getExposedPorts()
+			portsStr, portsErr := getExposedPorts()
+			if portsErr != nil {
+				return portsErr
+			}
 			if len(portsStr) == 0 {
 				//No ports exposed
 				Warning.log("This container exposes no ports. The service will not be accessible.")

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -96,7 +96,10 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 		return perr
 
 	}
-	projectConfig := getProjectConfig()
+	projectConfig, configErr := getProjectConfig()
+	if configErr != nil {
+		return configErr
+	}
 	err := CheckPrereqs()
 	if err != nil {
 		Warning.logf("Failed to check prerequisites: %v\n", err)
@@ -108,11 +111,20 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 
 	var cmdName string
 	var cmdArgs []string
-	dockerPullImage(platformDefinition)
+	dockerPullErr := dockerPullImage(platformDefinition)
+	if dockerPullErr != nil {
+		return dockerPullErr
+	}
 
-	volumeMaps := getVolumeArgs()
+	volumeMaps, volumeErr := getVolumeArgs()
+	if volumeErr != nil {
+		return volumeErr
+	}
 	// Mount the APPSODY_DEPS cache volume if it exists
-	depsEnvVar := getEnvVar("APPSODY_DEPS")
+	depsEnvVar, envErr := getEnvVar("APPSODY_DEPS")
+	if envErr != nil {
+		return envErr
+	}
 	if depsEnvVar != "" {
 		depsMount := depsVolumeName + ":" + depsEnvVar
 		Debug.log("Adding dependency cache to volume mounts: ", depsMount)
@@ -164,7 +176,8 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
-		dockerStop(containerName)
+		err := dockerStop(containerName)
+		Error.log(err)
 		//dockerRemove(containerName) is not needed due to --rm flag
 		os.Exit(1)
 	}()
@@ -174,12 +187,20 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 	if !validPorts {
 		return errors.Errorf("Ports provided as input to the command are not valid: %v\n", portError)
 	}
-	cmdArgs = processPorts(cmdArgs)
+	var portsErr error
+	cmdArgs, portsErr = processPorts(cmdArgs)
+	if portsErr != nil {
+		return portsErr
+	}
 	cmdArgs = append(cmdArgs, "--name", containerName)
 	if dockerNetwork != "" {
 		cmdArgs = append(cmdArgs, "--network", dockerNetwork)
 	}
-	if getEnvVarBool("APPSODY_USER_RUN_AS_LOCAL") && runtime.GOOS != "windows" {
+	runAsLocal, boolErr := getEnvVarBool("APPSODY_USER_RUN_AS_LOCAL")
+	if boolErr != nil {
+		return boolErr
+	}
+	if runAsLocal && runtime.GOOS != "windows" {
 		current, _ := user.Current()
 		cmdArgs = append(cmdArgs, "-u", fmt.Sprintf("%s:%s", current.Uid, current.Gid))
 		cmdArgs = append(cmdArgs, "-e", fmt.Sprintf("APPSODY_USER=%s", current.Uid), "-e", fmt.Sprintf("APPSODY_GROUP=%s", current.Gid))
@@ -218,15 +239,21 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 
 }
 
-func processPorts(cmdArgs []string) []string {
+func processPorts(cmdArgs []string) ([]string, error) {
 
 	var exposedPortsMapping []string
 
-	dockerExposedPorts := getExposedPorts()
+	dockerExposedPorts, portsErr := getExposedPorts()
+	if portsErr != nil {
+		return cmdArgs, portsErr
+	}
 	Debug.log("Exposed ports provided by the docker file", dockerExposedPorts)
 	// if the container port is not in the lised of exposed ports add it to the list
 
-	containerPort := getEnvVar("PORT")
+	containerPort, envErr := getEnvVar("PORT")
+	if envErr != nil {
+		return cmdArgs, envErr
+	}
 	containerPortIsExposed := false
 
 	Debug.log("Container port set to: ", containerPort)
@@ -275,7 +302,7 @@ func processPorts(cmdArgs []string) []string {
 	for k := 0; k < len(exposedPortsMapping); k++ {
 		cmdArgs = append(cmdArgs, "-p", exposedPortsMapping[k])
 	}
-	return cmdArgs
+	return cmdArgs, nil
 }
 func checkPortInput(publishedPorts []string) (bool, error) {
 	validPorts := true

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -37,7 +37,10 @@ in preparation to build the final docker image.`,
 		if perr != nil {
 			return errors.Errorf("%v", perr)
 		}
-		projectConfig := getProjectConfig()
+		projectConfig, projectErr := getProjectConfig()
+		if projectErr != nil {
+			return projectErr
+		}
 		Info.log("Extracting project from development environment")
 
 		if targetDir != "" {
@@ -94,12 +97,18 @@ in preparation to build the final docker image.`,
 
 		stackImage := projectConfig.Platform
 
-		dockerPullImage(stackImage)
+		dockerPullErr := dockerPullImage(stackImage)
+		if dockerPullErr != nil {
+			return dockerPullErr
+		}
 
 		containerProjectDir := "/project"
 		Debug.log("Container project dir: ", containerProjectDir)
 
-		volumeMaps := getVolumeArgs()
+		volumeMaps, volumeErr := getVolumeArgs()
+		if volumeErr != nil {
+			return volumeErr
+		}
 		cmdName := "docker"
 		var appDir string
 		cmdArgs := []string{"--name", extractContainerName}
@@ -115,7 +124,8 @@ in preparation to build the final docker image.`,
 			if err != nil {
 
 				Error.log("docker create command failed: ", err)
-				dockerRemove(extractContainerName)
+				removeErr := dockerRemove(extractContainerName)
+				Error.log("Error in dockerRemove", removeErr)
 				return err
 
 			}
@@ -133,7 +143,10 @@ in preparation to build the final docker image.`,
 			if err != nil {
 				Debug.log("Error attempting to run copy command ", bashCmd, " on image ", stackImage)
 
-				dockerRemove(extractContainerName)
+				removeErr := dockerRemove(extractContainerName)
+				if removeErr != nil {
+					Error.log("dockerRemove error ", removeErr)
+				}
 				return errors.Errorf("Error attempting to run copy command %s on image %s", bashCmd, stackImage)
 
 			}
@@ -144,11 +157,17 @@ in preparation to build the final docker image.`,
 		err = execAndWaitReturnErr(cmdName, cmdArgs, Debug)
 		if err != nil {
 			Error.log("docker cp command failed: ", err)
-			dockerRemove(extractContainerName)
+			removeErr := dockerRemove(extractContainerName)
+			if removeErr != nil {
+				Error.log("dockerRemove error ", removeErr)
+			}
 			return errors.Errorf("docker cp command failed: %v", err)
 		}
 
-		dockerRemove(extractContainerName)
+		removeErr := dockerRemove(extractContainerName)
+		if removeErr != nil {
+			Error.log("dockerRemove error ", removeErr)
+		}
 		if targetDir == "" {
 			if !dryrun {
 				Info.log("Project extracted to ", extractDir)

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -20,6 +20,7 @@ import (
 	"path/filepath"
 	"runtime"
 
+	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
 
@@ -31,11 +32,10 @@ var extractCmd = &cobra.Command{
 	Short: "Extract the stack and your Appsody project to a local directory",
 	Long: `This copies the full project, stack plus app, into a local directory
 in preparation to build the final docker image.`,
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 		projectName, perr := getProjectName()
 		if perr != nil {
-			Error.log(perr)
-			os.Exit(1)
+			return errors.Errorf("%v", perr)
 		}
 		projectConfig := getProjectConfig()
 		Info.log("Extracting project from development environment")
@@ -46,30 +46,26 @@ in preparation to build the final docker image.`,
 			Debug.log("Checking if target-dir exists: ", targetDir)
 			targetExists, err := exists(targetDir)
 			if err != nil {
-				Error.log("Error checking target directory: ", err)
-				os.Exit(1)
+				return errors.Errorf("Error checking target directory: %v", err)
 			}
 			if targetExists {
-				Error.log("Cannot extract to an existing target-dir: ", targetDir)
-				os.Exit(1)
+				return errors.Errorf("Cannot extract to an existing target-dir: %s", targetDir)
+
 			}
 			targetDirParent := filepath.Dir(targetDir)
 			targetDirParentExists, err := exists(targetDirParent)
 			if err != nil {
-				Error.log("Error checking directory: ", err)
-				os.Exit(1)
+				return errors.Errorf("Error checking directory: %v", err)
 			}
 			if !targetDirParentExists {
-				Error.log(targetDirParent, " does not exist")
-				os.Exit(1)
+				return errors.Errorf("%s does not exist", targetDirParent)
 			}
 		}
 
 		extractDir := filepath.Join(getHome(), "extract")
 		extractDirExists, err := exists(extractDir)
 		if err != nil {
-			Error.log("Error checking directory: ", err)
-			os.Exit(1)
+			return errors.Errorf("Error checking directory: %v", err)
 		}
 		if !extractDirExists {
 			if dryrun {
@@ -78,16 +74,14 @@ in preparation to build the final docker image.`,
 				Debug.log("Creating extract dir: ", extractDir)
 				err = os.MkdirAll(extractDir, os.ModePerm)
 				if err != nil {
-					Error.log("Error creating directories ", extractDir, " ", err)
-					os.Exit(1)
+					return errors.Errorf("Error creating directories %s %v", extractDir, err)
 				}
 			}
 		}
 		extractDir = filepath.Join(extractDir, projectName)
 		extractDirExists, err = exists(extractDir)
 		if err != nil {
-			Error.log("Error checking directory: ", err)
-			os.Exit(1)
+			return errors.Errorf("Error checking directory: %v", err)
 		}
 		if extractDirExists {
 			if dryrun {
@@ -104,6 +98,7 @@ in preparation to build the final docker image.`,
 
 		containerProjectDir := "/project"
 		Debug.log("Container project dir: ", containerProjectDir)
+
 		volumeMaps := getVolumeArgs()
 		cmdName := "docker"
 		var appDir string
@@ -117,11 +112,12 @@ in preparation to build the final docker image.`,
 			cmdArgs = append([]string{"create"}, cmdArgs...)
 			cmdArgs = append(cmdArgs, stackImage)
 			err = execAndWaitReturnErr(cmdName, cmdArgs, Debug)
-
 			if err != nil {
+
 				Error.log("docker create command failed: ", err)
 				dockerRemove(extractContainerName)
-				os.Exit(1)
+				return err
+
 			}
 			appDir = extractContainerName + ":" + containerProjectDir
 
@@ -136,20 +132,22 @@ in preparation to build the final docker image.`,
 			_, err = DockerRunBashCmd(cmdArgs, stackImage, bashCmd)
 			if err != nil {
 				Debug.log("Error attempting to run copy command ", bashCmd, " on image ", stackImage)
+
 				dockerRemove(extractContainerName)
-				os.Exit(1)
+				return errors.Errorf("Error attempting to run copy command %s on image %s", bashCmd, stackImage)
+
 			}
 			//If everything went fine, we need to set the source project directory to /tmp/...
 			appDir = extractContainerName + ":" + filepath.Join("/tmp", containerProjectDir)
 		}
 		cmdArgs = []string{"cp", appDir, extractDir}
 		err = execAndWaitReturnErr(cmdName, cmdArgs, Debug)
-
 		if err != nil {
 			Error.log("docker cp command failed: ", err)
 			dockerRemove(extractContainerName)
-			os.Exit(1)
+			return errors.Errorf("docker cp command failed: %v", err)
 		}
+
 		dockerRemove(extractContainerName)
 		if targetDir == "" {
 			if !dryrun {
@@ -161,12 +159,13 @@ in preparation to build the final docker image.`,
 			} else {
 				err = MoveDir(extractDir, targetDir)
 				if err != nil {
-					Error.log("Extract failed when moving ", extractDir, " to ", targetDir, " ", err)
-					os.Exit(1)
+					return errors.Errorf("Extract failed when moving %s to %s %v", extractDir, targetDir, err)
+
 				}
 				Info.log("Project extracted to ", targetDir)
 			}
 		}
+		return nil
 	},
 }
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -401,7 +401,10 @@ func extractAndInitialize() error {
 		}
 		// set the --target-dir flag for extract
 		targetDir = workdir
-		extractCmd.Run(extractCmd, nil)
+		extractErr := extractCmd.RunE(extractCmd, nil)
+		if extractErr != nil {
+			return extractErr
+		}
 
 	} else {
 		Info.log("Dry Run skipping extract.")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -159,7 +159,11 @@ func install() error {
 		return errors.Errorf("%v", perr)
 
 	}
-	platformDefinition := getProjectConfig().Platform
+	projectConfig, configErr := getProjectConfig()
+	if configErr != nil {
+		return configErr
+	}
+	platformDefinition := projectConfig.Platform
 
 	Debug.logf("Setting up the development environment for projectDir: %s and platform: %s", projectDir, platformDefinition)
 
@@ -372,7 +376,11 @@ func extractAndInitialize() error {
 	//Determine if we need to run extract
 	//We run it only if there is an initialization script to run locally
 	//Checking if the script is present on the image
-	stackImage := getProjectConfig().Platform
+	projectConfig, configErr := getProjectConfig()
+	if configErr != nil {
+		return configErr
+	}
+	stackImage := projectConfig.Platform
 	bashCmd := "find /project -type f -name " + scriptFileName
 	cmdOptions := []string{"--rm"}
 	Debug.log("Attempting to run ", bashCmd, " on image ", stackImage, " with options: ", cmdOptions)
@@ -401,9 +409,10 @@ func extractAndInitialize() error {
 		}
 		// set the --target-dir flag for extract
 		targetDir = workdir
-		extractErr := extractCmd.RunE(extractCmd, nil)
-		if extractErr != nil {
-			return extractErr
+
+		extractError := extractCmd.RunE(extractCmd, nil)
+		if extractError != nil {
+			return extractError
 		}
 
 	} else {

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,17 +18,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func dockerStop(imageName string) {
+func dockerStop(imageName string) error {
 	cmdName := "docker"
 	cmdArgs := []string{"stop", imageName}
-	execAndWait(cmdName, cmdArgs, Debug)
+	err := execAndWait(cmdName, cmdArgs, Debug)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
-func dockerRemove(imageName string) {
+func dockerRemove(imageName string) error {
 	cmdName := "docker"
 	//Added "-f" to force removal if container is still running or image has containers
 	cmdArgs := []string{"rm", imageName, "-f"}
-	execAndWait(cmdName, cmdArgs, Debug)
+	err := execAndWait(cmdName, cmdArgs, Debug)
+	if err != nil {
+		return err
+	}
+	return nil
+
 }
 
 // runCmd represents the run command

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -15,8 +15,6 @@
 package cmd
 
 import (
-	"os"
-
 	"github.com/spf13/cobra"
 )
 
@@ -30,12 +28,16 @@ Stops the docker container specified by the --name flag.
 If --name is not specified, the container name is determined from the current working directory (see default below).
 To see a list of all your running docker containers, run the command "docker ps". The name is in the last column.`,
 
-	Run: func(cmd *cobra.Command, args []string) {
+	RunE: func(cmd *cobra.Command, args []string) error {
 
 		Info.log("Stopping development environment")
-		dockerStop(containerName)
+		err := dockerStop(containerName)
+		if err != nil {
+			return err
+		}
 		//dockerRemove(imageName) is not needed due to --rm flag
-		os.Exit(1)
+		//os.Exit(1)
+		return nil
 	},
 }
 


### PR DESCRIPTION
Partial fullfillment of #36 
Removed os.exit calls from utils.go and callers of utils.go