### PR TITLE
Added initial support for multiple repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ stages:
   - name: lint
   - name: test
   - name: deploy
-    if: branch = master AND tag IS present
+    if: tag IS present
 
 install-controller: &install-controller
   install:

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -53,7 +53,7 @@ Use 'appsody list' to see the available stack options.
 Without the [stack] argument, this command must be run on an existing Appsody project and will only run the stack init script to
 setup the local dev environment.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-		var index RepoIndex
+		//var index RepoIndex
 
 		var proceedWithTemplate bool
 
@@ -62,18 +62,32 @@ setup the local dev environment.`,
 			Warning.logf("Failed to check prerequisites: %v\n", err)
 		}
 
-		err = index.getIndex()
+		//err = index.getIndex()
+		var repos RepositoryFile
+		indices, err := repos.GetIndices()
+
 		if err != nil {
-			return errors.Errorf("Could not read index: %v", err)
+			return errors.Errorf("Could not read indices: %v", err)
 		}
+		if len(indices) == 0 {
+			return errors.Errorf("Your stack repository is empty - please use `appsody repo add` to add a repository.")
+		}
+		var index *RepoIndex
+		var repoName string
 		if len(args) >= 1 {
 
 			projectType := args[0]
+			projectFound := false
 
-			if len(index.Projects[projectType]) < 1 {
-				return errors.Errorf("Could not find a stack with the id \"%s\". Run `appsody list` to see the available stacks or -h for help.", projectType)
-
+			for repoName, index = range indices {
+				if len(index.Projects[projectType]) >= 1 {
+					projectFound = true
+				}
 			}
+			if !projectFound {
+				return errors.Errorf("Could not find a stack with the id \"%s\". Run `appsody list` to see the available stacks or -h for help.", projectType)
+			}
+			Debug.log("Stack ", projectType, " found in repo ", repoName)
 			var projectName = index.Projects[projectType][0].URLs[0]
 
 			// 1. Check for empty directory

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -58,7 +58,10 @@ setup the local dev environment.`,
 			return setupErr
 		}
 		//var index RepoIndex
-
+		var repos RepositoryFile
+		if _, err := repos.getRepos(); err != nil {
+			return err
+		}
 		var proceedWithTemplate bool
 
 		err := CheckPrereqs()
@@ -67,7 +70,7 @@ setup the local dev environment.`,
 		}
 
 		//err = index.getIndex()
-		var repos RepositoryFile
+
 		indices, err := repos.GetIndices()
 
 		if err != nil {
@@ -464,7 +467,9 @@ func parseProjectParm(projectParm string) (string, string, error) {
 	if len(parms) == 1 {
 		Debug.log("Non-fully qualified stack - retrieving default repo...")
 		var r RepositoryFile
-		r.getRepos()
+		if _, err := r.getRepos(); err != nil {
+			return "", "", err
+		}
 		return r.GetDefaultRepoName(), parms[0], nil
 	}
 

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -57,7 +57,7 @@ setup the local dev environment.`,
 		if setupErr != nil {
 			return setupErr
 		}
-		var index RepoIndex
+		//var index RepoIndex
 
 		var proceedWithTemplate bool
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -29,18 +29,11 @@ var listCmd = &cobra.Command{
 		//var index RepoIndex
 
 		var repos RepositoryFile
-		indices, err := repos.GetIndices()
-
-		//err := index.getIndex()
+		projects, err := repos.listProjects()
 		if err != nil {
-			return errors.Errorf("Could not read indices: %v", err)
+			return errors.Errorf("%v", err)
 		}
-		if len(indices) != 0 {
-			for repoName, index := range indices {
-				Info.log("\n", "Repository: ", repoName)
-				Info.log(index.listProjects())
-			}
-		}
+		Info.log("\n", projects)
 		return nil
 	},
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -28,9 +28,14 @@ var listCmd = &cobra.Command{
 	repositories will be listed.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		var repos RepositoryFile
+
 		setupErr := setupConfig()
 		if setupErr != nil {
 			return setupErr
+		}
+
+		if _, err := repos.getRepos(); err != nil {
+			return err
 		}
 		//var index RepoIndex
 		if len(args) < 1 {
@@ -41,7 +46,10 @@ var listCmd = &cobra.Command{
 			Info.log("\n", projects)
 		} else {
 			repoName := args[0]
-			repos.getRepos()
+			_, err := repos.getRepos()
+			if err != nil {
+				return err
+			}
 			repoProjects, err := repos.listRepoProjects(repoName)
 			if err != nil {
 				return err

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -31,7 +31,7 @@ var listCmd = &cobra.Command{
 		setupErr := setupConfig()
 		if setupErr != nil {
 			return setupErr
-		}		
+		}
 		//var index RepoIndex
 		if len(args) < 1 {
 			projects, err := repos.listProjects()
@@ -48,9 +48,8 @@ var listCmd = &cobra.Command{
 			} else {
 				Info.log("\n", repoProjects)
 			}
-
-
-		return nil
+			return nil
+		}
 	},
 }
 

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -42,7 +42,8 @@ var listCmd = &cobra.Command{
 		} else {
 			repoName := args[0]
 			repos.getRepos()
-			if repoProjects, err := repos.listRepoProjects(repoName); err != nil {
+			repoProjects, err := repos.listRepoProjects(repoName)
+			if err != nil {
 				return err
 			}
 			Info.log("\n", repoProjects)

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -26,13 +26,21 @@ var listCmd = &cobra.Command{
 	Long:  ``,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
-		var index RepoIndex
-		err := index.getIndex()
-		if err != nil {
-			return errors.Errorf("Could not read index: %v", err)
+		//var index RepoIndex
 
+		var repos RepositoryFile
+		indices, err := repos.GetIndices()
+
+		//err := index.getIndex()
+		if err != nil {
+			return errors.Errorf("Could not read indices: %v", err)
 		}
-		Info.log("\n", index.listProjects())
+		if len(indices) != 0 {
+			for repoName, index := range indices {
+				Info.log("\n", "Repository: ", repoName)
+				Info.log(index.listProjects())
+			}
+		}
 		return nil
 	},
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -21,19 +21,30 @@ import (
 
 // listCmd represents the list command
 var listCmd = &cobra.Command{
-	Use:   "list",
+	Use:   "list [repo]",
 	Short: "List the Appsody stacks available to init",
-	Long:  ``,
+	Long: `This command lists all the stacks available in your repositories, if you omit the 
+	optional [repo] parameter. If you specify the repository name [repo], only the stacks in that
+	repositories will be listed.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
-
-		//var index RepoIndex
-
 		var repos RepositoryFile
-		projects, err := repos.listProjects()
-		if err != nil {
-			return errors.Errorf("%v", err)
+		//var index RepoIndex
+		if len(args) < 1 {
+			projects, err := repos.listProjects()
+			if err != nil {
+				return errors.Errorf("%v", err)
+			}
+			Info.log("\n", projects)
+			return nil
+		} else {
+			repoName := args[0]
+			repos.getRepos()
+			if repoProjects, err := repos.listRepoProjects(repoName); err != nil {
+				return err
+			} else {
+				Info.log("\n", repoProjects)
+			}
 		}
-		Info.log("\n", projects)
 		return nil
 	},
 }

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -39,17 +39,15 @@ var listCmd = &cobra.Command{
 				return errors.Errorf("%v", err)
 			}
 			Info.log("\n", projects)
-			return nil
 		} else {
 			repoName := args[0]
 			repos.getRepos()
 			if repoProjects, err := repos.listRepoProjects(repoName); err != nil {
 				return err
-			} else {
-				Info.log("\n", repoProjects)
 			}
-			return nil
+			Info.log("\n", repoProjects)
 		}
+		return nil
 	},
 }
 

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -19,7 +19,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"math/rand"
+	//"math/rand"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -258,12 +258,13 @@ func (index *RepoIndex) listProjects() string {
 func (r *RepositoryFile) listProjects() (string, error) {
 	table := uitable.New()
 	table.MaxColWidth = 60
-	table.AddRow("REPO", "ID", "VERSION", "TEMPLATES", "DESCRIPTION")
+	//table.AddRow("REPO", "ID", "VERSION", "TEMPLATES", "DESCRIPTION")
+	table.AddRow("REPO", "ID", "VERSION", "DESCRIPTION")
 	indices, err := r.GetIndices()
-	rnd := rand.New(rand.NewSource(99))
+	//rnd := rand.New(rand.NewSource(99))
 
 	//err := index.getIndex()
-	templates := [8]string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"}
+	//templates := [8]string{"alpha", "beta", "gamma", "delta", "epsilon", "zeta", "eta", "theta"}
 	if err != nil {
 		return "", errors.Errorf("Could not read indices: %v", err)
 	}
@@ -271,17 +272,18 @@ func (r *RepositoryFile) listProjects() (string, error) {
 		for repoName, index := range indices {
 			//Info.log("\n", "Repository: ", repoName)
 			for id, value := range index.Projects {
-				r1 := rnd.Intn(8)
-				r2 := rnd.Intn(8)
-				r3 := rnd.Intn(8)
-				rndTemplates := "*" + templates[r1] + ", " + templates[r2] + ", " + templates[r3]
-				table.AddRow(repoName, id, value[0].Version, rndTemplates, value[0].Description)
+				//r1 := rnd.Intn(8)
+				//r2 := rnd.Intn(8)
+				//r3 := rnd.Intn(8)
+				//rndTemplates := "*" + templates[r1] + ", " + templates[r2] + ", " + templates[r3]
+				//table.AddRow(repoName, id, value[0].Version, rndTemplates, value[0].Description)
+				table.AddRow(repoName, id, value[0].Version, value[0].Description)
 			}
 		}
 		return table.String(), nil
-	} else {
-		return "", errors.New("there are no repositories in your configuration")
 	}
+	return "", errors.New("there are no repositories in your configuration")
+
 }
 func (r *RepositoryFile) listRepoProjects(repoName string) (string, error) {
 	if repo := r.GetRepo(repoName); repo != nil {

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -294,9 +294,21 @@ func (r *RepositoryFile) listProjects() (string, error) {
 				table.AddRow(repoName, id, value[0].Version, rndTemplates, value[0].Description)
 			}
 		}
+		return table.String(), nil
+	} else {
+		return "", errors.New("there are no repositories in your configuration")
 	}
-
-	return table.String(), nil
+}
+func (r *RepositoryFile) listRepoProjects(repoName string) (string, error) {
+	if repo := r.GetRepo(repoName); repo != nil {
+		url := repo.URL
+		if index, err := getIndex(url); err != nil {
+			return "", err
+		} else {
+			return index.listProjects(), nil
+		}
+	}
+	return "", errors.New("cannot locate repository named " + repoName)
 }
 
 func (r *RepositoryFile) getRepos() *RepositoryFile {
@@ -354,6 +366,15 @@ func (r *RepositoryFile) Has(name string) bool {
 		}
 	}
 	return false
+}
+func (r *RepositoryFile) GetRepo(name string) *RepositoryEntry {
+	r.getRepos()
+	for _, rf := range r.Repositories {
+		if rf.Name == name {
+			return rf
+		}
+	}
+	return nil
 }
 
 func (r *RepositoryFile) HasURL(url string) bool {

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -66,7 +66,7 @@ type RepositoryFile struct {
 type RepositoryEntry struct {
 	Name      string `yaml:"name"`
 	URL       string `yaml:"url"`
-	IsDefault bool   `yaml:"isdefault,omitempty"`
+	IsDefault bool   `yaml:"default,omitempty"`
 }
 
 var (
@@ -344,7 +344,7 @@ func (r *RepositoryFile) Add(re ...*RepositoryEntry) {
 }
 
 func (r *RepositoryFile) Has(name string) bool {
-	r.getRepos()
+
 	for _, rf := range r.Repositories {
 		if rf.Name == name {
 			return true
@@ -353,7 +353,6 @@ func (r *RepositoryFile) Has(name string) bool {
 	return false
 }
 func (r *RepositoryFile) GetRepo(name string) *RepositoryEntry {
-	r.getRepos()
 	for _, rf := range r.Repositories {
 		if rf.Name == name {
 			return rf
@@ -398,7 +397,7 @@ func (r *RepositoryFile) WriteFile(path string) error {
 }
 
 func (r *RepositoryFile) GetIndices() (RepoIndices, error) {
-	r.getRepos()
+
 	indices := make(map[string]*RepoIndex)
 	for _, rf := range r.Repositories {
 		var index, err = downloadIndex(rf.URL)

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -245,12 +245,12 @@ func downloadIndex(url string) (*RepoIndex, error) {
 	return &index, nil
 }
 
-func (index *RepoIndex) listProjects() string {
+func (index *RepoIndex) listProjects(repoName string) string {
 	table := uitable.New()
 	table.MaxColWidth = 60
-	table.AddRow("ID", "VERSION", "DESCRIPTION")
+	table.AddRow("REPO", "ID", "VERSION", "DESCRIPTION")
 	for id, value := range index.Projects {
-		table.AddRow(id, value[0].Version, value[0].Description)
+		table.AddRow(repoName, id, value[0].Version, value[0].Description)
 	}
 
 	return table.String()
@@ -288,11 +288,11 @@ func (r *RepositoryFile) listProjects() (string, error) {
 func (r *RepositoryFile) listRepoProjects(repoName string) (string, error) {
 	if repo := r.GetRepo(repoName); repo != nil {
 		url := repo.URL
-		if index, err := downloadIndex(url); err != nil {
+		index, err := downloadIndex(url)
+		if err != nil {
 			return "", err
-		} else {
-			return index.listProjects(), nil
 		}
+		return index.listProjects(repoName), nil
 	}
 	return "", errors.New("cannot locate repository named " + repoName)
 }

--- a/cmd/repo_remove.go
+++ b/cmd/repo_remove.go
@@ -38,7 +38,11 @@ var removeCmd = &cobra.Command{
 			Info.log("Dry Run - Skipping appsody repo remove ", repoName)
 		} else {
 			if repoFile.Has(repoName) {
-				repoFile.Remove(repoName)
+				if repoName != repoFile.GetDefaultRepoName() {
+					repoFile.Remove(repoName)
+				} else {
+					Error.log("You cannot remove the default repository " + repoName)
+				}
 			} else {
 				Error.log("Repository is not in configured list of repositories")
 			}


### PR DESCRIPTION
This PR introduces the following functionality:
1) Supports multiple repositories in an adequate way. Now, the same stack name may be present in multiple repositories.
1) Introduces the concept of *default repo*. The default repo is marked with an asterisk when you run `appsody repo list`. The default repo can be modified by manually editing `~/.appsody/repository/repository.yaml` and moving the `default:true` yaml element to the repo that you want to make the default repo.
1) Now, `appsody list` lists all the stacks that are available with an indication of the repo they come from.
1) There's a new `appsody list <repo>` variation of the command, which only shows the stacks in the specified repo (if it exists).
1) To create an appsody project, you can keep using the old `appsody init <stack>`, with the understanding that Appsody will try to find <stack> in the default repo.
1) If you want to initialize a project that is located in a repo other than the default one, you can now issue `appsody init <repo>/<stack>` (i.e. you can fully qualify the stack you want to initialize). Appsody will look into the `<repo>` you indicate.
1) The command `appsody repo remove <repo>` won't allow you to remove the default repo.
1) A new installation of Appsody sets the first repo as the default repo.