### PR TITLE
CLI repo and init: add support for V2 repository schema

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ stages:
   - name: lint
   - name: test
   - name: deploy
-    if: branch = master AND tag IS present
+    if: tag IS present
 
 install-controller: &install-controller
   install:

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -82,7 +82,7 @@ setup the local dev environment.`,
 		var index *RepoIndex
 
 		if len(args) >= 1 {
-
+			var projectName string
 			projectParm := args[0]
 
 			repoName, projectType, err := parseProjectParm(projectParm)
@@ -91,12 +91,27 @@ setup the local dev environment.`,
 			}
 			Debug.log("Attempting to locate stack ", projectType, " in repo ", repoName)
 			index = indices[repoName]
-			if len(index.Projects[projectType]) < 1 {
+			projectFound := false
+			stackFound := false
+
+			if len(index.Projects[projectType]) >= 1 { //V1 repos
+				projectFound = true
+				//return errors.Errorf("Could not find a stack with the id \"%s\" in repository \"%s\". Run `appsody list` to see the available stacks or -h for help.", projectType, repoName)
+				Debug.log("Project ", projectType, " found in repo ", repoName)
+				projectName = index.Projects[projectType][0].URLs[0]
+			}
+
+			for _, stack := range index.Stacks {
+				if stack.ID == projectType {
+					stackFound = true
+					Debug.log("Stack ", projectType, " found in repo ", repoName)
+					projectName = stack.Templates[0].URL
+				}
+			}
+
+			if !projectFound && !stackFound {
 				return errors.Errorf("Could not find a stack with the id \"%s\" in repository \"%s\". Run `appsody list` to see the available stacks or -h for help.", projectType, repoName)
 			}
-			Debug.log("Stack ", projectType, " found in repo ", repoName)
-			var projectName = index.Projects[projectType][0].URLs[0]
-
 			// 1. Check for empty directory
 			dir, err := os.Getwd()
 			if err != nil {

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -36,6 +36,7 @@ type RepoIndex struct {
 	APIVersion string                     `yaml:"apiVersion"`
 	Generated  time.Time                  `yaml:"generated"`
 	Projects   map[string]ProjectVersions `yaml:"projects"`
+	Stacks     []ProjectVersion           `yaml:"stacks"`
 }
 
 // RepoIndices maps repos to their RepoIndex (i.e. the projects in a repo)
@@ -44,17 +45,18 @@ type RepoIndices map[string]*RepoIndex
 type ProjectVersions []*ProjectVersion
 
 type ProjectVersion struct {
-	APIVersion  string    `yaml:"apiVersion"`
-	Created     time.Time `yaml:"created"`
-	Name        string    `yaml:"name"`
-	Home        string    `yaml:"home"`
-	Version     string    `yaml:"version"`
-	Description string    `yaml:"description"`
-	Keywords    []string  `yaml:"keywords"`
-	Maintainers []string  `yaml:"maintainers"`
-	Icon        string    `yaml:"icon"`
-	Digest      string    `yaml:"digest"`
-	URLs        []string  `yaml:"urls"`
+	APIVersion  string        `yaml:"apiVersion"`
+	Id          string        `yaml:"id,omitempty"`
+	Created     time.Time     `yaml:"created"`
+	Name        string        `yaml:"name"`
+	Home        string        `yaml:"home"`
+	Version     string        `yaml:"version"`
+	Description string        `yaml:"description"`
+	Keywords    []string      `yaml:"keywords"`
+	Maintainers []interface{} `yaml:"maintainers"`
+	Icon        string        `yaml:"icon"`
+	Digest      string        `yaml:"digest"`
+	URLs        []string      `yaml:"urls"`
 }
 
 type RepositoryFile struct {
@@ -252,7 +254,9 @@ func (index *RepoIndex) listProjects(repoName string) string {
 	for id, value := range index.Projects {
 		table.AddRow(repoName, id, value[0].Version, value[0].Description)
 	}
-
+	for _, value := range index.Stacks {
+		table.AddRow(repoName, value.Id, value.Version, value.Description)
+	}
 	return table.String()
 }
 func (r *RepositoryFile) listProjects() (string, error) {
@@ -278,6 +282,9 @@ func (r *RepositoryFile) listProjects() (string, error) {
 				//rndTemplates := "*" + templates[r1] + ", " + templates[r2] + ", " + templates[r3]
 				//table.AddRow(repoName, id, value[0].Version, rndTemplates, value[0].Description)
 				table.AddRow(repoName, id, value[0].Version, value[0].Description)
+			}
+			for _, value := range index.Stacks {
+				table.AddRow(repoName, value.Id, value.Version, value.Description)
 			}
 		}
 		return table.String(), nil

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -73,8 +73,8 @@ type RepositoryEntry struct {
 }
 
 type Template struct {
-	ID  string `yaml:id`
-	URL string `yaml:url`
+	ID  string `yaml:"id"`
+	URL string `yaml:"url"`
 }
 
 var (

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -56,7 +56,8 @@ type ProjectVersion struct {
 	Maintainers []interface{} `yaml:"maintainers"`
 	Icon        string        `yaml:"icon"`
 	Digest      string        `yaml:"digest"`
-	URLs        []string      `yaml:"urls"`
+	URLs        []string      `yaml:"urls"` //V1
+	Templates   []Template    `yaml:"templates,omitempty"`
 }
 
 type RepositoryFile struct {
@@ -69,6 +70,11 @@ type RepositoryEntry struct {
 	Name      string `yaml:"name"`
 	URL       string `yaml:"url"`
 	IsDefault bool   `yaml:"default,omitempty"`
+}
+
+type Template struct {
+	ID  string `yaml:id`
+	URL string `yaml:url`
 }
 
 var (

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -46,7 +46,7 @@ type ProjectVersions []*ProjectVersion
 
 type ProjectVersion struct {
 	APIVersion  string        `yaml:"apiVersion"`
-	Id          string        `yaml:"id,omitempty"`
+	ID          string        `yaml:"id,omitempty"`
 	Created     time.Time     `yaml:"created"`
 	Name        string        `yaml:"name"`
 	Home        string        `yaml:"home"`
@@ -255,7 +255,7 @@ func (index *RepoIndex) listProjects(repoName string) string {
 		table.AddRow(repoName, id, value[0].Version, value[0].Description)
 	}
 	for _, value := range index.Stacks {
-		table.AddRow(repoName, value.Id, value.Version, value.Description)
+		table.AddRow(repoName, value.ID, value.Version, value.Description)
 	}
 	return table.String()
 }
@@ -284,7 +284,7 @@ func (r *RepositoryFile) listProjects() (string, error) {
 				table.AddRow(repoName, id, value[0].Version, value[0].Description)
 			}
 			for _, value := range index.Stacks {
-				table.AddRow(repoName, value.Id, value.Version, value.Description)
+				table.AddRow(repoName, value.ID, value.Version, value.Description)
 			}
 		}
 		return table.String(), nil


### PR DESCRIPTION
This PR allows the CLI to deal with a mixture of V1 and V2 repositories.