### PR TITLE
additional check for error message

### DIFF
--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -181,7 +181,9 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 	go func() {
 		<-c
 		err := dockerStop(containerName)
-		Error.log(err)
+		if err != nil {
+			Error.log(err)
+		}
 		//dockerRemove(containerName) is not needed due to --rm flag
 		os.Exit(1)
 	}()


### PR DESCRIPTION
Adds an if check so we don't print out an Error <nil> message on a good Ctrl-c for appsody run, etc.

Fulfills #142