### PR TITLE
Added .gz to the windows archieve file name, updated RELEASE.md

### DIFF
--- a/RELEASE.md
+++ b/RELEASE.md
@@ -20,7 +20,7 @@ The Appsody CLI is made available by creating a tagged GitHub release
     * appsody-x.y.z-1.x86_64.rpm
     * appsody-x.y.z-darwin-amd64.tar
     * appsody-x.y.z-linux-amd64.tar
-    * appsody-x.y.z-windows.tar
+    * appsody-x.y.z-windows.tar.gz
     * appsody-homebrew-x.y.z.tar.gz
     * appsody.rb
     * appsody_x.y.z_amd64.deb

--- a/win-build/build-win.sh
+++ b/win-build/build-win.sh
@@ -2,7 +2,7 @@
 set -e
 cd $(dirname "$0")
 VERSION=$4
-FILE_NAME="appsody-$VERSION-windows.tar"
+FILE_NAME="appsody-$VERSION-windows.tar.gz"
 FILE_POSTFIX="windows"
 CMD_NAME=$2
 CMD_NAME=${CMD_NAME%.*}


### PR DESCRIPTION
Fixes #132 

Changes Windows archieve file name from ".tar" to ".tar.gz" extension.