### PR TITLE
Add support for custom image repositories for stacks

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -253,6 +253,12 @@ func getProjectConfig() (ProjectConfig, error) {
 		}
 		stack := viper.GetString("stack")
 		Debug.log("Project stack from config file: ", stack)
+		imageRepo := cliConfig.GetString("images")
+		Debug.log("Image repository set to: ", imageRepo)
+		if imageRepo != "index.docker.io" {
+			stack = imageRepo + "/" + stack
+		}
+		Debug.log("Pulling stack image as: ", stack)
 		projectConfig = &ProjectConfig{stack}
 	}
 	return *projectConfig, nil


### PR DESCRIPTION
The Appsody CLI config in `$HOME/.`appsody/.appsody.yaml` provides an `images` field to allow for custom image repositories for the Appsody Stack Images:

```
$ cat ~/.appsody/.appsody.yaml 
home: /Users/bailey/.appsody
images: index.docker.io
tektonserver: ""
```

The `images` field isn't currently honoured. This updates the CLI so that if that field is set to anything other that `index.docker.io` (ie, DockerHub), it uses that repo to find the Appsody Stack Images.