### PR TITLE
enable extract to use `buildah` sequences for image extraction

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -280,7 +280,7 @@ func generateDeploymentConfig() error {
 
 	var cmdName string
 	var cmdArgs []string
-	pullErr := pullImage(stackImage, false)
+	pullErr := pullImage(stackImage)
 	if pullErr != nil {
 		return pullErr
 	}
@@ -305,7 +305,7 @@ func generateDeploymentConfig() error {
 	if err != nil {
 
 		Error.log("docker create command failed: ", err)
-		removeErr := containerRemove(extractContainerName, false)
+		removeErr := containerRemove(extractContainerName)
 		Error.log("Error in containerRemove", removeErr)
 		return err
 
@@ -317,14 +317,14 @@ func generateDeploymentConfig() error {
 	if err != nil {
 		Error.log("docker cp command failed: ", err)
 
-		removeErr := containerRemove(extractContainerName, false)
+		removeErr := containerRemove(extractContainerName)
 		if removeErr != nil {
 			Error.log("containerRemove error ", removeErr)
 		}
 		return errors.Errorf("docker cp command failed: %v", err)
 	}
 
-	removeErr := containerRemove(extractContainerName, false)
+	removeErr := containerRemove(extractContainerName)
 	if removeErr != nil {
 		Error.log("containerRemove error ", removeErr)
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -280,7 +280,7 @@ func generateDeploymentConfig() error {
 
 	var cmdName string
 	var cmdArgs []string
-	dockerPullErr := dockerPullImage(stackImage)
+	dockerPullErr := containerPullImage(stackImage, false)
 	if dockerPullErr != nil {
 		return dockerPullErr
 	}
@@ -305,8 +305,8 @@ func generateDeploymentConfig() error {
 	if err != nil {
 
 		Error.log("docker create command failed: ", err)
-		removeErr := dockerRemove(extractContainerName)
-		Error.log("Error in dockerRemove", removeErr)
+		removeErr := containerRemove(extractContainerName, false)
+		Error.log("Error in containerRemove", removeErr)
 		return err
 
 	}
@@ -317,16 +317,16 @@ func generateDeploymentConfig() error {
 	if err != nil {
 		Error.log("docker cp command failed: ", err)
 
-		removeErr := dockerRemove(extractContainerName)
+		removeErr := containerRemove(extractContainerName, false)
 		if removeErr != nil {
-			Error.log("dockerRemove error ", removeErr)
+			Error.log("containerRemove error ", removeErr)
 		}
 		return errors.Errorf("docker cp command failed: %v", err)
 	}
 
-	removeErr := dockerRemove(extractContainerName)
+	removeErr := containerRemove(extractContainerName, false)
 	if removeErr != nil {
-		Error.log("dockerRemove error ", removeErr)
+		Error.log("containerRemove error ", removeErr)
 	}
 
 	yamlReader, err := ioutil.ReadFile(configFile)

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -280,9 +280,9 @@ func generateDeploymentConfig() error {
 
 	var cmdName string
 	var cmdArgs []string
-	dockerPullErr := containerPullImage(stackImage, false)
-	if dockerPullErr != nil {
-		return dockerPullErr
+	pullErr := pullImage(stackImage, false)
+	if pullErr != nil {
+		return pullErr
 	}
 
 	c := make(chan os.Signal, 1)

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -129,17 +129,17 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 	Debug.log("Project directory: ", projectDir)
 
 	var cmdArgs []string
-	dockerPullErr := dockerPullImage(platformDefinition)
+	dockerPullErr := containerPullImage(platformDefinition, false)
 	if dockerPullErr != nil {
 		return dockerPullErr
 	}
 
-	volumeMaps, volumeErr := getVolumeArgs()
+	volumeMaps, volumeErr := getVolumeArgs(false)
 	if volumeErr != nil {
 		return volumeErr
 	}
 	// Mount the APPSODY_DEPS cache volume if it exists
-	depsEnvVar, envErr := getEnvVar("APPSODY_DEPS")
+	depsEnvVar, envErr := getEnvVar("APPSODY_DEPS", false)
 	if envErr != nil {
 		return envErr
 	}
@@ -217,7 +217,7 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 		if err != nil {
 			Error.log(err)
 		}
-		//dockerRemove(containerName) is not needed due to --rm flag
+		//containerRemove(containerName) is not needed due to --rm flag
 		os.Exit(1)
 	}()
 
@@ -298,7 +298,7 @@ func processPorts(cmdArgs []string) ([]string, error) {
 	Debug.log("Exposed ports provided by the docker file", dockerExposedPorts)
 	// if the container port is not in the lised of exposed ports add it to the list
 
-	containerPort, envErr := getEnvVar("PORT")
+	containerPort, envErr := getEnvVar("PORT", false)
 	if envErr != nil {
 		return cmdArgs, envErr
 	}

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -129,17 +129,17 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 	Debug.log("Project directory: ", projectDir)
 
 	var cmdArgs []string
-	pullErr := pullImage(platformDefinition, false)
+	pullErr := pullImage(platformDefinition)
 	if pullErr != nil {
 		return pullErr
 	}
 
-	volumeMaps, volumeErr := getVolumeArgs(false)
+	volumeMaps, volumeErr := getVolumeArgs()
 	if volumeErr != nil {
 		return volumeErr
 	}
 	// Mount the APPSODY_DEPS cache volume if it exists
-	depsEnvVar, envErr := getEnvVar("APPSODY_DEPS", false)
+	depsEnvVar, envErr := getEnvVar("APPSODY_DEPS")
 	if envErr != nil {
 		return envErr
 	}
@@ -298,7 +298,7 @@ func processPorts(cmdArgs []string) ([]string, error) {
 	Debug.log("Exposed ports provided by the docker file", dockerExposedPorts)
 	// if the container port is not in the lised of exposed ports add it to the list
 
-	containerPort, envErr := getEnvVar("PORT", false)
+	containerPort, envErr := getEnvVar("PORT")
 	if envErr != nil {
 		return cmdArgs, envErr
 	}

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -129,9 +129,9 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 	Debug.log("Project directory: ", projectDir)
 
 	var cmdArgs []string
-	dockerPullErr := containerPullImage(platformDefinition, false)
-	if dockerPullErr != nil {
-		return dockerPullErr
+	pullErr := pullImage(platformDefinition, false)
+	if pullErr != nil {
+		return pullErr
 	}
 
 	volumeMaps, volumeErr := getVolumeArgs(false)

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -102,11 +102,13 @@ in preparation to build the final container image.`,
 			}
 		}
 
-		// Buildah fails if the destination does not exist.
-		Debug.log("Creating extract dir: ", extractDir)
-		err = os.MkdirAll(extractDir, os.ModePerm)
-		if err != nil {
-			return errors.Errorf("Error creating directories %s %v", extractDir, err)
+		if buildah {
+			// Buildah fails if the destination does not exist.
+			Debug.log("Creating extract dir: ", extractDir)
+			err = os.MkdirAll(extractDir, os.ModePerm)
+			if err != nil {
+				return errors.Errorf("Error creating directories %s %v", extractDir, err)
+			}
 		}
 
 		stackImage := projectConfig.Platform

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -34,7 +34,7 @@ var extractCmd = &cobra.Command{
 	Use:   "extract",
 	Short: "Extract the stack and your Appsody project to a local directory",
 	Long: `This copies the full project, stack plus app, into a local directory
-in preparation to build the final buidlah / docker image.`,
+in preparation to build the final container image.`,
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		setupErr := setupConfig()
@@ -103,7 +103,7 @@ in preparation to build the final buidlah / docker image.`,
 			}
 		}
 
-		// Buildah fails if the desitnation does not exist.
+		// Buildah fails if the destination does not exist.
 		Debug.log("Creating extract dir: ", extractDir)
 		err = os.MkdirAll(extractDir, os.ModePerm)
 		if err != nil {

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -112,9 +112,9 @@ in preparation to build the final container image.`,
 
 		stackImage := projectConfig.Platform
 
-		containerPullErr := containerPullImage(stackImage, buildah)
-		if containerPullErr != nil {
-			return containerPullErr
+		pullErr := pullImage(stackImage, buildah)
+		if pullErr != nil {
+			return pullErr
 		}
 
 		containerProjectDir, containerProjectDirErr := getExtractDir(buildah)

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -28,7 +28,7 @@ func dockerStop(imageName string) error {
 	return nil
 }
 
-func containerRemove(imageName string, buildah bool) error {
+func containerRemove(imageName string) error {
 	cmdName := "docker"
 	//Added "-f" to force removal if container is still running or image has containers
 	cmdArgs := []string{"rm", imageName, "-f"}

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -28,10 +28,14 @@ func dockerStop(imageName string) error {
 	return nil
 }
 
-func dockerRemove(imageName string) error {
+func containerRemove(imageName string, buildah bool) error {
 	cmdName := "docker"
 	//Added "-f" to force removal if container is still running or image has containers
 	cmdArgs := []string{"rm", imageName, "-f"}
+	if buildah {
+		cmdName = "buildah"
+		cmdArgs = []string{"rm", imageName}
+	}
 	err := execAndWait(cmdName, cmdArgs, Debug)
 	if err != nil {
 		return err

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -82,9 +82,9 @@ func getEnvVar(searchEnvVar string, buildah bool) (string, error) {
 		return "", projectConfigErr
 	}
 	imageName := projectConfig.Platform
-	containerPullErrs := containerPullImage(imageName, buildah)
-	if containerPullErrs != nil {
-		return "", containerPullErrs
+	pullErrs := pullImage(imageName, buildah)
+	if pullErrs != nil {
+		return "", pullErrs
 	}
 	cmdName := "docker"
 	cmdArgs := []string{"image", "inspect", imageName}
@@ -452,9 +452,9 @@ func getExposedPorts() ([]string, error) {
 		return nil, projectConfigErr
 	}
 	imageName := projectConfig.Platform
-	containerPullErrs := containerPullImage(imageName, false)
-	if containerPullErrs != nil {
-		return nil, containerPullErrs
+	pullErrs := pullImage(imageName, false)
+	if pullErrs != nil {
+		return nil, pullErrs
 	}
 	cmdName := "docker"
 	cmdArgs := []string{"image", "inspect", imageName}
@@ -638,9 +638,9 @@ func DockerPush(imageToPush string) error {
 func DockerRunBashCmd(options []string, image string, bashCmd string) (cmdOutput string, err error) {
 	cmdName := "docker"
 	var cmdArgs []string
-	containerPullErrs := containerPullImage(image, false)
-	if containerPullErrs != nil {
-		return "", containerPullErrs
+	pullErrs := pullImage(image, false)
+	if pullErrs != nil {
+		return "", pullErrs
 	}
 	if len(options) >= 0 {
 		cmdArgs = append([]string{"run"}, options...)
@@ -798,10 +798,10 @@ func KubeGetDeploymentURL(service string) (url string, err error) {
 	return "", err
 }
 
-//containerPullCmd
+//pullCmd
 // enable extract to use `buildah` sequences for image extraction.
 // Pull the given docker image
-func containerPullCmd(imageToPull string, buildah bool) error {
+func pullCmd(imageToPull string, buildah bool) error {
 	cmdName := "docker"
 	if buildah {
 		cmdName = "buildah"
@@ -838,10 +838,10 @@ func checkDockerImageExistsLocally(imageToPull string) bool {
 	return false
 }
 
-//containerPullImage
+//pullImage
 // pulls buildah / docker image, if APPSODY_PULL_POLICY set to IFNOTPRESENT
 //it checks for image in local repo and pulls if not in the repo
-func containerPullImage(imageToPull string, buildah bool) error {
+func pullImage(imageToPull string, buildah bool) error {
 
 	Debug.logf("%s image pulled status: %t", imageToPull, imagePulled[imageToPull])
 	if imagePulled[imageToPull] {
@@ -864,7 +864,7 @@ func containerPullImage(imageToPull string, buildah bool) error {
 	}
 
 	if pullPolicyAlways || (!pullPolicyAlways && !localImageFound) {
-		err := containerPullCmd(imageToPull, buildah)
+		err := pullCmd(imageToPull, buildah)
 		if err != nil {
 			if pullPolicyAlways {
 				localImageFound = checkDockerImageExistsLocally(imageToPull)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -70,7 +70,7 @@ func exists(path string) (bool, error) {
 	return true, err
 }
 
-func getEnvVar(searchEnvVar string, buildah bool) (string, error) {
+func getEnvVar(searchEnvVar string) (string, error) {
 	// TODO cache this so the buildah / docker inspect command only runs once per cli invocation
 
 	// Docker and Buildah produce slightly different output
@@ -82,7 +82,7 @@ func getEnvVar(searchEnvVar string, buildah bool) (string, error) {
 		return "", projectConfigErr
 	}
 	imageName := projectConfig.Platform
-	pullErrs := pullImage(imageName, buildah)
+	pullErrs := pullImage(imageName)
 	if pullErrs != nil {
 		return "", pullErrs
 	}
@@ -143,7 +143,7 @@ func getEnvVar(searchEnvVar string, buildah bool) (string, error) {
 }
 
 func getEnvVarBool(searchEnvVar string) (bool, error) {
-	strVal, envErr := getEnvVar(searchEnvVar, false)
+	strVal, envErr := getEnvVar(searchEnvVar)
 	if envErr != nil {
 		return false, envErr
 	}
@@ -152,7 +152,7 @@ func getEnvVarBool(searchEnvVar string) (bool, error) {
 
 func getEnvVarInt(searchEnvVar string) (int, error) {
 
-	strVal, envErr := getEnvVar(searchEnvVar, false)
+	strVal, envErr := getEnvVar(searchEnvVar)
 	if envErr != nil {
 		return 0, envErr
 	}
@@ -164,8 +164,8 @@ func getEnvVarInt(searchEnvVar string) (int, error) {
 
 }
 
-func getExtractDir(buildah bool) (string, error) {
-	extractDir, envErr := getEnvVar("APPSODY_PROJECT_DIR", buildah)
+func getExtractDir() (string, error) {
+	extractDir, envErr := getEnvVar("APPSODY_PROJECT_DIR")
 	if envErr != nil {
 		return "", envErr
 	}
@@ -176,9 +176,9 @@ func getExtractDir(buildah bool) (string, error) {
 	return extractDir, nil
 }
 
-func getVolumeArgs(buildah bool) ([]string, error) {
+func getVolumeArgs() ([]string, error) {
 	volumeArgs := []string{}
-	stackMounts, envErr := getEnvVar("APPSODY_MOUNTS", buildah)
+	stackMounts, envErr := getEnvVar("APPSODY_MOUNTS")
 	if envErr != nil {
 		return nil, envErr
 	}
@@ -452,7 +452,7 @@ func getExposedPorts() ([]string, error) {
 		return nil, projectConfigErr
 	}
 	imageName := projectConfig.Platform
-	pullErrs := pullImage(imageName, false)
+	pullErrs := pullImage(imageName)
 	if pullErrs != nil {
 		return nil, pullErrs
 	}
@@ -638,7 +638,7 @@ func DockerPush(imageToPush string) error {
 func DockerRunBashCmd(options []string, image string, bashCmd string) (cmdOutput string, err error) {
 	cmdName := "docker"
 	var cmdArgs []string
-	pullErrs := pullImage(image, false)
+	pullErrs := pullImage(image)
 	if pullErrs != nil {
 		return "", pullErrs
 	}
@@ -801,7 +801,7 @@ func KubeGetDeploymentURL(service string) (url string, err error) {
 //pullCmd
 // enable extract to use `buildah` sequences for image extraction.
 // Pull the given docker image
-func pullCmd(imageToPull string, buildah bool) error {
+func pullCmd(imageToPull string) error {
 	cmdName := "docker"
 	if buildah {
 		cmdName = "buildah"
@@ -841,7 +841,7 @@ func checkDockerImageExistsLocally(imageToPull string) bool {
 //pullImage
 // pulls buildah / docker image, if APPSODY_PULL_POLICY set to IFNOTPRESENT
 //it checks for image in local repo and pulls if not in the repo
-func pullImage(imageToPull string, buildah bool) error {
+func pullImage(imageToPull string) error {
 
 	Debug.logf("%s image pulled status: %t", imageToPull, imagePulled[imageToPull])
 	if imagePulled[imageToPull] {
@@ -864,7 +864,7 @@ func pullImage(imageToPull string, buildah bool) error {
 	}
 
 	if pullPolicyAlways || (!pullPolicyAlways && !localImageFound) {
-		err := pullCmd(imageToPull, buildah)
+		err := pullCmd(imageToPull)
 		if err != nil {
 			if pullPolicyAlways {
 				localImageFound = checkDockerImageExistsLocally(imageToPull)


### PR DESCRIPTION
Introduce a `--buildah` flag.

An alternate approach that addresses a drawback in https://github.com/appsody/appsody-docker/pull/9 - wherein static assumptions about the project structure was required.

Signed-off-by: Gireesh Punathil gpunathi@in.ibm.com

Still a work in progress, want to set the semantics straight before proposing.

cc @seabaylea - pls have a quick look and suggest!
cc @pushkarnk - pls feel free to add commit(s).
