### PR TITLE
Add ps command to list stack-based containers currently running

### DIFF
--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -1,0 +1,130 @@
+// Copyright © 2019 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bufio"
+	"os/exec"
+	"strings"
+
+	"github.com/gosuri/uitable"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+// StackContainer is our internal representation of the attributes of stack based container
+type StackContainer struct {
+	ID            string
+	stackName     string
+	status        string
+	containerName string
+}
+
+// psCmd represents the ps command
+var psCmd = &cobra.Command{
+	Use:   "ps",
+	Short: "List the appsody containers running in the local docker environment",
+	Long:  `This command lists all stack-based containers, that are currently running in the local docker envionment.`,
+	RunE: func(cmd *cobra.Command, args []string) error {
+
+		setupErr := setupConfig()
+		if setupErr != nil {
+			return setupErr
+		}
+
+		containers, err := listContainers()
+		if err != nil {
+			return err
+		}
+
+		table, err := formatTable(containers)
+		if err != nil {
+			return errors.Errorf("%v", err)
+		}
+		Info.log(table)
+		return nil
+	},
+}
+
+func listContainers() ([]StackContainer, error) {
+	var containers = []StackContainer{}
+
+	// We are going to do a 'docker ps' and parse the output into fields. At least one of these
+	// fields can have white space in it (Status), so we need a way of splitting up the output.
+	// To do this we use the --format option and include a string of illegal characters as a
+	// seperator, which we then subsequently use to parse.
+	strSep := "$!$!$!"
+	cmdName := "docker"
+	cmdArgs := []string{
+		"ps",
+		"--no-trunc",
+		"--format",
+		"{{.ID}}" + strSep + "{{.Image}}" + strSep + "{{.Status}}" +
+			strSep + "{{.Names}}" + strSep + "{{.Command}}"}
+
+	cmd := exec.Command(cmdName, cmdArgs...)
+	cmdReader, err := cmd.StdoutPipe()
+	if err != nil {
+		Error.log("Error creating StdoutPipe for Cmd", err)
+		return nil, err
+	}
+
+	outScanner := bufio.NewScanner(cmdReader)
+	outScanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+	go func() {
+		for outScanner.Scan() {
+			fields := strings.Split(outScanner.Text(), strSep)
+			if strings.Contains(fields[4], "appsody-controller") {
+				stack := strings.Split(fields[1], "/")
+				containers = append(containers, StackContainer{fields[0][0:12], stack[len(stack)-1], fields[2], fields[3]})
+			}
+		}
+	}()
+
+	err = cmd.Start()
+	if err != nil {
+		Error.log("Error running command", err)
+		return nil, err
+	}
+	err = cmd.Wait()
+	if err != nil {
+		Error.log("Error waiting for command", err)
+		return nil, err
+	}
+
+	return containers, nil
+}
+
+func formatTable(containers []StackContainer) (string, error) {
+	table := uitable.New()
+	table.MaxColWidth = 60
+	table.Wrap = true
+
+	if len(containers) != 0 {
+		table.AddRow("CONTAINER ID", "STACK", "STATUS", "NAME")
+
+		for _, value := range containers {
+			table.AddRow(value.ID, value.stackName, value.status, value.containerName)
+		}
+	} else {
+		return "", errors.New("there are no stack-based containers running in your docker environment")
+	}
+
+	return table.String(), nil
+}
+
+func init() {
+	rootCmd.AddCommand(psCmd)
+}

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -118,7 +118,8 @@ func formatTable(containers []StackContainer) (string, error) {
 			table.AddRow(value.ID, value.containerName, value.stackName, value.status)
 		}
 	} else {
-		return "", errors.New("there are no stack-based containers running in your docker environment")
+		Info.log("There are no stack-based containers running in your docker environment")
+		return "", nil
 	}
 
 	return table.String(), nil

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -87,8 +87,7 @@ func listContainers() ([]StackContainer, error) {
 		for outScanner.Scan() {
 			fields := strings.Split(outScanner.Text(), strSep)
 			if strings.Contains(fields[4], "appsody-controller") {
-				stack := strings.Split(fields[1], "/")
-				containers = append(containers, StackContainer{fields[0][0:12], stack[len(stack)-1], fields[2], fields[3]})
+				containers = append(containers, StackContainer{fields[0][0:12], fields[1], fields[2], fields[3]})
 			}
 		}
 	}()
@@ -113,10 +112,10 @@ func formatTable(containers []StackContainer) (string, error) {
 	table.Wrap = true
 
 	if len(containers) != 0 {
-		table.AddRow("CONTAINER ID", "STACK", "STATUS", "NAME")
+		table.AddRow("CONTAINER ID", "NAME", "IMAGE", "STATUS")
 
 		for _, value := range containers {
-			table.AddRow(value.ID, value.stackName, value.status, value.containerName)
+			table.AddRow(value.ID, value.containerName, value.stackName, value.status)
 		}
 	} else {
 		return "", errors.New("there are no stack-based containers running in your docker environment")

--- a/functest/ps_test.go
+++ b/functest/ps_test.go
@@ -1,0 +1,105 @@
+// Copyright © 2019 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package functest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"strings"
+	"time"
+
+	"os"
+	"testing"
+
+	"github.com/appsody/appsody/cmd/cmdtest"
+)
+
+func TestPS(t *testing.T) {
+	//
+	// Test Plan:
+	//
+	// - Spin up a named conatainer using appsody run (any one will do)
+	// - Use docker ps to wait until it is ready
+	// - execute 'appsody ps', and check it we get at least a header line and the
+	//   right container in the output
+	// - use 'appsody stop' to stop the container
+	//
+
+	// create a temporary dir to create the project and run the test
+	projectDir, err := ioutil.TempDir("", "appsody-ps-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(projectDir)
+	log.Println("Created project dir: " + projectDir)
+
+	// appsody init nodejs-express
+	_, err = cmdtest.RunAppsodyCmdExec([]string{"init", "nodejs-express"}, projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// appsody run
+	runChannel := make(chan error)
+	containerName := "testPSContainer"
+	go func() {
+		_, err = cmdtest.RunAppsodyCmdExec([]string{"run", "--name", containerName}, projectDir)
+		runChannel <- err
+	}()
+
+	// It will take a while for the container to spin up, so let's use docker ps to wait for it
+	fmt.Println("calling docker ps to wait for container")
+	containerRunning := false
+	count := 100
+	for {
+		dockerOutput, dockerErr := cmdtest.RunDockerCmdExec([]string{"ps", "-q", "-f", "name=" + containerName})
+		if dockerErr != nil {
+			log.Print("Ignoring error running docker ps -q -f name="+containerName, dockerErr)
+		}
+		if dockerOutput != "" {
+			fmt.Println("docker container " + containerName + " was found")
+			containerRunning = true
+		} else {
+			time.Sleep(2 * time.Second)
+			count = count - 1
+		}
+		if count == 0 || containerRunning {
+			break
+		}
+	}
+
+	// now run appsody ps and see if we can spot the container
+	go func() {
+		fmt.Println("about to run appsody ps")
+		stopOutput, errStop := cmdtest.RunAppsodyCmd([]string{"ps"}, projectDir)
+		if !strings.Contains(stopOutput, "CONTAINER") {
+			t.Fatal("output doesn't contain header line")
+		}
+		if !strings.Contains(stopOutput, containerName) {
+			t.Fatal("output doesn't contain correct conatiner name")
+		}
+		if errStop != nil {
+			log.Printf("Ignoring error running appsody ps: %s", errStop)
+		}
+	}()
+
+	// defer the appsody stop to close the docker container
+	defer func() {
+		_, err = cmdtest.RunAppsodyCmdExec([]string{"stop", "--name", "testPSContainer"}, projectDir)
+		if err != nil {
+			fmt.Printf("Ignoring error running appsody stop: %s", err)
+		}
+	}()
+}

--- a/functest/ps_test.go
+++ b/functest/ps_test.go
@@ -81,7 +81,7 @@ func TestPS(t *testing.T) {
 	}
 
 	if !containerRunning {
-		t.Fatal("container never appeared t ostart")
+		t.Fatal("container never appeared to start")
 	}
 
 	// now run appsody ps and see if we can spot the container
@@ -91,7 +91,7 @@ func TestPS(t *testing.T) {
 		t.Fatal("output doesn't contain header line")
 	}
 	if !strings.Contains(stopOutput, containerName) {
-		t.Fatal("output doesn't contain correct conatiner name")
+		t.Fatal("output doesn't contain correct container name")
 	}
 	if errStop != nil {
 		log.Printf("Ignoring error running appsody ps: %s", errStop)

--- a/functest/ps_test.go
+++ b/functest/ps_test.go
@@ -80,20 +80,22 @@ func TestPS(t *testing.T) {
 		}
 	}
 
+	if !containerRunning {
+		t.Fatal("container never appeared t ostart")
+	}
+
 	// now run appsody ps and see if we can spot the container
-	go func() {
-		fmt.Println("about to run appsody ps")
-		stopOutput, errStop := cmdtest.RunAppsodyCmd([]string{"ps"}, projectDir)
-		if !strings.Contains(stopOutput, "CONTAINER") {
-			t.Fatal("output doesn't contain header line")
-		}
-		if !strings.Contains(stopOutput, containerName) {
-			t.Fatal("output doesn't contain correct conatiner name")
-		}
-		if errStop != nil {
-			log.Printf("Ignoring error running appsody ps: %s", errStop)
-		}
-	}()
+	fmt.Println("about to run appsody ps")
+	stopOutput, errStop := cmdtest.RunAppsodyCmd([]string{"ps"}, projectDir)
+	if !strings.Contains(stopOutput, "CONTAINER") {
+		t.Fatal("output doesn't contain header line")
+	}
+	if !strings.Contains(stopOutput, containerName) {
+		t.Fatal("output doesn't contain correct conatiner name")
+	}
+	if errStop != nil {
+		log.Printf("Ignoring error running appsody ps: %s", errStop)
+	}
 
 	// defer the appsody stop to close the docker container
 	defer func() {


### PR DESCRIPTION
Provide the option (along the lines of docker ps) to list details of the stack-based containers that are currently running in the docker environment.

Fixes: https://github.com/appsody/appsody/issues/69

