### PR TITLE
Support templates +  URL. Fixes #188

### DIFF
--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -70,6 +70,7 @@ type ProjectVersion struct {
 	URLs            []string      `yaml:"urls"` //V1
 	Templates       []Template    `yaml:"templates,omitempty"`
 	DefaultTemplate string        `yaml:"default-template"`
+	Image           string        `yaml:"image,omitempty"`
 }
 
 type RepositoryFile struct {

--- a/cmd/testdata/kabanero.yaml
+++ b/cmd/testdata/kabanero.yaml
@@ -19,6 +19,8 @@ stacks:
     templates:
       - id: simple
         url: https://github.com/appsody/stacks/releases/download/nodejs-v0.2.2/incubator.nodejs.templates.simple.tar.gz
+      - id: in-image
+        url: image:/path/test.tgz
     pipelines:
       - id: default
         url: https://github.com//releases/latest/download/incubator.nodejs.pipeline.default.tar.gz


### PR DESCRIPTION
POC to support `image:` URLs for in-stack templates.

```  - id: java-spring-boot2
    name: Spring Boot®
    version: 0.4.0
    description: Spring Boot using OpenJ9 and Maven
    license: Apache-2.0
    maintainers:
      - name: Erin Schnabel
        email: schnabel@us.ibm.com
        github-id: ebullient
    default-template: default
    templates:
      - id: default
        url: image:/templates/default.tgz
      - id: kotlin
        url: image:/templates/kotlin.tgz
    image: appsody/java-spring-boot2:0.4.0
```

This works against PR appsody/stacks#180