### PR TITLE
Add support for customizing the project directory

### DIFF
--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -107,7 +107,10 @@ in preparation to build the final docker image.`,
 			return dockerPullErr
 		}
 
-		containerProjectDir := "/project"
+		containerProjectDir, containerProjectDirErr := getExtractDir()
+		if containerProjectDirErr != nil {
+			return containerProjectDirErr
+		}
 		Debug.log("Container project dir: ", containerProjectDir)
 
 		volumeMaps, volumeErr := getVolumeArgs()

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -137,6 +137,18 @@ func getEnvVarInt(searchEnvVar string) (int, error) {
 
 }
 
+func getExtractDir() (string, error) {
+	extractDir, envErr := getEnvVar("APPSODY_PROJECT_DIR")
+	if envErr != nil {
+		return "", envErr
+	}
+	if extractDir == "" {
+		Warning.log("The stack image does not contain APPSODY_PROJECT_DIR. Using /project")
+		return "/project", nil
+	}
+	return extractDir, nil
+}
+
 func getVolumeArgs() ([]string, error) {
 	volumeArgs := []string{}
 	stackMounts, envErr := getEnvVar("APPSODY_MOUNTS")


### PR DESCRIPTION
The `appsody extract` and therefore `appsody build` commands currently make the assumption that the application sits inside the `/project` directory inside the container. Whilst this has been true for all Appsody Stacks so far, it may not be in the future.

An example of this is "Traditional WebSphere", where the standard docker images provide assets in `/work/config`.

This adds an optional `APPSODY_PROJECT_DIR` environment variable, which defaults to `/project`.