### PR TITLE
Added release version in branch names for website and .rb branch and also added  website release not created info message

### DIFF
--- a/deploy-build/deploy.sh
+++ b/deploy-build/deploy.sh
@@ -5,11 +5,11 @@ cd ./tmpclone
 git clone https://${GH_TOKEN}@github.com/${GH_ORG}/homebrew-appsody.git
 
 cd homebrew-appsody
-git checkout -b test${TRAVIS_BUILD_NUMBER}
+git checkout -b test${VERSION}
 cp ../../package/appsody.rb .
 git add appsody.rb
-git commit -m "Travis build: $TRAVIS_BUILD_NUMBER" --author="Kyle G. Christianson <christik@us.ibm.com>"
-git push --set-upstream origin test${TRAVIS_BUILD_NUMBER}
+git commit -m "Travis build: $VERSION" --author="Kyle G. Christianson <christik@us.ibm.com>"
+git push --set-upstream origin test${VERSION}
 # clean up
 cd ../..
 rm -rf tmpclone

--- a/docs-build/deploy.sh
+++ b/docs-build/deploy.sh
@@ -11,15 +11,16 @@ diff ../../build/cli-commands.md ./content/docs/using-appsody/cli-commands.md
 if [ $? -ne 0 ]
 then
     set -e
-    git checkout -b test${TRAVIS_BUILD_NUMBER}
+    git checkout -b test${VERSION}
     cp ../../build/cli-commands.md ./content/docs/using-appsody/cli-commands.md
 
     git add content/docs/using-appsody/cli-commands.md
 
-    git commit -m "Travis build: $TRAVIS_BUILD_NUMBER" --author="Kyle G. Christianson <christik@us.ibm.com>"
+    git commit -m "Travis build: $VERSION" --author="Kyle G. Christianson <christik@us.ibm.com>"
 
-    git push --set-upstream origin test${TRAVIS_BUILD_NUMBER}
-
+    git push --set-upstream origin test${VERSION}
+else
+    echo "No changes were found in the appsody doc generation process between releases, no appsody/website branch will be created."
 fi
 # clean up
 cd ../..


### PR DESCRIPTION
Fixes #105 
Fixes #112 

Names created branches after the release version, not the travis build
Adds a message to say that website branch was not generated.