### PR TITLE
added controller version and logic to pull controller for functest

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,7 @@ ifeq (,$(wildcard ~/.appsody/appsody-controller))
 	chmod +x appsody-controller
 	mkdir -p ~/.appsody
 	cp appsody-controller ~/.appsody/ 
+	rm appsody-controller
 endif	
 .PHONY: test
 test: ## Run the all the automated tests

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ package_binary = $(COMMAND)$(BINARY_EXT_$(os))
 .PHONY: all
 all: lint test package ## Run lint, test, build, and package
 
-PHONY: install-controller
+.PHONY: install-controller
 install-controller:  ## Get the controller and install it
 ifeq (,$(wildcard ~/.appsody/appsody-controller))
 	wget $(CONTROLLER_BASE_URL)/appsody-controller

--- a/Makefile
+++ b/Makefile
@@ -16,9 +16,8 @@ BINARY_EXT_darwin :=
 BINARY_EXT_windows := .exe
 DOCKER_IMAGE_RPM := alectolytic/rpmbuilder
 DOCKER_IMAGE_DEB := appsody/debian-builder
-CONTROLLER_VERSION :=0.2.2
-CONTROLLER_BASE_HOST := https://github.com/
-CONTROLLER_BASE_PATH :=/controller/releases/download/$(CONTROLLER_VERSION)
+GH_ORG ?= appsody
+CONTROLLER_VERSION ?=0.2.2
 CONTROLLER_BASE_URL := https://github.com/${GH_ORG}/controller/releases/download/$(CONTROLLER_VERSION)
 
 #### Dynamic variables. These change depending on the target name.
@@ -36,13 +35,7 @@ all: lint test package ## Run lint, test, build, and package
 PHONY: install-controller
 install-controller:  ## Get the controller and install it
 ifeq (,$(wildcard ~/.appsody/appsody-controller))
-ifndef GH_ORG
-	echo "GH_ORG not set using 'appsody' release of controller" 
-	wget $(CONTROLLER_BASE_HOST)appsody$(CONTROLLER_BASE_PATH)/appsody-controller
-else
-	echo "GH_ORG is set: $(GH_ORG)"
-	wget $(CONTROLLER_BASE_HOST)$(GH_ORG)$(CONTROLLER_BASE_PATH)/appsody-controller	
-endif	
+	wget $(CONTROLLER_BASE_URL)/appsody-controller
 	chmod +x appsody-controller
 	mkdir -p ~/.appsody
 	cp appsody-controller ~/.appsody/ 


### PR DESCRIPTION
Fixes #98 
Also fixes PR 181

Addes logic to choose appsody version of controller if the controller is not present during functest.
