### PR TITLE
--docker-options flag added

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -16,11 +16,27 @@ package cmd
 
 import (
 	"path/filepath"
+	"regexp"
 	"strings"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 )
+
+func checkDockerBuildOptions(options []string) error {
+	buildOptionsTest := "(^((-t)|(--tag)|(-f)|(--file))(=?$)|(=.*))"
+
+	blackListedBuildOptionsRegexp := regexp.MustCompile(buildOptionsTest)
+	for _, value := range options {
+		isInBlackListed := blackListedBuildOptionsRegexp.MatchString(value)
+		if isInBlackListed {
+			return errors.Errorf("%s is not allowed in --docker-options", value)
+
+		}
+	}
+	return nil
+
+}
 
 var dockerBuildOptions string
 
@@ -55,6 +71,10 @@ var buildCmd = &cobra.Command{
 
 		if dockerBuildOptions != "" {
 			options := strings.Split(dockerBuildOptions, " ")
+			err := checkDockerBuildOptions(options)
+			if err != nil {
+				return err
+			}
 			cmdArgs = append(cmdArgs, options...)
 
 		}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -70,6 +70,8 @@ var buildCmd = &cobra.Command{
 		cmdArgs := []string{"-t", buildImage}
 
 		if dockerBuildOptions != "" {
+			dockerBuildOptions = strings.TrimPrefix(dockerBuildOptions, " ")
+			dockerBuildOptions = strings.TrimSuffix(dockerBuildOptions, " ")
 			options := strings.Split(dockerBuildOptions, " ")
 			err := checkDockerBuildOptions(options)
 			if err != nil {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -55,9 +55,7 @@ var buildCmd = &cobra.Command{
 
 		if dockerBuildOptions != "" {
 			options := strings.Split(dockerBuildOptions, " ")
-			for _, value := range options {
-				cmdArgs = append(cmdArgs, value)
-			}
+			cmdArgs = append(cmdArgs, options...)
 
 		}
 		cmdArgs = append(cmdArgs, "-f", dockerfile, extractDir)

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -43,6 +43,7 @@ var nameFlags *flag.FlagSet
 var commonFlags *flag.FlagSet
 
 func checkDockerRunOptions(options []string) error {
+	fmt.Println("testing docker options", options)
 	runOptionsTest := "(^((-p)|(--publish)|(--publish-all)|(-P)|(-u)|(--user)|(--name)|(--network)|(-t)|(--tty)|(--rm)|(--entrypoint)|(-v)|(--volume)|(-e)|(--env))(=?$)|(=.*))"
 
 	blackListedRunOptionsRegexp := regexp.MustCompile(runOptionsTest)
@@ -248,6 +249,8 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 		cmdArgs = append(cmdArgs, volumeMaps...)
 	}
 	if dockerOptions != "" {
+		dockerOptions = strings.TrimPrefix(dockerOptions, " ")
+		dockerOptions = strings.TrimSuffix(dockerOptions, " ")
 		dockerOptionsCmd := strings.Split(dockerOptions, " ")
 		err := checkDockerRunOptions(dockerOptionsCmd)
 		if err != nil {

--- a/cmd/docker_commands.go
+++ b/cmd/docker_commands.go
@@ -1,0 +1,76 @@
+package cmd
+
+import (
+	"bufio"
+	"os/exec"
+)
+
+func DockerRunAndListen(args []string, logger appsodylogger) (*exec.Cmd, error) {
+	var runArgs = []string{"run"}
+	runArgs = append(runArgs, args...)
+	return RunDockerCommandAndListen(runArgs, logger)
+}
+
+func DockerBuild(args []string, logger appsodylogger) error {
+	var buildArgs = []string{"build"}
+	buildArgs = append(buildArgs, args...)
+	return RunDockerCommandAndWait(buildArgs, logger)
+}
+
+func RunDockerCommandAndWait(args []string, logger appsodylogger) error {
+
+	cmd, err := RunDockerCommandAndListen(args, logger)
+	if err != nil {
+		return err
+	}
+	return cmd.Wait()
+
+}
+
+func RunDockerCommandAndListen(args []string, logger appsodylogger) (*exec.Cmd, error) {
+	var execCmd *exec.Cmd
+	var command = "docker"
+	var err error
+	if dryrun {
+		Info.log("Dry Run - Skipping docker command: ", command, args)
+	} else {
+		Info.log("Running docker command: ", command, args)
+		execCmd = exec.Command(command, args...)
+
+		cmdReader, err := execCmd.StdoutPipe()
+		if err != nil {
+			Error.log("Error creating StdoutPipe for docker Cmd ", err)
+			return nil, err
+		}
+
+		errReader, err := execCmd.StderrPipe()
+		if err != nil {
+			Error.log("Error creating StderrPipe for docker Cmd ", err)
+			return nil, err
+		}
+
+		outScanner := bufio.NewScanner(cmdReader)
+		outScanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		go func() {
+			for outScanner.Scan() {
+				logger.log(outScanner.Text())
+			}
+		}()
+
+		errScanner := bufio.NewScanner(errReader)
+		errScanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+		go func() {
+			for errScanner.Scan() {
+				logger.log(errScanner.Text())
+			}
+		}()
+
+		err = execCmd.Start()
+		if err != nil {
+			Debug.log("Error running ", command, " command: ", errScanner.Text(), err)
+			return nil, err
+		}
+
+	}
+	return execCmd, err
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -275,19 +275,7 @@ func getProjectName() (string, error) {
 	projectName := strings.ToLower(filepath.Base(projectDir))
 	return projectName, nil
 }
-func execAndListen(command string, args []string, logger appsodylogger) (*exec.Cmd, error) {
-	return execAndListenWithWorkDir(command, args, logger, workDirNotSet) // no workdir
-}
 
-func execAndListenWithWorkDir(command string, args []string, logger appsodylogger, workdir string) (*exec.Cmd, error) {
-
-	cmd, err := execAndListenWithWorkDirReturnErr(command, args, logger, workdir)
-	if err != nil {
-		return cmd, err
-	}
-	return cmd, nil
-
-}
 func execAndWait(command string, args []string, logger appsodylogger) error {
 
 	return execAndWaitWithWorkDir(command, args, logger, workDirNotSet)

--- a/functest/docker_options_test.go
+++ b/functest/docker_options_test.go
@@ -1,0 +1,63 @@
+// Copyright © 2019 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package functest
+
+import (
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/appsody/appsody/cmd/cmdtest"
+)
+
+func TestRunWithDockerOptionsRegex(t *testing.T) {
+
+	var runOutput string
+	// create a temporary dir to create the project and run the test
+	projectDir, err := ioutil.TempDir("", "appsody-docker-options-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(projectDir)
+
+	log.Println("Created project dir: " + projectDir)
+
+	// appsody init nodejs-express
+	_, err = cmdtest.RunAppsodyCmdExec([]string{"init", "nodejs-express"}, projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var testOptions = []string{"-p", "--publish", "--publish-all", "-P", "-u", "--user", "--name", "--network", "-t", "--tty", "--rm", "--entrypoint", "-v", "--volume", "-e", "--env"}
+	for _, value := range testOptions {
+		fmt.Println("Option is", value)
+		runOutput, err = cmdtest.RunAppsodyCmdExec([]string{"run", "--docker-options", value, "--dryrun"}, projectDir)
+		fmt.Println("err ", err)
+		if !strings.Contains(runOutput, value+" is not allowed in --docker-options") {
+			t.Fatal("Error message not found:" + value + " is not allowed in --docker-options")
+
+		}
+		runOutput, err = cmdtest.RunAppsodyCmdExec([]string{"run", "--docker-options", value + "=", "--dryrun"}, projectDir)
+		fmt.Println("err ", err)
+		if !strings.Contains(runOutput, value+"="+" is not allowed in --docker-options") {
+			t.Fatal("Error message not found:" + value + "=" + " is not allowed in --docker-options")
+
+		}
+
+	}
+}

--- a/functest/ports_test.go
+++ b/functest/ports_test.go
@@ -103,3 +103,30 @@ func TestRunWithNetwork(t *testing.T) {
 
 	}
 }
+
+// This test tests the setting of --docker-options
+func TestRunWithDockerOptions(t *testing.T) {
+
+	var runOutput string
+	// create a temporary dir to create the project and run the test
+	projectDir, err := ioutil.TempDir("", "appsody-docker-options-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	defer os.RemoveAll(projectDir)
+
+	log.Println("Created project dir: " + projectDir)
+
+	// appsody init nodejs-express
+	_, err = cmdtest.RunAppsodyCmdExec([]string{"init", "nodejs-express"}, projectDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	runOutput, _ = cmdtest.RunAppsodyCmdExec([]string{"run", "--docker-options \"-m 4g\"", "--publish-all", "--dryrun"}, projectDir)
+
+	if !strings.Contains(runOutput, "--docker-options \"-m 4g\"") {
+		t.Fatal("docker-options flag is not found in output as:  --docker-options \"-m 4g\"")
+
+	}
+}


### PR DESCRIPTION
Fixes #116 

Adds the --docker-options flag to allow users to send options to docker command (run, build) via the appsody command line.