### PR TITLE
Add a Makefile default for the repo from where the appsody-controller is pulled

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ DOCKER_IMAGE_RPM := alectolytic/rpmbuilder
 DOCKER_IMAGE_DEB := appsody/debian-builder
 
 # If you need to pull the appsody controller from a different repo, then set the GH_ORG
-# environment variable before runing this Makefile
+# environment variable before running this Makefile
 GH_ORG ?= appsody
 CONTROLLER_BASE_URL := https://github.com/${GH_ORG}/controller/releases/download/0.2.2
 

--- a/Makefile
+++ b/Makefile
@@ -16,6 +16,10 @@ BINARY_EXT_darwin :=
 BINARY_EXT_windows := .exe
 DOCKER_IMAGE_RPM := alectolytic/rpmbuilder
 DOCKER_IMAGE_DEB := appsody/debian-builder
+
+# If you need to pull the appsody controller from a different repo, then set the GH_ORG
+# environment variable before runing this Makefile
+GH_ORG ?= appsody
 CONTROLLER_BASE_URL := https://github.com/${GH_ORG}/controller/releases/download/0.2.2
 
 #### Dynamic variables. These change depending on the target name.
@@ -30,7 +34,7 @@ package_binary = $(COMMAND)$(BINARY_EXT_$(os))
 .PHONY: all
 all: lint test package ## Run lint, test, build, and package
 
-PHONY: install-controller
+.PHONY: install-controller
 install-controller: ## Get the controller and install it
 	wget $(CONTROLLER_BASE_URL)/appsody-controller
 	chmod +x appsody-controller

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ build_name = $(COMMAND)-$(VERSION)-$(os)-amd64
 build_binary = $(build_name)$(BINARY_EXT_$(os))
 package_binary = $(COMMAND)$(BINARY_EXT_$(os))
 
-.PHONY: all
+PHONY: all
 all: lint test package ## Run lint, test, build, and package
 
 .PHONY: install-controller


### PR DESCRIPTION
Ensures that the Makefile will default the repo from where to pull the appsody-controller to 'appsody'. This still allows for the GH_ORG environment variable to be set ahead of executing the makefile to override this default. Without this default, the make fails if a developer does not know to set GH_ORG.

Partially Fixes: https://github.com/appsody/appsody/issues/130