### PR TITLE
cmd: fixed bug in appsody init test

### DIFF
--- a/functest/init_test.go
+++ b/functest/init_test.go
@@ -320,7 +320,7 @@ func TestInitV2WithBadStackSpecified(t *testing.T) {
 	log.Println("Created project dir: " + projectDir)
 
 	// appsody init nodejs-express
-	output, _ := cmdtest.RunAppsodyCmdExec([]string{"init", "experimental/badnodejs-express"}, projectDir)
+	output, _ := cmdtest.RunAppsodyCmdExec([]string{"init", "badnodejs-express"}, projectDir)
 	if !(strings.Contains(output, "Could not find a stack with the id")) {
 		t.Error("Should have flagged non existing stack")
 	}


### PR DESCRIPTION
Removed repository "experimental" so the CLI outputs that it could not find the stack, and the test passes if the CLI prints the correct message

Fixes: https://github.com/appsody/appsody/issues/199