### PR TITLE
regex fix for =

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -24,7 +24,7 @@ import (
 )
 
 func checkDockerBuildOptions(options []string) error {
-	buildOptionsTest := "(^((-t)|(--tag)|(-f)|(--file))(=?$)|(=.*))"
+	buildOptionsTest := "(^((-t)|(--tag)|(-f)|(--file))((=?$)|(=.*)))"
 
 	blackListedBuildOptionsRegexp := regexp.MustCompile(buildOptionsTest)
 	for _, value := range options {

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -44,7 +44,7 @@ var commonFlags *flag.FlagSet
 
 func checkDockerRunOptions(options []string) error {
 	fmt.Println("testing docker options", options)
-	runOptionsTest := "(^((-p)|(--publish)|(--publish-all)|(-P)|(-u)|(--user)|(--name)|(--network)|(-t)|(--tty)|(--rm)|(--entrypoint)|(-v)|(--volume)|(-e)|(--env))(=?$)|(=.*))"
+	runOptionsTest := "(^((-p)|(--publish)|(--publish-all)|(-P)|(-u)|(--user)|(--name)|(--network)|(-t)|(--tty)|(--rm)|(--entrypoint)|(-v)|(--volume)|(-e)|(--env))((=?$)|(=.*)))"
 
 	blackListedRunOptionsRegexp := regexp.MustCompile(runOptionsTest)
 	for _, value := range options {


### PR DESCRIPTION
Bug for good path where -m=4g failed even though it was a valid docker-options parameter.
Retested on both good and bad path.

Fixes #203