### PR TITLE
fix for wait on docker_commands dryrun path

### DIFF
--- a/cmd/docker_commands.go
+++ b/cmd/docker_commands.go
@@ -23,6 +23,11 @@ func RunDockerCommandAndWait(args []string, logger appsodylogger) error {
 	if err != nil {
 		return err
 	}
+	if dryrun {
+		Info.log("Dry Run - Skipping : cmd.Wait")
+
+		return nil
+	}
 	return cmd.Wait()
 
 }


### PR DESCRIPTION
appsody build --dryrun segv's  same thing happens with appsody deploy --dryrun

Fixes #208