### PR TITLE
Fix checksum error path for controller copy

### DIFF
--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -176,7 +176,7 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 		if controllerExists {
 			var checksumMatchErr error
 			checksumMatch, checksumMatchErr = checksum256TestFile(filepath.Join(binaryLocation, "appsody-controller"), destController)
-			Debug.log("checksum returned: ", controllerExists)
+			Debug.log("checksum returned: ", checksumMatch)
 			if checksumMatchErr != nil {
 				return checksumMatchErr
 			}

--- a/cmd/docker_commands.go
+++ b/cmd/docker_commands.go
@@ -23,6 +23,11 @@ func RunDockerCommandAndWait(args []string, logger appsodylogger) error {
 	if err != nil {
 		return err
 	}
+	if dryrun {
+		Info.log("Dry Run - Skipping : cmd.Wait")
+
+		return nil
+	}
 	return cmd.Wait()
 
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -935,13 +935,13 @@ func checksum256TestFile(newFileName string, oldFileName string) (bool, error) {
 	}
 	newSha256, errNew := createChecksumHash(newFileName)
 	if errNew != nil {
-		return false, nil
+		return false, errNew
 	}
 	Debug.logf("%x\n", oldSha256.Sum(nil))
 	Debug.logf("%x\n", newSha256.Sum(nil))
 	checkValue = bytes.Equal(oldSha256.Sum(nil), newSha256.Sum(nil))
 
-	Debug.log("Checksum returned", checkValue)
+	Debug.log("Checksum returned: ", checkValue)
 
 	return checkValue, nil
 }


### PR DESCRIPTION
Issue where /usr/local/Cellar/appsody/<release>/bin/appsody-controller did not exist, fixed error path to return error earlier.
Fixes #207