### PR TITLE
appsody operator install --dryrun causes error

### DIFF
--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -176,7 +176,7 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 		if controllerExists {
 			var checksumMatchErr error
 			checksumMatch, checksumMatchErr = checksum256TestFile(filepath.Join(binaryLocation, "appsody-controller"), destController)
-			Debug.log("checksum returned: ", controllerExists)
+			Debug.log("checksum returned: ", checksumMatch)
 			if checksumMatchErr != nil {
 				return checksumMatchErr
 			}

--- a/cmd/docker_commands.go
+++ b/cmd/docker_commands.go
@@ -23,6 +23,11 @@ func RunDockerCommandAndWait(args []string, logger appsodylogger) error {
 	if err != nil {
 		return err
 	}
+	if dryrun {
+		Info.log("Dry Run - Skipping : cmd.Wait")
+
+		return nil
+	}
 	return cmd.Wait()
 
 }

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -121,9 +121,12 @@ var installCmd = &cobra.Command{
 		}
 
 		appsodyCRD := filepath.Join(deployConfigDir, appsodyCRDName)
-		file, err := downloadCRDYaml(crdURL, appsodyCRD)
-		if err != nil {
-			return err
+		var file string
+		if !dryrun {
+			file, err = downloadCRDYaml(crdURL, appsodyCRD)
+			if err != nil {
+				return err
+			}
 		}
 		err = KubeApply(file)
 		if err != nil {
@@ -140,9 +143,11 @@ var installCmd = &cobra.Command{
 		}
 
 		operatorYaml := filepath.Join(deployConfigDir, operatorYamlName)
-		file, err = downloadOperatorYaml(operatorURL, operatorNamespace, watchNamespace, operatorYaml)
-		if err != nil {
-			return err
+		if !dryrun {
+			file, err = downloadOperatorYaml(operatorURL, operatorNamespace, watchNamespace, operatorYaml)
+			if err != nil {
+				return err
+			}
 		}
 		err = KubeApply(file)
 		if err != nil {

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -33,6 +33,10 @@ var operatorURL = "https://raw.githubusercontent.com/appsody/appsody-operator/ma
 
 func downloadYaml(url string, target string) (string, error) {
 	Debug.log("Downloading file: ", url)
+	if dryrun {
+		Info.log("Skipping Downloading file: ", url)
+		return "", nil
+	}
 	fileBuffer := bytes.NewBuffer(nil)
 	err := downloadFile(url, fileBuffer)
 	if err != nil {
@@ -52,6 +56,11 @@ func downloadYaml(url string, target string) (string, error) {
 }
 
 func downloadOperatorYaml(url string, operatorNamespace string, watchNamespace string, target string) (string, error) {
+	if dryrun {
+		Info.log("Skipping download of operator yaml: ", url)
+		return "", nil
+
+	}
 	file, err := downloadYaml(url, target)
 	if err != nil {
 		return "", fmt.Errorf("Could not download Operator YAML file %s", url)
@@ -122,12 +131,12 @@ var installCmd = &cobra.Command{
 
 		appsodyCRD := filepath.Join(deployConfigDir, appsodyCRDName)
 		var file string
-		if !dryrun {
-			file, err = downloadCRDYaml(crdURL, appsodyCRD)
-			if err != nil {
-				return err
-			}
+
+		file, err = downloadCRDYaml(crdURL, appsodyCRD)
+		if err != nil {
+			return err
 		}
+
 		err = KubeApply(file)
 		if err != nil {
 			return err
@@ -143,12 +152,12 @@ var installCmd = &cobra.Command{
 		}
 
 		operatorYaml := filepath.Join(deployConfigDir, operatorYamlName)
-		if !dryrun {
-			file, err = downloadOperatorYaml(operatorURL, operatorNamespace, watchNamespace, operatorYaml)
-			if err != nil {
-				return err
-			}
+
+		file, err = downloadOperatorYaml(operatorURL, operatorNamespace, watchNamespace, operatorYaml)
+		if err != nil {
+			return err
 		}
+
 		err = KubeApply(file)
 		if err != nil {
 			return err

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -935,13 +935,13 @@ func checksum256TestFile(newFileName string, oldFileName string) (bool, error) {
 	}
 	newSha256, errNew := createChecksumHash(newFileName)
 	if errNew != nil {
-		return false, nil
+		return false, errNew
 	}
 	Debug.logf("%x\n", oldSha256.Sum(nil))
 	Debug.logf("%x\n", newSha256.Sum(nil))
 	checkValue = bytes.Equal(oldSha256.Sum(nil), newSha256.Sum(nil))
 
-	Debug.log("Checksum returned", checkValue)
+	Debug.log("Checksum returned: ", checkValue)
 
 	return checkValue, nil
 }


### PR DESCRIPTION
Fixes #209 
Error when doing appsody install --dryrun

Note this PR needs to merge after 2 previous PRs, which will clean up extra files.