### PR TITLE
Move delete cmd to subcmd under deploy

### DIFF
--- a/cmd/deploy_delete.go
+++ b/cmd/deploy_delete.go
@@ -46,7 +46,7 @@ var deleteDeploymentCmd = &cobra.Command{
 }
 
 func init() {
-	rootCmd.AddCommand(deleteDeploymentCmd)
+	deployCmd.AddCommand(deleteDeploymentCmd)
 	deleteDeploymentCmd.PersistentFlags().StringVarP(&deployConfigFile, "file", "f", "app-deploy.yaml", "The file name to use for the deployment configuration.")
 
 }


### PR DESCRIPTION
As discussed with @seabaylea @neeraj-laad and @tomleah - we felt it made more sense for `appsody delete` to be `appsody deploy delete`.  Otherwise it could be confusing as to what exactly is being deleted.  With `appsody deploy delete` it's clear that it's the deployment that's being deleted.

My first contribution - all feedback very welcome - hopefully this is correct.