### PR TITLE
Added temporary help text for appsody init --overwrite

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -230,7 +230,7 @@ setup the local dev environment.`,
 
 func init() {
 	rootCmd.AddCommand(initCmd)
-	initCmd.PersistentFlags().BoolVar(&overwrite, "overwrite", false, "Download and extract the template project, overwriting existing files.")
+	initCmd.PersistentFlags().BoolVar(&overwrite, "overwrite", false, "Download and extract the template project, overwriting existing files.  This option is not intended to be used in Appsody project directories.")
 	initCmd.PersistentFlags().BoolVar(&noTemplate, "no-template", false, "Only create the .appsody-config.yaml file. Do not unzip the template project. [Deprecated]")
 }
 


### PR DESCRIPTION
Temporary stop-gap for  #215, which we will leave open
Fixes #215

If there is a .appsody-config.yaml file we will never proceed regardless of --overwrite.
We will consider lifting these restrictions in a future sprint.