### PR TITLE
Switch operator download URL to latest release and make configurable

### DIFF
--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -28,8 +28,6 @@ import (
 
 var operatorYamlName = "appsody-app-operator.yaml"
 var appsodyCRDName = "appsody-app-crd.yaml"
-var crdURL = "https://raw.githubusercontent.com/appsody/appsody-operator/master/deploy/releases/0.1.0/appsody-app-crd.yaml"
-var operatorURL = "https://raw.githubusercontent.com/appsody/appsody-operator/master/deploy/releases/0.1.0/appsody-app-operator.yaml"
 
 func downloadYaml(url string, target string) (string, error) {
 	Debug.log("Downloading file: ", url)
@@ -129,6 +127,7 @@ var installCmd = &cobra.Command{
 			return errors.Errorf("Error getting deploy config dir: %v", err)
 		}
 
+		var crdURL = getOperatorHome() + "/" + appsodyCRDName
 		appsodyCRD := filepath.Join(deployConfigDir, appsodyCRDName)
 		var file string
 
@@ -153,6 +152,7 @@ var installCmd = &cobra.Command{
 
 		operatorYaml := filepath.Join(deployConfigDir, operatorYamlName)
 
+		var operatorURL = getOperatorHome() + "/" + operatorYamlName
 		file, err = downloadOperatorYaml(operatorURL, operatorNamespace, watchNamespace, operatorYaml)
 		if err != nil {
 			return err
@@ -193,6 +193,7 @@ var uninstallCmd = &cobra.Command{
 			return errors.Errorf("Error checking file: %v", err)
 		}
 		if !crdFileExists {
+			var crdURL = getOperatorHome() + "/" + appsodyCRDName
 			_, err := downloadCRDYaml(crdURL, appsodyCRD)
 			if err != nil {
 				return err
@@ -222,6 +223,7 @@ var uninstallCmd = &cobra.Command{
 			if watchspace != "" {
 				watchNamespace = watchspace
 			}
+			var operatorURL = getOperatorHome() + "/" + operatorYamlName
 			_, err := downloadOperatorYaml(operatorURL, operatorNamespace, watchNamespace, operatorYaml)
 			if err != nil {
 				return err

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -54,6 +54,8 @@ func homeDir() (string, error) {
 	return home, nil
 }
 
+var operatorHome = "https://github.com/appsody/appsody-operator/releases/latest/download"
+
 var rootCmd = &cobra.Command{
 	Use:           "appsody",
 	SilenceErrors: true,
@@ -123,6 +125,7 @@ func initConfig() error {
 	}
 	cliConfig.SetDefault("home", filepath.Join(homeDirectory, ".appsody"))
 	cliConfig.SetDefault("images", "index.docker.io")
+	cliConfig.SetDefault("operator", operatorHome)
 	cliConfig.SetDefault("tektonserver", "")
 	if cfgFile != "" {
 		// Use config file from the flag.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -279,6 +279,13 @@ func getProjectConfig() (ProjectConfig, error) {
 	}
 	return *projectConfig, nil
 }
+
+func getOperatorHome() string {
+	operatorHome := cliConfig.GetString("operator")
+	Debug.log("Operator home set to: ", operatorHome)
+	return operatorHome
+}
+
 func getProjectName() (string, error) {
 	projectDir, err := getProjectDir()
 	if err != nil {


### PR DESCRIPTION
This changes the base URL used for the Appsody-operator to point to the latest release of the Appsody-operator repo.

It also makes it configurable via the `APPSODY_HOME/.appsody.yaml` file using a `operator: ` entry.

```
home: /Users/bailey/.appsody
images: index.docker.io
operator: https://raw.githubusercontent.com/appsody/appsody-operator/master/deploy/releases/0.1.0
```

The above example reverts to the current release URL (which are files embedded in master).