### PR TITLE
new index: switching index from v1 to v2

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -78,6 +78,7 @@ func setupConfig() error {
 	}
 
 	checkTime()
+	setNewIndexURL()
 	return nil
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1015,3 +1015,22 @@ func checkTime() {
 		}
 	}
 }
+
+func setNewIndexURL() {
+
+	var repoFile = getRepoFileLocation()
+	var oldIndexUrl = "https://raw.githubusercontent.com/appsody/stacks/master/index.yaml"
+	var newIndexUrl = "https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml"
+
+	data, err := ioutil.ReadFile(repoFile)
+	if err != nil {
+		Warning.log("Unable to read repository file")
+	}
+
+	replaceUrl := bytes.Replace(data, []byte(oldIndexUrl), []byte(newIndexUrl), -1)
+
+	if err = ioutil.WriteFile(repoFile, replaceUrl, 0666); err != nil {
+		fmt.Println(err)
+		os.Exit(1)
+	}
+}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1016,6 +1016,8 @@ func checkTime() {
 	}
 }
 
+// TEMPORARY CODE: sets the old v1 index to point to the new v2 index (latest)
+// this code should be removed when we think everyone is using the latest index.
 func setNewIndexURL() {
 
 	var repoFile = getRepoFileLocation()
@@ -1029,8 +1031,7 @@ func setNewIndexURL() {
 
 	replaceURL := bytes.Replace(data, []byte(oldIndexURL), []byte(newIndexURL), -1)
 
-	if err = ioutil.WriteFile(repoFile, replaceURL, 0666); err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+	if err = ioutil.WriteFile(repoFile, replaceURL, 0644); err != nil {
+		Warning.log(err)
 	}
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1019,17 +1019,17 @@ func checkTime() {
 func setNewIndexURL() {
 
 	var repoFile = getRepoFileLocation()
-	var oldIndexUrl = "https://raw.githubusercontent.com/appsody/stacks/master/index.yaml"
-	var newIndexUrl = "https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml"
+	var oldIndexURL = "https://raw.githubusercontent.com/appsody/stacks/master/index.yaml"
+	var newIndexURL = "https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml"
 
 	data, err := ioutil.ReadFile(repoFile)
 	if err != nil {
 		Warning.log("Unable to read repository file")
 	}
 
-	replaceUrl := bytes.Replace(data, []byte(oldIndexUrl), []byte(newIndexUrl), -1)
+	replaceURL := bytes.Replace(data, []byte(oldIndexURL), []byte(newIndexURL), -1)
 
-	if err = ioutil.WriteFile(repoFile, replaceUrl, 0666); err != nil {
+	if err = ioutil.WriteFile(repoFile, replaceURL, 0666); err != nil {
 		fmt.Println(err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Reads the users local appsody `repository.yaml` and switches the v1 index to use the v2 index.

fixes: https://github.com/appsody/appsody/issues/250