### PR TITLE
buildah: revert to the bind mount model for copying

### DIFF
--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -188,7 +188,7 @@ in preparation to build the final container image.`,
 		if buildah {
 			appDir = containerProjectDir
 			cmdName = "/bin/sh"
-			script := fmt.Sprintf("buildah run -v %s:/ex %s bash -c 'cp -rf %s/* /ex; exit'", extractDir, extractContainerName, appDir)
+			script := fmt.Sprintf("x=`buildah mount %s`; cp -rf $x/%s/* %s", extractContainerName, appDir, extractDir)
 			cmdArgs = []string{"-c", script}
 		}
 		err = execAndWaitReturnErr(cmdName, cmdArgs, Debug)


### PR DESCRIPTION
When stacks whose Dockerfile defines less privileged users as the owner of the container, extraction fails in CRI-O deployments with:

```
[Debug] cp: cannot create regular file '/ex/Dockerfile': Permission denied
...
```
this is because the mount point /ex is owned by privileged user who started the parent container, and the less privileged user does not have write permission into it.

`chmod -R 666 /ex` or its ancestor folder prior to the mount does not seem to work it around.

So we go by the old bind mount route where:
 - don't run the child container, just get its mount point,
 - copy the project folder from the mount to the extract folder.