### PR TITLE
buildah: use bind mount and localy copy

### DIFF
--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -17,7 +17,7 @@ package cmd
 import (
 	"fmt"
 	"os"
-	s "strings"
+	"strings"
 
 	"path/filepath"
 	"runtime"
@@ -217,17 +217,17 @@ in preparation to build the final container image.`,
 		// ref: https://github.com/containers/buildah/issues/1821
 		if buildah {
 			for _, item := range volumeMaps {
-				if s.Contains(item, ":") {
+				if strings.Contains(item, ":") {
 					Debug.log("Appsody mount: ", item)
-					var src = s.Split(item, ":")[0]
-					var dest = s.Split(item, ":")[1]
-					if s.EqualFold(src, ".") {
+					var src = strings.Split(item, ":")[0]
+					var dest = strings.Split(item, ":")[1]
+					if strings.EqualFold(src, ".") {
 						src, err = os.Getwd()
 						if err != nil {
 							return errors.Errorf("Error getting cwd: %v", err)
 						}
 					}
-					dest = s.Replace(dest, appDir, extractDir, -1)
+					dest = strings.Replace(dest, appDir, extractDir, -1)
 					Debug.log("Local-adjusted mount destination: ", dest)
 					fileInfo, err := os.Lstat(src)
 					if err != nil {


### PR DESCRIPTION
1. 

When stacks whose Dockerfile defines less privileged users
as the owner of the container, extraction fails in CRI-O
deployments because the mount point is owned by privileged
user who started the parent container, and the less privileged
user does not have write permission into it.
    
So we go by the old bind mount route where:
  - don't run the child container, just get its mount point,
  - copy the project folder from the mount to the extract folder.

2. 

A class of systems (e.g:- RHEL 7.6) exhibit situations wherein
the bindmount volumes are not propagated to the child containers
Accommodate those systems as well, by performing local copies
for the locations that are resident in the host.
ref: https://github.com/containers/buildah/issues/1821
