### PR TITLE
added --no-watcher flag to disable file watching regardless of Stack Environment variable settings.

### DIFF
--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -33,6 +33,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var disableWatcher bool
 var containerName string
 var depsVolumeName string
 var ports []string
@@ -86,6 +87,7 @@ func buildCommonFlags() {
 		commonFlags.StringArrayVarP(&ports, "publish", "p", nil, "Publish the container's ports to the host. The stack's exposed ports will always be published, but you can publish addition ports or override the host ports with this option.")
 		commonFlags.BoolVarP(&publishAllPorts, "publish-all", "P", false, "Publish all exposed ports to random ports")
 		commonFlags.StringVar(&dockerOptions, "docker-options", "", "Specify the docker options to use.  Value must be in \"\".")
+		commonFlags.BoolVar(&disableWatcher, "no-watcher", false, "Disable file watching, regardless of container environment variable settings.")
 	}
 
 }
@@ -272,6 +274,9 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 	cmdArgs = append(cmdArgs, "-t", "--entrypoint", "/appsody/appsody-controller", platformDefinition, "--mode="+mode)
 	if verbose {
 		cmdArgs = append(cmdArgs, "-v")
+	}
+	if disableWatcher {
+		cmdArgs = append(cmdArgs, "--no-watcher")
 	}
 	Debug.logf("Attempting to start image %s with container name %s", platformDefinition, containerName)
 	execCmd, err := DockerRunAndListen(cmdArgs, Container)


### PR DESCRIPTION
This PR adds a --no-watcher flag to disable file watching by the controller regardless of the Docker Environment variables in the stack.

In order for this PR to function correctly, a new release of the controller will be needed.
That function is part of Issue https://github.com/appsody/controller/issues/21 of the appsody controller component and its corresponding pull request.