### PR TITLE
cmd: removed [] from argument list

### DIFF
--- a/cmd/docker_commands.go
+++ b/cmd/docker_commands.go
@@ -3,6 +3,7 @@ package cmd
 import (
 	"bufio"
 	"os/exec"
+	"strings"
 )
 
 func DockerRunAndListen(args []string, logger appsodylogger) (*exec.Cmd, error) {
@@ -37,9 +38,9 @@ func RunDockerCommandAndListen(args []string, logger appsodylogger) (*exec.Cmd, 
 	var command = "docker"
 	var err error
 	if dryrun {
-		Info.log("Dry Run - Skipping docker command: ", command, args)
+		Info.log("Dry Run - Skipping docker command: ", command, " ", strings.Join(args, " "))
 	} else {
-		Info.log("Running docker command: ", command, args)
+		Info.log("Running docker command: ", command, " ", strings.Join(args, " "))
 		execCmd = exec.Command(command, args...)
 
 		cmdReader, err := execCmd.StdoutPipe()

--- a/cmd/operator_utils.go
+++ b/cmd/operator_utils.go
@@ -41,10 +41,10 @@ func RunKubeDelete(args []string) (string, error) {
 func RunKube(kargs []string) (string, error) {
 	kcmd := "kubectl"
 	if dryrun {
-		Info.log("Dry run - skipping execution of: ", kcmd, " ", kargs)
+		Info.log("Dry run - skipping execution of: ", kcmd, " ", strings.Join(kargs, " "))
 		return "", nil
 	}
-	Info.log("Running command: ", kcmd, kargs)
+	Info.log("Running command: ", kcmd, " ", strings.Join(kargs, " "))
 	execCmd := exec.Command(kcmd, kargs...)
 	kout, kerr := execCmd.Output()
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -181,14 +181,7 @@ var (
 
 func (l appsodylogger) log(args ...interface{}) {
 	msgString := fmt.Sprint(args...)
-
-	if strings.Contains(msgString, "Running command:") || strings.Contains(msgString, "docker command:") {
-		r := strings.NewReplacer("[", " ", "]", " ")
-		resultString := r.Replace(msgString)
-		l.internalLog(resultString, args...)
-	} else {
-		l.internalLog(msgString, args...)
-	}
+	l.internalLog(msgString, args...)
 }
 
 func (l appsodylogger) logf(fmtString string, args ...interface{}) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -181,7 +181,14 @@ var (
 
 func (l appsodylogger) log(args ...interface{}) {
 	msgString := fmt.Sprint(args...)
-	l.internalLog(msgString, args...)
+
+	if strings.Contains(msgString, "Running command:") || strings.Contains(msgString, "docker command:") {
+		r := strings.NewReplacer("[", " ", "]", " ")
+		resultString := r.Replace(msgString)
+		l.internalLog(resultString, args...)
+	} else {
+		l.internalLog(msgString, args...)
+	}
 }
 
 func (l appsodylogger) logf(fmtString string, args ...interface{}) {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -602,7 +602,7 @@ func DockerTag(imageToTag string, tag string) error {
 	cmdName := "docker"
 	cmdArgs := []string{"image", "tag", imageToTag, tag}
 	if dryrun {
-		Info.log("Dry run - skipping execution of: ", cmdName, " ", cmdArgs)
+		Info.log("Dry run - skipping execution of: ", cmdName, " ", strings.Join(cmdArgs, " "))
 		return nil
 	}
 	tagCmd := exec.Command(cmdName, cmdArgs...)
@@ -621,7 +621,7 @@ func DockerPush(imageToPush string) error {
 	cmdName := "docker"
 	cmdArgs := []string{"push", imageToPush}
 	if dryrun {
-		Info.log("Dry run - skipping execution of: ", cmdName, " ", cmdArgs)
+		Info.log("Dry run - skipping execution of: ", cmdName, " ", strings.Join(cmdArgs, " "))
 		return nil
 	}
 	pushCmd := exec.Command(cmdName, cmdArgs...)
@@ -648,7 +648,7 @@ func DockerRunBashCmd(options []string, image string, bashCmd string) (cmdOutput
 		cmdArgs = []string{"run"}
 	}
 	cmdArgs = append(cmdArgs, "--entrypoint", "/bin/bash", image, "-c", bashCmd)
-	Info.log("Running command: ", cmdName, cmdArgs)
+	Info.log("Running command: ", cmdName, " ", strings.Join(cmdArgs, " "))
 	dockerCmd := exec.Command(cmdName, cmdArgs...)
 	dockerOutBytes, err := dockerCmd.Output()
 	if err != nil {
@@ -670,10 +670,10 @@ func KubeGet(args []string) (string, error) {
 	}
 
 	if dryrun {
-		Info.log("Dry run - skipping execution of: ", kcmd, " ", kargs)
+		Info.log("Dry run - skipping execution of: ", kcmd, " ", strings.Join(kargs, " "))
 		return "", nil
 	}
-	Info.log("Running command: ", kcmd, kargs)
+	Info.log("Running command: ", kcmd, " ", strings.Join(kargs, " "))
 	execCmd := exec.Command(kcmd, kargs...)
 	kout, kerr := execCmd.Output()
 	if kerr != nil {
@@ -692,10 +692,10 @@ func KubeApply(fileToApply string) error {
 	}
 
 	if dryrun {
-		Info.log("Dry run - skipping execution of: ", kcmd, " ", kargs)
+		Info.log("Dry run - skipping execution of: ", kcmd, " ", strings.Join(kargs, " "))
 		return nil
 	}
-	Info.log("Running command: ", kcmd, kargs)
+	Info.log("Running command: ", kcmd, " ", strings.Join(kargs, " "))
 	execCmd := exec.Command(kcmd, kargs...)
 	kout, kerr := execCmd.Output()
 	if kerr != nil {
@@ -716,10 +716,10 @@ func KubeDelete(fileToApply string) error {
 	}
 
 	if dryrun {
-		Info.log("Dry run - skipping execution of: ", kcmd, " ", kargs)
+		Info.log("Dry run - skipping execution of: ", kcmd, " ", strings.Join(kargs, " "))
 		return nil
 	}
-	Info.log("Running command: ", kcmd, kargs)
+	Info.log("Running command: ", kcmd, " ", strings.Join(kargs, " "))
 	execCmd := exec.Command(kcmd, kargs...)
 	var stderr bytes.Buffer
 	execCmd.Stderr = &stderr
@@ -768,10 +768,10 @@ func KubeGetKnativeURL(service string) (url string, err error) {
 	}
 
 	if dryrun {
-		Info.log("Dry run - skipping execution of: ", kcmd, " ", kargs)
+		Info.log("Dry run - skipping execution of: ", kcmd, " ", strings.Join(kargs, " "))
 		return "", nil
 	}
-	Info.log("Running command: ", kcmd, kargs)
+	Info.log("Running command: ", kcmd, " ", strings.Join(kargs, " "))
 	execCmd := exec.Command(kcmd, kargs...)
 	kout, kerr := execCmd.Output()
 	if kerr != nil {
@@ -808,7 +808,7 @@ func pullCmd(imageToPull string) error {
 	}
 	pullArgs := []string{"pull", imageToPull}
 	if dryrun {
-		Info.log("Dry run - skipping execution of: ", cmdName, " ", pullArgs)
+		Info.log("Dry run - skipping execution of: ", cmdName, " ", " ", strings.Join(pullArgs, " "))
 		return nil
 	}
 	Debug.log("Pulling docker image ", imageToPull)
@@ -885,9 +885,9 @@ func execAndListenWithWorkDirReturnErr(command string, args []string, logger app
 	var execCmd *exec.Cmd
 	var err error
 	if dryrun {
-		Info.log("Dry Run - Skipping command: ", command, args)
+		Info.log("Dry Run - Skipping command: ", command, " ", strings.Join(args, " "))
 	} else {
-		Info.log("Running command: ", command, args)
+		Info.log("Running command: ", command, " ", strings.Join(args, " "))
 		execCmd = exec.Command(command, args...)
 		if workdir != "" {
 			execCmd.Dir = workdir
@@ -936,7 +936,7 @@ func execAndWaitWithWorkDirReturnErr(command string, args []string, logger appso
 	var err error
 	var execCmd *exec.Cmd
 	if dryrun {
-		Info.log("Dry Run - Skipping command: ", command, args)
+		Info.log("Dry Run - Skipping command: ", command, " ", strings.Join(args, " "))
 	} else {
 		execCmd, err = execAndListenWithWorkDirReturnErr(command, args, logger, workdir)
 		if err != nil {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -808,7 +808,7 @@ func pullCmd(imageToPull string) error {
 	}
 	pullArgs := []string{"pull", imageToPull}
 	if dryrun {
-		Info.log("Dry run - skipping execution of: ", cmdName, " ", " ", strings.Join(pullArgs, " "))
+		Info.log("Dry run - skipping execution of: ", cmdName, " ", strings.Join(pullArgs, " "))
 		return nil
 	}
 	Debug.log("Pulling docker image ", imageToPull)

--- a/functest/ports_test.go
+++ b/functest/ports_test.go
@@ -42,7 +42,7 @@ func TestPortMap(t *testing.T) {
 		t.Fatal(err)
 	}
 	runOutput, _ = cmdtest.RunAppsodyCmdExec([]string{"run", "--dryrun", "--publish", "3100:3000", "--publish", "4100:4000", "--publish", "9230:9229"}, projectDir)
-	if !strings.Contains(runOutput, "docker[run --rm -p 3100:3000 -p 4100:4000 -p 9230:9229") {
+	if !strings.Contains(runOutput, "docker run --rm -p 3100:3000 -p 4100:4000 -p 9230:9229") {
 
 		t.Fatal("Ports are not correctly specified as: -p 3100:3000 -p 4100:4000 -p 9230:9229")
 
@@ -70,8 +70,8 @@ func TestPublishAll(t *testing.T) {
 	}
 	runOutput, _ = cmdtest.RunAppsodyCmdExec([]string{"run", "--publish-all", "--dryrun"}, projectDir)
 
-	if !strings.Contains(runOutput, "docker[run --rm -P") {
-		t.Fatal("publish all is not found in output as: docker[run --rm -P")
+	if !strings.Contains(runOutput, "docker run --rm -P") {
+		t.Fatal("publish all is not found in output as: docker run --rm -P")
 
 	}
 

--- a/functest/stop_test.go
+++ b/functest/stop_test.go
@@ -60,8 +60,8 @@ func TestStopWithoutName(t *testing.T) {
 		fmt.Println("calling docker stop")
 		stopOutput, errStop := cmdtest.RunAppsodyCmdExec([]string{"stop"}, projectDir)
 
-		//docker[stop appsody-stop-test
-		if !strings.Contains(stopOutput, "docker[stop appsody-stop-test") {
+		//docker stop appsody-stop-test
+		if !strings.Contains(stopOutput, "docker stop appsody-stop-test") {
 			t.Fatal("docker stop command not present for appsody-stop-test...")
 		}
 		if errStop != nil {
@@ -145,7 +145,7 @@ func TestStopWithName(t *testing.T) {
 	defer func() {
 		fmt.Println("about to run stop for with name")
 		stopOutput, errStop := cmdtest.RunAppsodyCmdExec([]string{"stop", "--name", "testStopContainer"}, projectDir)
-		if !strings.Contains(stopOutput, "docker[stop testStopContainer") {
+		if !strings.Contains(stopOutput, "docker stop testStopContainer") {
 			t.Fatal("docker stop command not present for container testStopContainer")
 		}
 		if errStop != nil {


### PR DESCRIPTION
Removed the "[" and "]" surrounding the args in the CLI output only in cases where output contains "docker command:" or "Running command:"

Fixes: #268 