### PR TITLE
linter: added linting for stack.yaml

### DIFF
--- a/cmd/stack_lint.go
+++ b/cmd/stack_lint.go
@@ -24,6 +24,9 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var errorCount int
+var warningCount int
+
 var lintCmd = &cobra.Command{
 	Use:   "lint",
 	Short: "Lint your stack to verify that it conforms to the standard of an Appsody stack",
@@ -34,8 +37,6 @@ This command can be run from the base directory of your stack or you can supply 
 	RunE: func(cmd *cobra.Command, args []string) error {
 
 		stackPath, _ := os.Getwd()
-		errorCount := 0
-		warningCount := 0
 
 		if len(args) > 0 {
 			stackPath = args[0]
@@ -144,6 +145,9 @@ This command can be run from the base directory of your stack or you can supply 
 				errorCount++
 			}
 		}
+
+		var s StackDetails
+		s.validateYaml()
 
 		Info.log("TOTAL ERRORS: ", errorCount)
 		Info.log("TOTAL WARNINGS: ", warningCount)

--- a/cmd/stack_lint.go
+++ b/cmd/stack_lint.go
@@ -24,8 +24,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var errorCount int
-var warningCount int
+var stackLintErrorCount int
+var stackLintWarningCount int
 
 var lintCmd = &cobra.Command{
 	Use:   "lint",
@@ -52,86 +52,86 @@ This command can be run from the base directory of your stack or you can supply 
 		fileCheck, err := exists(filepath.Join(stackPath, "/README.md"))
 		if err != nil {
 			Error.log("Error attempting to determine file: ", err)
-			errorCount++
+			stackLintErrorCount++
 		} else if !fileCheck {
 			Error.log("Missing README.md in: ", stackPath)
-			errorCount++
+			stackLintErrorCount++
 		}
 		fileCheck, err = exists(filepath.Join(stackPath, "/stack.yaml"))
 		if err != nil {
 			Error.log("Error attempting to determine file: ", err)
-			errorCount++
+			stackLintErrorCount++
 		} else if !fileCheck {
 			Error.log("Missing stack.yaml in: ", stackPath)
-			errorCount++
+			stackLintErrorCount++
 		}
 
 		fileCheck, err = exists(imagePath)
 		if err != nil {
 			Error.log("Error attempting to determine file: ", err)
-			errorCount++
+			stackLintErrorCount++
 		} else if !fileCheck {
 			Error.log("Missing image directory in ", stackPath)
-			errorCount++
+			stackLintErrorCount++
 		}
 
 		fileCheck, err = exists(filepath.Join(imagePath, "/Dockerfile-stack"))
 		if err != nil {
 			Error.log("Error attempting to determine file: ", err)
-			errorCount++
+			stackLintErrorCount++
 		} else if !fileCheck {
 			Error.log("Missing Dockerfile-stack in ", imagePath)
-			errorCount++
+			stackLintErrorCount++
 		}
 
 		fileCheck, err = exists(filepath.Join(imagePath, "/LICENSE"))
 		if err != nil {
 			Error.log("Error attempting to determine file: ", err)
-			errorCount++
+			stackLintErrorCount++
 		} else if !fileCheck {
 			Error.log("Missing LICENSE in ", imagePath)
-			errorCount++
+			stackLintErrorCount++
 		}
 
 		fileCheck, err = exists(configPath)
 		if err != nil {
 			Error.log("Error attempting to determine file: ", err)
-			errorCount++
+			stackLintErrorCount++
 		} else if !fileCheck {
 			Warning.log("Missing config directory in ", imagePath, " (Knative deployment will be used over Kubernetes)")
-			warningCount++
+			stackLintWarningCount++
 		}
 
 		fileCheck, err = exists(filepath.Join(configPath, "/app-deploy.yaml"))
 		if err != nil {
 			Error.log("Error attempting to determine file: ", err)
-			errorCount++
+			stackLintErrorCount++
 		} else if !fileCheck {
 			Warning.log("Missing app-deploy.yaml in ", configPath, " (Knative deployment will be used over Kubernetes)")
-			warningCount++
+			stackLintWarningCount++
 		}
 
 		fileCheck, err = exists(filepath.Join(projectPath, "/Dockerfile"))
 		if err != nil {
 			Error.log("Error attempting to determine file: ", err)
-			errorCount++
+			stackLintErrorCount++
 		} else if !fileCheck {
 			Warning.log("Missing Dockerfile in ", projectPath)
-			warningCount++
+			stackLintWarningCount++
 		}
 
 		fileCheck, err = exists(templatePath)
 		if err != nil {
 			Error.log("Error attempting to determine file: ", err)
-			errorCount++
+			stackLintErrorCount++
 		} else if !fileCheck {
 			Error.log("Missing template directory in: ", stackPath)
-			errorCount++
+			stackLintErrorCount++
 		}
 
 		if IsEmptyDir(templatePath) {
 			Error.log("No templates found in: ", templatePath)
-			errorCount++
+			stackLintErrorCount++
 		}
 
 		templates, _ := ioutil.ReadDir(templatePath)
@@ -139,20 +139,20 @@ This command can be run from the base directory of your stack or you can supply 
 			fileCheck, err = exists(filepath.Join(templatePath, f.Name(), ".appsody-config.yaml"))
 			if (err != nil) && f.Name() != ".DS_Store" {
 				Error.log("Error attempting to determine file: ", err)
-				errorCount++
+				stackLintErrorCount++
 			} else if fileCheck && f.Name() != ".DS_Store" {
 				Error.log("Unexpected .appsody-config.yaml in ", filepath.Join(templatePath, f.Name()))
-				errorCount++
+				stackLintErrorCount++
 			}
 		}
 
 		var s StackDetails
 		s.validateYaml()
 
-		Info.log("TOTAL ERRORS: ", errorCount)
-		Info.log("TOTAL WARNINGS: ", warningCount)
+		Info.log("TOTAL ERRORS: ", stackLintErrorCount)
+		Info.log("TOTAL WARNINGS: ", stackLintWarningCount)
 
-		if errorCount > 0 {
+		if stackLintErrorCount > 0 {
 			return errors.Errorf("LINT TEST FAILED")
 		}
 

--- a/cmd/stack_lint.go
+++ b/cmd/stack_lint.go
@@ -147,7 +147,7 @@ This command can be run from the base directory of your stack or you can supply 
 		}
 
 		var s StackDetails
-		s.validateYaml()
+		s.validateYaml(stackPath)
 
 		Info.log("TOTAL ERRORS: ", stackLintErrorCount)
 		Info.log("TOTAL WARNINGS: ", stackLintWarningCount)

--- a/cmd/stack_yaml_lint.go
+++ b/cmd/stack_yaml_lint.go
@@ -26,16 +26,16 @@ import (
 )
 
 type StackDetails struct {
-	Name        string            `yaml: "name"`
-	Version     string            `yaml: "version"`
-	Description string            `yaml: "description"`
-	License     string            `yaml: "license"`
-	Language    string            `yaml: "language"`
-	Maintainers []StackMaintainer `yaml: "maintainers"`
+	Name        string            `yaml:"name"`
+	Version     string            `yaml:"version"`
+	Description string            `yaml:"description"`
+	License     string            `yaml:"license"`
+	Language    string            `yaml:"language"`
+	Maintainers []StackMaintainer `yaml:"maintainers"`
 }
 
 type StackMaintainer struct {
-	Email string `yaml: "email"`
+	Email string `yaml:"email"`
 }
 
 var DefaultFound bool

--- a/cmd/stack_yaml_lint.go
+++ b/cmd/stack_yaml_lint.go
@@ -1,0 +1,149 @@
+// Copyright © 2019 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd
+
+import (
+	"bufio"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"reflect"
+	"strings"
+
+	"gopkg.in/yaml.v2"
+)
+
+type StackDetails struct {
+	Name        string            `yaml: "name"`
+	Version     string            `yaml: "version"`
+	Description string            `yaml: "description"`
+	License     string            `yaml: "license"`
+	Language    string            `yaml: "language"`
+	Maintainers []StackMaintainer `yaml: "maintainers"`
+}
+
+type StackMaintainer struct {
+	Email string `yaml: "email"`
+}
+
+var DefaultFound bool
+
+func (s *StackDetails) validateYaml() *StackDetails {
+	stackPath, _ := os.Getwd()
+
+	if len(os.Args) > 3 {
+		stackPath = os.Args[3]
+	}
+
+	arg := filepath.Join(stackPath, "/stack.yaml")
+
+	stackyaml, err := ioutil.ReadFile(arg)
+	if err != nil {
+		Error.log("stackyaml.Get err ", err)
+		errorCount++
+	}
+
+	err = yaml.Unmarshal([]byte(stackyaml), s)
+	if err != nil {
+		Error.log("Unmarshal: ", err)
+		errorCount++
+	}
+
+	s.validateFields(arg)
+	return s
+}
+
+func (s *StackDetails) validateFields(arg string) *StackDetails {
+	v := reflect.ValueOf(s).Elem()
+	yamlValues := make([]interface{}, v.NumField())
+
+	for i := 0; i < v.NumField(); i++ {
+		yamlValues[i] = v.Field(i).Interface()
+		if yamlValues[i] == "" {
+			Error.log("Missing value for field: ", strings.ToLower(v.Type().Field(i).Name), " in ", arg)
+			errorCount++
+		}
+	}
+
+	s.checkMaintainer(arg, yamlValues)
+
+	return s
+
+}
+
+func (s *StackDetails) checkMaintainer(arg string, yamlValues []interface{}) *StackDetails {
+	Map := make(map[string]interface{})
+	Map["maintainerEmails"] = yamlValues[5]
+
+	maintainerEmails := Map["maintainerEmails"].([]StackMaintainer)
+
+	if len(maintainerEmails) == 0 {
+		Error.log("Email is not provided under field: maintainers in ", arg)
+	}
+
+	s.checkVersion(arg)
+	return s
+}
+
+func (s *StackDetails) checkVersion(arg string) *StackDetails {
+	versionNo := strings.Split(s.Version, ".")
+
+	if len(versionNo) < 3 {
+		Error.log("Version is not formatted as major.minor.patch in ", arg)
+		errorCount++
+	}
+
+	s.checkDescLenth(arg)
+	return s
+}
+
+func (s *StackDetails) checkDescLenth(arg string) *StackDetails {
+
+	if len(s.Description) > 70 {
+		Error.log("Description should be under 70 characters in ", arg)
+		errorCount++
+	}
+
+	s.checkDefaultTemplate(arg)
+	return s
+}
+
+func (s *StackDetails) checkDefaultTemplate(arg string) *StackDetails {
+	DefaultFound = false
+	file, err := os.Open(arg)
+	if err != nil {
+		Error.log(err)
+	}
+	defer file.Close()
+
+	scanner := bufio.NewScanner(file)
+	for scanner.Scan() {
+		yamlFields := strings.Split(scanner.Text(), ":")
+		if yamlFields[0] == "default-template" {
+			DefaultFound = true
+		}
+	}
+
+	if err := scanner.Err(); err != nil {
+		Error.log(err)
+	}
+
+	if !DefaultFound {
+		Error.log("Missing value for field: default-template in ", arg)
+		errorCount++
+	}
+
+	return s
+}

--- a/cmd/stack_yaml_lint.go
+++ b/cmd/stack_yaml_lint.go
@@ -39,7 +39,7 @@ type StackMaintainer struct {
 	Email string `yaml:"email"`
 }
 
-var DefaultFound bool
+var defaultTemplateFound bool
 
 func (s *StackDetails) validateYaml() *StackDetails {
 	stackPath, _ := os.Getwd()
@@ -113,14 +113,19 @@ func (s *StackDetails) checkVersion(arg string) *StackDetails {
 		stackLintErrorCount++
 	}
 
-	s.checkDescLenth(arg)
+	s.checkDescLength(arg)
 	return s
 }
 
-func (s *StackDetails) checkDescLenth(arg string) *StackDetails {
+func (s *StackDetails) checkDescLength(arg string) *StackDetails {
 
 	if len(s.Description) > 70 {
 		Error.log("Description should be under 70 characters in ", arg)
+		stackLintErrorCount++
+	}
+
+	if len(s.Name) > 30 {
+		Error.log("Stack name should be under 30 characters in ", arg)
 		stackLintErrorCount++
 	}
 
@@ -129,7 +134,7 @@ func (s *StackDetails) checkDescLenth(arg string) *StackDetails {
 }
 
 func (s *StackDetails) checkDefaultTemplate(arg string) *StackDetails {
-	DefaultFound = false
+	defaultTemplateFound = false
 	file, err := os.Open(arg)
 	if err != nil {
 		Error.log(err)
@@ -140,7 +145,7 @@ func (s *StackDetails) checkDefaultTemplate(arg string) *StackDetails {
 	for scanner.Scan() {
 		yamlFields := strings.Split(scanner.Text(), ":")
 		if yamlFields[0] == "default-template" {
-			DefaultFound = true
+			defaultTemplateFound = true
 		}
 	}
 
@@ -148,7 +153,7 @@ func (s *StackDetails) checkDefaultTemplate(arg string) *StackDetails {
 		Error.log(err)
 	}
 
-	if !DefaultFound {
+	if !defaultTemplateFound {
 		Error.log("Missing value for field: default-template in ", arg)
 		stackLintErrorCount++
 	}


### PR DESCRIPTION
An extension to the directory linter that now validates the users `stack.yaml`

Validates:
- All fields are present
- Version is formatted as major.minor.patch
- Description length is limited to 70 characters
- Maintainer email has been provided as a point of contact

Fixes: https://github.com/appsody/appsody/issues/271