### PR TITLE
Handle --knative option for current stacks as well as stacks that do not contain app-deploy.yaml

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -127,6 +127,12 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 				foundCreateKnativeTag = true
 				localFoundCreateKnativeTag = true
 			}
+			if strings.Contains(line, "createKnativeService") && strings.Contains(line, "false") && knative {
+				//if knative we want to replace false with true in
+				line = strings.Replace(line, "false", "true", 1)
+				foundCreateKnativeTag = true
+				localFoundCreateKnativeTag = true
+			}
 			if strings.Contains(line, "kind:") && strings.Contains(line, "Service") {
 				isKnativeService = true
 			}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -31,7 +31,7 @@ import (
 )
 
 var configFile, namespace, watchspace, tag string
-var generate, force, push bool
+var knative, generate, force, push bool
 
 var deployCmd = &cobra.Command{
 	Use:   "deploy",
@@ -78,21 +78,26 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 			}
 		}
 		Info.log("Found existing deployment manifest ", configFile)
+		//Retrieve the project name and lowercase it
+		projectName, perr := getProjectName()
+		if perr != nil {
+			return errors.Errorf("%v", perr)
+		}
 
+		if tag == "" {
+			buildCmd.PersistentFlags().Set("tag", "dev.local/"+projectName)
+		}
 		// Extract code and build the image - and tags it if -t is specified
 		buildErr := buildCmd.RunE(cmd, args)
 		if buildErr != nil {
 			return buildErr
 		}
 
-		//Retrieve the project name and lowercase it
-		projectName, perr := getProjectName()
-		if perr != nil {
-			return errors.Errorf("%v", perr)
-		}
 		deployImage := projectName // if not tagged, this is the deploy image name
 		if tag != "" {
 			deployImage = tag //Otherwise, it's the tag
+		} else {
+			deployImage = "dev.local/" + projectName
 		}
 		// Edit the deployment manifest to reflect the new tag
 		yamlFile, err := os.Open(configFile)
@@ -103,10 +108,13 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 			return errors.Errorf("Failed reading file %s", configFile)
 		}
 		defer yamlFile.Close()
+		var foundCreateKnativeTag, isKnativeService bool
+
 		scanner := bufio.NewScanner(yamlFile)
 		scanner.Split(bufio.ScanLines)
 		var txtlines []string
 		for scanner.Scan() {
+			var localFoundCreateKnativeTag bool
 			line := scanner.Text()
 			if strings.Contains(line, "applicationImage:") {
 				index := strings.Index(line, ": ")
@@ -114,15 +122,31 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 				line = start + deployImage
 				Info.log("Using applicationImage of: ", deployImage)
 			}
-			txtlines = append(txtlines, line)
+			if strings.Contains(line, "createKnativeService") && strings.Contains(line, "createKnativeService") {
+				foundCreateKnativeTag = true
+				localFoundCreateKnativeTag = true
+			}
+			if strings.Contains(line, "kind:") && strings.Contains(line, "Service") {
+				isKnativeService = true
+			}
+			if !(localFoundCreateKnativeTag && !knative) {
+				txtlines = append(txtlines, line)
+			}
+
 		}
-		tempConfigFile := "temp-" + configFile
-		file, err := os.Create(tempConfigFile)
+		if !foundCreateKnativeTag && knative && !isKnativeService {
+			txtlines = append(txtlines, "  createKnativeService: true")
+		}
+
+		//yamlFile.Close() // need to think about defer
+
+		targetConfigFile := configFile
+		file, err := os.Create(targetConfigFile)
 		if err != nil {
 			return err
 		}
 
-		defer closeAndRemoveFile(file, tempConfigFile)
+		defer file.Close()
 		w := bufio.NewWriter(file)
 		for _, line := range txtlines {
 			fmt.Fprintln(w, line)
@@ -135,7 +159,7 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 				return errors.Errorf("Could not push the docker image - exiting. Error: %v", err)
 			}
 		}
-		err = KubeApply(tempConfigFile)
+		err = KubeApply(configFile)
 		// Performing the kubectl apply
 		if err != nil {
 			return errors.Errorf("Failed to deploy to your Kubernetes cluster: %v", err)
@@ -160,14 +184,6 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 	},
 }
 
-func closeAndRemoveFile(file *os.File, fileName string) {
-	file.Close()
-	Debug.log("Removing file: ", fileName)
-	err := os.Remove(fileName)
-	if err != nil {
-		Warning.logf("Failed to remove %s.", fileName)
-	}
-}
 func deployWithKnative(cmd *cobra.Command, args []string) error {
 	buildErr := buildCmd.RunE(cmd, args)
 	if buildErr != nil {
@@ -328,7 +344,6 @@ func generateDeploymentConfig() error {
 	if removeErr != nil {
 		Error.log("containerRemove error ", removeErr)
 	}
-
 	yamlReader, err := ioutil.ReadFile(configFile)
 	if !dryrun && err != nil {
 		if os.IsNotExist(err) {
@@ -397,5 +412,5 @@ func init() {
 	deployCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "", "Target namespace in your Kubernetes cluster")
 	deployCmd.PersistentFlags().StringVarP(&tag, "tag", "t", "", "Docker image name and optionally a tag in the 'name:tag' format")
 	deployCmd.PersistentFlags().BoolVar(&push, "push", false, "Push this image to an external Docker registry. Assumes that you have previously successfully done docker login")
-
+	deployCmd.PersistentFlags().BoolVar(&knative, "knative", false, "Deploy as a Knative Service")
 }

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -84,8 +84,15 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 			return errors.Errorf("%v", perr)
 		}
 
+		var deployImage string
 		if tag == "" {
-			_ = buildCmd.PersistentFlags().Set("tag", "dev.local/"+projectName)
+			deployImage = "dev.local/" + projectName
+			// send the modified tag to the buildCmd if no tag is given
+			// you can't add the tag to the args
+			// if the tag was on the deployCmd, then build will receive that.
+			_ = buildCmd.PersistentFlags().Set("tag", deployImage)
+		} else {
+			deployImage = tag //Otherwise, it's the tag
 		}
 		// Extract code and build the image - and tags it if -t is specified
 		buildErr := buildCmd.RunE(cmd, args)
@@ -93,13 +100,6 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 			return buildErr
 		}
 
-		var deployImage string
-		//	:= projectName // if not tagged, this is the deploy image name
-		if tag != "" {
-			deployImage = tag //Otherwise, it's the tag
-		} else {
-			deployImage = "dev.local/" + projectName
-		}
 		// Edit the deployment manifest to reflect the new tag
 		yamlFile, err := os.Open(configFile)
 		if !dryrun && err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -115,7 +115,7 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 		scanner.Split(bufio.ScanLines)
 		var txtlines []string
 		for scanner.Scan() {
-			var localFoundCreateKnativeTag bool
+
 			line := scanner.Text()
 			if strings.Contains(line, "applicationImage:") {
 				index := strings.Index(line, ": ")
@@ -123,22 +123,22 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 				line = start + deployImage
 				Info.log("Using applicationImage of: ", deployImage)
 			}
-			if strings.Contains(line, "createKnativeService") && strings.Contains(line, "true") {
+			if strings.Contains(line, "createKnativeService") {
 				foundCreateKnativeTag = true
-				localFoundCreateKnativeTag = true
+				if strings.Contains(line, "true") && !knative {
+					line = strings.Replace(line, "true", "false", 1)
+				}
+				if strings.Contains(line, "false") && knative {
+					line = strings.Replace(line, "false", "true", 1)
+				}
+
 			}
-			if strings.Contains(line, "createKnativeService") && strings.Contains(line, "false") && knative {
-				//if knative we want to replace false with true in
-				line = strings.Replace(line, "false", "true", 1)
-				foundCreateKnativeTag = true
-				localFoundCreateKnativeTag = true
-			}
+
 			if strings.Contains(line, "kind:") && strings.Contains(line, "Service") {
 				isKnativeService = true
 			}
-			if !(localFoundCreateKnativeTag && !knative) {
-				txtlines = append(txtlines, line)
-			}
+
+			txtlines = append(txtlines, line)
 
 		}
 		if !foundCreateKnativeTag && knative && !isKnativeService {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -85,7 +85,7 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 		}
 
 		if tag == "" {
-			buildCmd.PersistentFlags().Set("tag", "dev.local/"+projectName)
+			_ = buildCmd.PersistentFlags().Set("tag", "dev.local/"+projectName)
 		}
 		// Extract code and build the image - and tags it if -t is specified
 		buildErr := buildCmd.RunE(cmd, args)
@@ -93,7 +93,8 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 			return buildErr
 		}
 
-		deployImage := projectName // if not tagged, this is the deploy image name
+		var deployImage string
+		//	:= projectName // if not tagged, this is the deploy image name
 		if tag != "" {
 			deployImage = tag //Otherwise, it's the tag
 		} else {
@@ -122,7 +123,7 @@ generates a deployment manifest (yaml) file if one is not present, and uses it t
 				line = start + deployImage
 				Info.log("Using applicationImage of: ", deployImage)
 			}
-			if strings.Contains(line, "createKnativeService") && strings.Contains(line, "createKnativeService") {
+			if strings.Contains(line, "createKnativeService") && strings.Contains(line, "true") {
 				foundCreateKnativeTag = true
 				localFoundCreateKnativeTag = true
 			}


### PR DESCRIPTION
If the --knative flag is present and there is a app-deploy.yaml containing an appsodyapplication, the createKnativeService: true tag will be added to the yaml file.

If the --knative flag is not present and createKnativeService: true is in the app-deploy.yaml file the createKnativeService element will be removed.  if it is createKnativeService: false, it will remain.

If the stack does not contain an app-deploy.yaml file containing and appsodyapplication, the --knative flag will have no impact.

Unless the appsody deploy is done with a --tag, -t option the imagename will be prefixed with dev.local/<projectname>