### PR TITLE
test: drain stale repo before adding

### DIFF
--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -21,6 +21,12 @@ import (
 )
 
 func TestList(t *testing.T) {
+
+	// tests that would have run before this and crashed could leave the repo
+	// in a bad state - mostly leading to: "a repo with this name already exists."
+	// so clean it up pro-actively, ignore any errors.
+	_, _ = cmdtest.RunAppsodyCmdExec([]string{"repo", "remove", "LocalTestRepo"}, ".")
+
 	// first add the test repo index
 	_, cleanup, err := cmdtest.AddLocalFileRepo("LocalTestRepo", "../cmd/testdata/index.yaml")
 	if err != nil {
@@ -48,6 +54,7 @@ func TestListV2(t *testing.T) {
 	var err error
 	var output string
 	var cleanup func()
+	_, _ = cmdtest.RunAppsodyCmdExec([]string{"repo", "remove", "incubatortest"}, ".")
 	_, cleanup, err = cmdtest.AddLocalFileRepo("incubatortest", "../cmd/testdata/kabanero.yaml")
 	if err != nil {
 		t.Fatal(err)

--- a/cmd/repo_add_test.go
+++ b/cmd/repo_add_test.go
@@ -29,6 +29,7 @@ func TestRepoAdd(t *testing.T) {
 	startRepos := cmdtest.ParseRepoList(output)
 
 	addRepoName := "LocalTestRepo"
+	_, _ = cmdtest.RunAppsodyCmdExec([]string{"repo", "remove", addRepoName}, ".")
 	addRepoURL, cleanup, err := cmdtest.AddLocalFileRepo(addRepoName, "testdata/index.yaml")
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
tests that would have run before this and crashed could leave the repo in a bad state - mostly leading to: "a repo with this name already exists." this is because the failed tests do not get a chance to run the cleanup routines which is supposed to remove the repo.

so clean it up pro-actively, ignore any errors. 

Helps in minimizing turbulence in test runs.
