### PR TITLE
cmd: export getEnvVar, to be reusable by tests

### DIFF
--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -139,7 +139,7 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 		return volumeErr
 	}
 	// Mount the APPSODY_DEPS cache volume if it exists
-	depsEnvVar, envErr := getEnvVar("APPSODY_DEPS")
+	depsEnvVar, envErr := GetEnvVar("APPSODY_DEPS")
 	if envErr != nil {
 		return envErr
 	}
@@ -312,7 +312,7 @@ func processPorts(cmdArgs []string) ([]string, error) {
 	Debug.log("Exposed ports provided by the docker file", dockerExposedPorts)
 	// if the container port is not in the lised of exposed ports add it to the list
 
-	containerPort, envErr := getEnvVar("PORT")
+	containerPort, envErr := GetEnvVar("PORT")
 	if envErr != nil {
 		return cmdArgs, envErr
 	}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -70,7 +70,7 @@ func exists(path string) (bool, error) {
 	return true, err
 }
 
-func getEnvVar(searchEnvVar string) (string, error) {
+func GetEnvVar(searchEnvVar string) (string, error) {
 	// TODO cache this so the buildah / docker inspect command only runs once per cli invocation
 
 	// Docker and Buildah produce slightly different output
@@ -143,7 +143,7 @@ func getEnvVar(searchEnvVar string) (string, error) {
 }
 
 func getEnvVarBool(searchEnvVar string) (bool, error) {
-	strVal, envErr := getEnvVar(searchEnvVar)
+	strVal, envErr := GetEnvVar(searchEnvVar)
 	if envErr != nil {
 		return false, envErr
 	}
@@ -152,7 +152,7 @@ func getEnvVarBool(searchEnvVar string) (bool, error) {
 
 func getEnvVarInt(searchEnvVar string) (int, error) {
 
-	strVal, envErr := getEnvVar(searchEnvVar)
+	strVal, envErr := GetEnvVar(searchEnvVar)
 	if envErr != nil {
 		return 0, envErr
 	}
@@ -165,7 +165,7 @@ func getEnvVarInt(searchEnvVar string) (int, error) {
 }
 
 func getExtractDir() (string, error) {
-	extractDir, envErr := getEnvVar("APPSODY_PROJECT_DIR")
+	extractDir, envErr := GetEnvVar("APPSODY_PROJECT_DIR")
 	if envErr != nil {
 		return "", envErr
 	}
@@ -178,7 +178,7 @@ func getExtractDir() (string, error) {
 
 func getVolumeArgs() ([]string, error) {
 	volumeArgs := []string{}
-	stackMounts, envErr := getEnvVar("APPSODY_MOUNTS")
+	stackMounts, envErr := GetEnvVar("APPSODY_MOUNTS")
 	if envErr != nil {
 		return nil, envErr
 	}


### PR DESCRIPTION
Make this public so that tests can make use of it - for now, https://github.com/appsody/appsody/pull/314

We have a mind to refactor this function for re-usability; basically cache the image inspection data and reuse it for future calls, in the CLI life. To reduce clutter, one at a time!
