### PR TITLE
src: remove hard-coded reference to `/project`

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -466,7 +466,11 @@ func extractAndInitialize() error {
 		return configErr
 	}
 	stackImage := projectConfig.Platform
-	bashCmd := "find /project -type f -name " + scriptFileName
+	containerProjectDir, containerProjectDirErr := getExtractDir()
+	if containerProjectDirErr != nil {
+		return containerProjectDirErr
+	}
+	bashCmd := "find " + containerProjectDir + " -type f -name " + scriptFileName
 	cmdOptions := []string{"--rm"}
 	Debug.log("Attempting to run ", bashCmd, " on image ", stackImage, " with options: ", cmdOptions)
 	//DockerRunBashCmd has a pullImage call


### PR DESCRIPTION
working directory was made configurable through `APPSODY_PROJECT_DIR`, but if that is exercised with any value other than `/project`, then `appsody init` fails at the moment. This is because of the hard-coding in the container startup command. Derive its value from
`getExtractDir()`