### PR TITLE
Cache and reuse the results of getEnvVar()

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -50,6 +50,7 @@ type RootCommandConfig struct {
 	// package scoped, these are mostly for caching
 	setupConfigRun bool
 	imagePulled    map[string]bool
+	cachedEnvVars  map[string]string
 }
 
 // Regular expression to match ANSI terminal commands so that we can remove them from the log

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -68,7 +68,11 @@ func Exists(path string) (bool, error) {
 }
 
 func GetEnvVar(searchEnvVar string, config *RootCommandConfig) (string, error) {
-	if value, present := cachedEnvVars[searchEnvVar]; present {
+	if config.cachedEnvVars == nil {
+		config.cachedEnvVars = make(map[string]string)
+	}
+
+	if value, present := config.cachedEnvVars[searchEnvVar]; present {
 		Debug.logf("Environment variable found cached: %s Value: %s", searchEnvVar, value)
 		return value, nil
 	}
@@ -127,14 +131,14 @@ func GetEnvVar(searchEnvVar string, config *RootCommandConfig) (string, error) {
 	for _, envVar := range envVars {
 		nameValuePair := strings.SplitN(envVar.(string), "=", 2)
 		name, value := nameValuePair[0], nameValuePair[1]
-		cachedEnvVars[name] = value
+		config.cachedEnvVars[name] = value
 		if name == searchEnvVar {
 			varFound = true
 		}
 	}
 	if varFound {
-		Debug.logf("Environment variable found: %s Value: %s", searchEnvVar, cachedEnvVars[searchEnvVar])
-		return cachedEnvVars[searchEnvVar], nil
+		Debug.logf("Environment variable found: %s Value: %s", searchEnvVar, config.cachedEnvVars[searchEnvVar])
+		return config.cachedEnvVars[searchEnvVar], nil
 	}
 	Debug.log("Could not find env var: ", searchEnvVar)
 	return "", nil

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -68,7 +68,10 @@ func Exists(path string) (bool, error) {
 }
 
 func GetEnvVar(searchEnvVar string, config *RootCommandConfig) (string, error) {
-	// TODO cache this so the buildah / docker inspect command only runs once per cli invocation
+	if value, present := cachedEnvVars[searchEnvVar]; present {
+		Debug.logf("Environment variable found cached: %s Value: %s", searchEnvVar, value)
+		return value, nil
+	}
 
 	// Docker and Buildah produce slightly different output
 	// for `inspect` command. Array of maps vs. maps
@@ -121,22 +124,20 @@ func GetEnvVar(searchEnvVar string, config *RootCommandConfig) (string, error) {
 	Debug.log("Number of environment variables in stack image: ", len(envVars))
 	Debug.log("All environment variables in stack image: ", envVars)
 	var varFound = false
-	var envVarValue string
 	for _, envVar := range envVars {
-		if strings.HasPrefix(envVar.(string), searchEnvVar) {
+		nameValuePair := strings.SplitN(envVar.(string), "=", 2)
+		name, value := nameValuePair[0], nameValuePair[1]
+		cachedEnvVars[name] = value
+		if name == searchEnvVar {
 			varFound = true
-			envVarValue = strings.SplitN(envVar.(string), "=", 2)[1]
-			break
 		}
 	}
 	if varFound {
-		Debug.logf("Environment variable found: %s Value: %s", searchEnvVar, envVarValue)
-	} else {
-		Debug.log("Could not find env var: ", searchEnvVar)
-		envVarValue = ""
+		Debug.logf("Environment variable found: %s Value: %s", searchEnvVar, cachedEnvVars[searchEnvVar])
+		return cachedEnvVars[searchEnvVar], nil
 	}
-	return envVarValue, nil
-
+	Debug.log("Could not find env var: ", searchEnvVar)
+	return "", nil
 }
 
 func getEnvVarBool(searchEnvVar string, config *RootCommandConfig) (bool, error) {


### PR DESCRIPTION
Motivation:
Commands may call getEnvVar() multiple times for different environment
variable names. Every invocation needs a `docker inspect` invocation followed
by unmarshalling of the json and a walk through the resulting array. Caching
the environment variables in a map can avoid repeating these steps and speed-up
command execution.