### PR TITLE
stacks: make mount separator configurable

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -188,7 +188,12 @@ func getVolumeArgs() ([]string, error) {
 		Warning.log("The stack image does not contain APPSODY_MOUNTS")
 		return volumeArgs, nil
 	}
-	stackMountList := strings.Split(stackMounts, ";")
+	mountSeparator, err := GetMountSeparator()
+	if err != nil {
+		Warning.log("Could not determine mount separator from The stack image")
+		return volumeArgs, err
+	}
+	stackMountList := strings.Split(stackMounts, mountSeparator)
 	homeDir := UserHomeDir()
 	homeDirOverride := os.Getenv("APPSODY_MOUNT_HOME")
 	homeDirOverridden := false
@@ -1071,4 +1076,16 @@ func IsEmptyDir(name string) bool {
 	_, err = f.Readdirnames(1)
 
 	return err == io.EOF
+}
+
+func GetMountSeparator() (string, error) {
+	mountSeparator, err := GetEnvVar("APPSODY_MOUNT_SEPARATOR")
+	if err != nil {
+		return "", err
+	}
+	if mountSeparator == "" {
+		return ":", nil
+	}
+	Debug.log("The stack image uses special APPSODY_MOUNT_SEPARATOR: ", mountSeparator)
+	return mountSeparator, nil
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1084,7 +1084,7 @@ func GetMountSeparator() (string, error) {
 		return "", err
 	}
 	if mountSeparator == "" {
-		return ":", nil
+		return ";", nil
 	}
 	Debug.log("The stack image uses special APPSODY_MOUNT_SEPARATOR: ", mountSeparator)
 	return mountSeparator, nil

--- a/functest/extract_test.go
+++ b/functest/extract_test.go
@@ -121,7 +121,11 @@ func TestExtract(t *testing.T) {
 		}
 		log.Println("Stack's project dir:", pDir)
 
-		mountlist := strings.Split(mounts, ";")
+		mountSeparator, err := cmd.GetMountSeparator()
+		if err != nil {
+			t.Fatal(err)
+		}
+		mountlist := strings.Split(mounts, mountSeparator)
 		for _, mount := range mountlist {
 			log.Println("mount:", mount)
 			src := strings.Split(mount, ":")[0]


### PR DESCRIPTION
Right now, `;` is hard-coded to be the mount separator
in the stack-mounts, which inhibits this character from
being used for path names.

Introduce an appsody env APPSODY_MOUNT_SEPARATOR that can
be used by stacks that want to use a different separator.

Partially fixes: https://github.com/appsody/appsody/issues/31