### PR TITLE
repo: increase the table column width for repo

### DIFF
--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -368,7 +368,7 @@ func (r *RepositoryFile) getRepos() (*RepositoryFile, error) {
 func (r *RepositoryFile) listRepos() (string, error) {
 	var entries = []RepositoryEntry{}
 	table := uitable.New()
-	table.MaxColWidth = 120
+	table.MaxColWidth = 1024
 	table.AddRow("NAME", "URL")
 	for _, value := range r.Repositories {
 		repoName := value.Name


### PR DESCRIPTION
While there is no platform-wide standard on the lengh of file path and / or www url, 120 proved to be too restrictive. Change to 1024 - should be a reasonable one. The table format gets skewed a bit with this, but data truncation on the other hand is more harmful, so!

Fixes: https://github.com/appsody/appsody/issues/350

cc @kylegc 