### PR TITLE
cmd: harden `--docker-options` parsing

### DIFF
--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -47,7 +47,7 @@ var commonFlags *flag.FlagSet
 func checkDockerRunOptions(options []string) error {
 	fmt.Println("testing docker options", options)
 	//runOptionsTest := "(^((-p)|(--publish)|(--publish-all)|(-P)|(-u)|(--user)|(--name)|(--network)|(-t)|(--tty)|(--rm)|(--entrypoint)|(-v)|(--volume)|(-e)|(--env))((=?$)|(=.*)))"
-	runOptionsTest := "(^((-p)|(--publish)|(--publish-all)|(-P)|(-u)|(--user)|(--name)|(--network)|(-t)|(--tty)|(--rm)|(--entrypoint)|(-v)|(--volume))((=?$)|(=.*)))"
+	runOptionsTest := "(^((^[^-].*)|(--help)|(-p)|(--publish)|(--publish-all)|(-P)|(-u)|(--user)|(--name)|(--network)|(-t)|(--tty)|(--rm)|(--entrypoint)|(-v)|(--volume))((=?$)|(=.*)))"
 
 	blackListedRunOptionsRegexp := regexp.MustCompile(runOptionsTest)
 	for _, value := range options {

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -47,7 +47,7 @@ var commonFlags *flag.FlagSet
 func checkDockerRunOptions(options []string) error {
 	fmt.Println("testing docker options", options)
 	//runOptionsTest := "(^((-p)|(--publish)|(--publish-all)|(-P)|(-u)|(--user)|(--name)|(--network)|(-t)|(--tty)|(--rm)|(--entrypoint)|(-v)|(--volume)|(-e)|(--env))((=?$)|(=.*)))"
-	runOptionsTest := "(^((^[^-].*)|(--help)|(-p)|(--publish)|(--publish-all)|(-P)|(-u)|(--user)|(--name)|(--network)|(-t)|(--tty)|(--rm)|(--entrypoint)|(-v)|(--volume))((=?$)|(=.*)))"
+	runOptionsTest := "(^((--help)|(-p)|(--publish)|(--publish-all)|(-P)|(-u)|(--user)|(--name)|(--network)|(-t)|(--tty)|(--rm)|(--entrypoint)|(-v)|(--volume))((=?$)|(=.*)))"
 
 	blackListedRunOptionsRegexp := regexp.MustCompile(runOptionsTest)
 	for _, value := range options {


### PR DESCRIPTION
~~Disallow anything that does not start with a `-`.
(luckily all the docker run options do)~~

EDIT: As per discussion, this was not pursued due to maintenance overhead.

Disallow `--help`
(not the best place to do `docker run --help`)
(in addition, even if it is, the output is truncated, so!)

Fixes: https://github.com/appsody/appsody/issues/346

cc @kylegc @chilanti @kewegner 