### PR TITLE
[on hold] cmd: remove sleep in runner when controller is interrupted

### DIFF
--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -24,7 +24,6 @@ import (
 	"runtime"
 	"strings"
 	"syscall"
-	"time"
 
 	"github.com/pkg/errors"
 
@@ -299,14 +298,14 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 		error := fmt.Sprintf("%s", err)
 		//Linux and Windows return a different error on Ctrl-C
 		if error == "signal: interrupt" || error == "exit status 2" {
-			Info.log("Closing down development environment, sleeping 60 seconds: ", error)
-
-			time.Sleep(60 * time.Second)
+			Info.log("Closing down, development environment was interrupted.")
 		} else {
-			return errors.Errorf("Error waiting in 'appsody %s' %s", mode, error)
+			return errors.Errorf("Error in 'appsody %s': %s", mode, error)
 
 		}
 
+	} else {
+		Info.log("Closing down development environment.")
 	}
 	return nil
 


### PR DESCRIPTION
1. Remove the 1 minute sleep in the runner
2. Adjust the messages accordingly.

Fixes: https://github.com/appsody/appsody/issues/334

cc @kylegc . It is not clear to me the need for `sleep`: In `tty` mode (ctrl+c intercepted by the controller) or not (ctrl+c intercepted by runner) , the `interrupt` signal is always obtained from the child (controller) , which means we don't need to wait anymore? Am I missing something? I tested in mac and linux, and did not see any issues with removal of sleep.


