### PR TITLE
cmd: print table only if non-empty

### DIFF
--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -53,7 +53,9 @@ var psCmd = &cobra.Command{
 		if err != nil {
 			return errors.Errorf("%v", err)
 		}
-		Info.log(table)
+		if table != "" {
+			Info.log(table)
+		}
 		return nil
 	},
 }


### PR DESCRIPTION
Fixes: https://github.com/appsody/appsody/issues/357