### PR TITLE
Remove appsody ps call from simple tests

### DIFF
--- a/functest/debug_test.go
+++ b/functest/debug_test.go
@@ -101,26 +101,12 @@ func TestDebugSimple(t *testing.T) {
 			t.Fatal("container never appeared to start")
 		}
 
-		// now run appsody ps and see if we can spot the container
-		fmt.Println("about to run appsody ps")
-		stopOutput, errStop := cmdtest.RunAppsodyCmd([]string{"ps"}, projectDir)
-		if !strings.Contains(stopOutput, "CONTAINER") {
-			t.Fatal("output doesn't contain header line")
-		}
-		if !strings.Contains(stopOutput, containerName) {
-			t.Fatal("output doesn't contain correct container name")
-		}
-		if errStop != nil {
-			log.Printf("Ignoring error running appsody ps: %s", errStop)
-		}
-
 		// stop and cleanup
-		func() {
-			_, err = cmdtest.RunAppsodyCmdExec([]string{"stop", "--name", containerName}, projectDir)
-			if err != nil {
-				fmt.Printf("Ignoring error running appsody stop: %s", err)
-			}
-		}()
+		_, err = cmdtest.RunAppsodyCmdExec([]string{"stop", "--name", containerName}, projectDir)
+		if err != nil {
+			fmt.Printf("Ignoring error running appsody stop: %s", err)
+		}
+		
 		cleanup()
 	}
 }

--- a/functest/run_test.go
+++ b/functest/run_test.go
@@ -180,26 +180,11 @@ func TestRunSimple(t *testing.T) {
 			t.Fatal("container never appeared to start")
 		}
 
-		// now run appsody ps and see if we can spot the container
-		fmt.Println("about to run appsody ps")
-		stopOutput, errStop := cmdtest.RunAppsodyCmd([]string{"ps"}, projectDir)
-		if !strings.Contains(stopOutput, "CONTAINER") {
-			t.Fatal("output doesn't contain header line")
-		}
-		if !strings.Contains(stopOutput, containerName) {
-			t.Fatal("output doesn't contain correct container name")
-		}
-		if errStop != nil {
-			log.Printf("Ignoring error running appsody ps: %s", errStop)
-		}
-
 		// stop and clean up after the run
-		func() {
-			_, err = cmdtest.RunAppsodyCmdExec([]string{"stop", "--name", "testRunSimpleContainer"}, projectDir)
-			if err != nil {
-				fmt.Printf("Ignoring error running appsody stop: %s", err)
-			}
-		}()
+		_, err = cmdtest.RunAppsodyCmdExec([]string{"stop", "--name", containerName}, projectDir)
+		if err != nil {
+			fmt.Printf("Ignoring error running appsody stop: %s", err)
+		}
 
 		cleanup()
 	}


### PR DESCRIPTION
These tests were randomly failing in Travis and giving us grief. I don't think it is necessary to call `appsody ps` in these tests were we already confirmed the container was running with `docker ps`. So I removed this code which should help the build.