### PR TITLE
Remove global vars and init() functions

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -23,6 +23,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
+type buildCommandConfig struct {
+	*RootCommandConfig
+	tag                string
+	dockerBuildOptions string
+}
+
 func checkDockerBuildOptions(options []string) error {
 	buildOptionsTest := "(^((-t)|(--tag)|(-f)|(--file))((=?$)|(=.*)))"
 
@@ -38,65 +44,71 @@ func checkDockerBuildOptions(options []string) error {
 
 }
 
-var dockerBuildOptions string
+func newBuildCmd(rootConfig *RootCommandConfig) *cobra.Command {
+	config := &buildCommandConfig{RootCommandConfig: rootConfig}
+	// buildCmd provides the ability run local builds, or setup/delete Tekton builds, for an appsody project
+	var buildCmd = &cobra.Command{
+		Use:   "build",
+		Short: "Locally build a docker image of your appsody project",
+		Long:  `This allows you to build a local Docker image from your Appsody project. Extract is run before the docker build.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return build(config)
+		},
+	}
 
-// buildCmd provides the ability run local builds, or setup/delete Tekton builds, for an appsody project
-var buildCmd = &cobra.Command{
-	Use:   "build",
-	Short: "Locally build a docker image of your appsody project",
-	Long:  `This allows you to build a local Docker image from your Appsody project. Extract is run before the docker build.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		// This needs to do:
-		// 1. appsody Extract
-		// 2. docker build -t <project name> -f Dockerfile ./extracted
+	buildCmd.PersistentFlags().StringVarP(&config.tag, "tag", "t", "", "Docker image name and optionally a tag in the 'name:tag' format")
+	buildCmd.PersistentFlags().StringVar(&config.dockerBuildOptions, "docker-options", "", "Specify the docker build options to use.  Value must be in \"\".")
 
-		extractErr := extractCmd.RunE(cmd, args)
-		if extractErr != nil {
-			return extractErr
-		}
-
-		projectName, perr := getProjectName()
-		if perr != nil {
-			return errors.Errorf("%v", perr)
-		}
-		extractDir := filepath.Join(getHome(), "extract", projectName)
-		dockerfile := filepath.Join(extractDir, "Dockerfile")
-		buildImage := projectName //Lowercased
-		// If a tag is specified, change the buildImage
-		if tag != "" {
-			buildImage = tag
-		}
-		//cmdName := "docker"
-		cmdArgs := []string{"-t", buildImage}
-
-		if dockerBuildOptions != "" {
-			dockerBuildOptions = strings.TrimPrefix(dockerBuildOptions, " ")
-			dockerBuildOptions = strings.TrimSuffix(dockerBuildOptions, " ")
-			options := strings.Split(dockerBuildOptions, " ")
-			err := checkDockerBuildOptions(options)
-			if err != nil {
-				return err
-			}
-			cmdArgs = append(cmdArgs, options...)
-
-		}
-		cmdArgs = append(cmdArgs, "-f", dockerfile, extractDir)
-		Debug.log("final cmd args", cmdArgs)
-		execError := DockerBuild(cmdArgs, DockerLog)
-
-		if execError != nil {
-			return execError
-		}
-		if !dryrun {
-			Info.log("Built docker image ", buildImage)
-		}
-		return nil
-	},
+	buildCmd.AddCommand(newBuildDeleteCmd(config))
+	buildCmd.AddCommand(newSetupCmd(config))
+	return buildCmd
 }
 
-func init() {
-	rootCmd.AddCommand(buildCmd)
-	buildCmd.PersistentFlags().StringVarP(&tag, "tag", "t", "", "Docker image name and optionally a tag in the 'name:tag' format")
-	buildCmd.PersistentFlags().StringVar(&dockerBuildOptions, "docker-options", "", "Specify the docker build options to use.  Value must be in \"\".")
+func build(config *buildCommandConfig) error {
+	// This needs to do:
+	// 1. appsody Extract
+	// 2. docker build -t <project name> -f Dockerfile ./extracted
 
+	extractConfig := &extractCommandConfig{RootCommandConfig: config.RootCommandConfig}
+	extractErr := extract(extractConfig)
+	if extractErr != nil {
+		return extractErr
+	}
+
+	projectName, perr := getProjectName(config.RootCommandConfig)
+	if perr != nil {
+		return errors.Errorf("%v", perr)
+	}
+	extractDir := filepath.Join(getHome(config.RootCommandConfig), "extract", projectName)
+	dockerfile := filepath.Join(extractDir, "Dockerfile")
+	buildImage := projectName //Lowercased
+	// If a tag is specified, change the buildImage
+	if config.tag != "" {
+		buildImage = config.tag
+	}
+	//cmdName := "docker"
+	cmdArgs := []string{"-t", buildImage}
+
+	if config.dockerBuildOptions != "" {
+		dockerBuildOptions := strings.TrimPrefix(config.dockerBuildOptions, " ")
+		dockerBuildOptions = strings.TrimSuffix(dockerBuildOptions, " ")
+		options := strings.Split(dockerBuildOptions, " ")
+		err := checkDockerBuildOptions(options)
+		if err != nil {
+			return err
+		}
+		cmdArgs = append(cmdArgs, options...)
+
+	}
+	cmdArgs = append(cmdArgs, "-f", dockerfile, extractDir)
+	Debug.log("final cmd args", cmdArgs)
+	execError := DockerBuild(cmdArgs, DockerLog, config.Verbose, config.Dryrun)
+
+	if execError != nil {
+		return execError
+	}
+	if !config.Dryrun {
+		Info.log("Built docker image ", buildImage)
+	}
+	return nil
 }

--- a/cmd/build_setup.go
+++ b/cmd/build_setup.go
@@ -24,65 +24,65 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// setupCmd allows you to setup a GitHook to drive a Tekton build pipeline for the Appsodys project in Git
-var setupCmd = &cobra.Command{
-	Use: "setup",
-	// disable this command until we have a better plan on how to support ci pipelines
-	Hidden: true,
-	Short:  "Setup a Githook and build pipeline for your Appsody project",
-	Long:   `This allows you to register a Githook for your Appsody project.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+func newSetupCmd(config *buildCommandConfig) *cobra.Command {
+	// setupCmd allows you to setup a GitHook to drive a Tekton build pipeline for the Appsodys project in Git
+	var setupCmd = &cobra.Command{
+		Use: "setup",
+		// disable this command until we have a better plan on how to support ci pipelines
+		Hidden: true,
+		Short:  "Setup a Githook and build pipeline for your Appsody project",
+		Long:   `This allows you to register a Githook for your Appsody project.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
 
-		// TODO: should we dynamically pick up the Git URL from the .git in the project?
-		// TODO: add validation of the supplied Git URL
-		if len(args) < 1 {
-			return errors.New("error, you must specify a Git project URL")
+			// TODO: should we dynamically pick up the Git URL from the .git in the project?
+			// TODO: add validation of the supplied Git URL
+			if len(args) < 1 {
+				return errors.New("error, you must specify a Git project URL")
 
-		}
-		gitProject := args[0]
+			}
+			gitProject := args[0]
 
-		// Use the "tektonserver" field from the config.
-		tektonServer := cliConfig.GetString("tektonserver")
-		if tektonServer == "" {
-			return errors.New("no target Tekton server specified in the configuration")
-		}
-		url := fmt.Sprintf("%s/v1/namespaces/default/githubsource/", tektonServer)
+			// Use the "tektonserver" field from the config.
+			tektonServer := config.CliConfig.GetString("tektonserver")
+			if tektonServer == "" {
+				return errors.New("no target Tekton server specified in the configuration")
+			}
+			url := fmt.Sprintf("%s/v1/namespaces/default/githubsource/", tektonServer)
 
-		// projectDir := getProjectDir()
-		// projectName := filepath.Base(projectDir)
-		projectName, perr := getProjectName()
-		if perr != nil {
-			return errors.Errorf("%v", perr)
-		}
-		// Setup JSON payload for use with the Tekton server
-		var jsonStr = fmt.Sprintf(`{"name":"%s", "gitrepositoryurl":"%s","accesstoken":"github-secret","pipeline":"appsody-build-pipeline"}`, projectName, gitProject)
-		if dryrun {
-			Info.logf("Dry Run appsody build setup project URL: %s\n", url)
-		} else {
-			req, _ := http.NewRequest("POST", url, bytes.NewBuffer([]byte(jsonStr)))
-			req.Header.Set("Content-Type", "application/json")
-
-			client := &http.Client{}
-			Info.log("Making request to ", url)
-			resp, err := client.Do(req)
-			if err != nil {
+			// projectDir := getProjectDir()
+			// projectName := filepath.Base(projectDir)
+			projectName, perr := getProjectName(config.RootCommandConfig)
+			if perr != nil {
 				return errors.Errorf("%v", perr)
 			}
-			defer resp.Body.Close()
-			body, _ := ioutil.ReadAll(resp.Body)
-			bodyStr := string(body)
+			// Setup JSON payload for use with the Tekton server
+			var jsonStr = fmt.Sprintf(`{"name":"%s", "gitrepositoryurl":"%s","accesstoken":"github-secret","pipeline":"appsody-build-pipeline"}`, projectName, gitProject)
+			if config.Dryrun {
+				Info.logf("Dry Run appsody build setup project URL: %s\n", url)
+			} else {
+				req, _ := http.NewRequest("POST", url, bytes.NewBuffer([]byte(jsonStr)))
+				req.Header.Set("Content-Type", "application/json")
 
-			if resp.StatusCode >= 300 {
-				return errors.Errorf("Bad Status Code: %s with message: %s", resp.Status, string(bodyStr))
+				client := &http.Client{}
+				Info.log("Making request to ", url)
+				resp, err := client.Do(req)
+				if err != nil {
+					return errors.Errorf("%v", perr)
+				}
+				defer resp.Body.Close()
+				body, _ := ioutil.ReadAll(resp.Body)
+				bodyStr := string(body)
+
+				if resp.StatusCode >= 300 {
+					return errors.Errorf("Bad Status Code: %s with message: %s", resp.Status, string(bodyStr))
+				}
+				Info.log(resp.Status)
+				Info.log(string(bodyStr))
+
 			}
-			Info.log(resp.Status)
-			Info.log(string(bodyStr))
+			return nil
+		},
+	}
 
-		}
-		return nil
-	},
-}
-
-func init() {
-	buildCmd.AddCommand(setupCmd)
+	return setupCmd
 }

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -21,11 +21,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// bash completions
-var bashCompletionCmd = &cobra.Command{
-	Use:   "completion",
-	Short: "Generates bash tab completions",
-	Long: `Outputs a bash completion script for appsody to stdout.  Bash completion is optionally available for your convenience. It helps you fill out appsody commands when you type the [TAB] key.
+func newCompletionCmd(rootCmd *cobra.Command) *cobra.Command {
+	// bash completions
+	var bashCompletionCmd = &cobra.Command{
+		Use:   "completion",
+		Short: "Generates bash tab completions",
+		Long: `Outputs a bash completion script for appsody to stdout.  Bash completion is optionally available for your convenience. It helps you fill out appsody commands when you type the [TAB] key.
 
 	To install on macOS
 	1. brew install bash-completion
@@ -38,37 +39,35 @@ var bashCompletionCmd = &cobra.Command{
 	3. Make sure to copy the appsody completion file generated above into the appropriate directory for your Linux distribution e.g.
 	appsody completion >  /etc/bash_completion.d/appsody`,
 
-	Run: func(cmd *cobra.Command, args []string) {
-		buf := new(bytes.Buffer)
+		Run: func(cmd *cobra.Command, args []string) {
+			buf := new(bytes.Buffer)
 
-		Debug.log("Running bash completion script")
-		_ = rootCmd.GenBashCompletion(buf)
-		output := buf.String()
-		// We need to use real spaces because .GenBashCompletion does and formatting requires it
-		spaceTab := "    "
-		afterAppsodyDevInit := strings.Split(output, "_appsody_init()")
-		header := "# Outputs a bash completion script for appsody to stdout. " +
-			"Bash completion is optionally available for your convenience. It helps you fill out appsody commands when you type the [TAB] key.\n" +
-			"# To install on Linux\n" +
-			"# 1. On a current Linux OS (in a non-minimal installation), bash completion should be available.\n" +
-			"# 2. Place the completion script generated above in your bash completions directory.\n" +
-			"# 3. appsody completion > /usr/local/etc/bash_completion.d/appsody\n\n" +
-			"# To install on macOS\n" +
-			"# 1. brew install bash-completion\n" +
-			"# 2. Make sure to update your ~/.bash_profile as instructed\n" +
-			"# 3. appsody completion > /usr/local/etc/bash_completion.d/appsody\n"
-		extra := "flags=()\n" + spaceTab +
-			"kdl=\"$((appsody list) | awk -F ' ' '{print $1}{print $2}')\"\n" +
-			spaceTab + "arr=($kdl)\n" + spaceTab + "len=${#arr[@]}\n" +
-			spaceTab + "for (( i=2; i<$len; i=i+2 ))\n" + spaceTab + "do\n" +
-			spaceTab + spaceTab + "j=i+1\n" + "thecmd=${arr[i]}/${arr[j]}\n" + "commands+=(\"${thecmd}\")\n" + spaceTab + "done\n"
+			Debug.log("Running bash completion script")
+			_ = rootCmd.GenBashCompletion(buf)
+			output := buf.String()
+			// We need to use real spaces because .GenBashCompletion does and formatting requires it
+			spaceTab := "    "
+			afterAppsodyDevInit := strings.Split(output, "_appsody_init()")
+			header := "# Outputs a bash completion script for appsody to stdout. " +
+				"Bash completion is optionally available for your convenience. It helps you fill out appsody commands when you type the [TAB] key.\n" +
+				"# To install on Linux\n" +
+				"# 1. On a current Linux OS (in a non-minimal installation), bash completion should be available.\n" +
+				"# 2. Place the completion script generated above in your bash completions directory.\n" +
+				"# 3. appsody completion > /usr/local/etc/bash_completion.d/appsody\n\n" +
+				"# To install on macOS\n" +
+				"# 1. brew install bash-completion\n" +
+				"# 2. Make sure to update your ~/.bash_profile as instructed\n" +
+				"# 3. appsody completion > /usr/local/etc/bash_completion.d/appsody\n"
+			extra := "flags=()\n" + spaceTab +
+				"kdl=\"$((appsody list) | awk -F ' ' '{print $1}{print $2}')\"\n" +
+				spaceTab + "arr=($kdl)\n" + spaceTab + "len=${#arr[@]}\n" +
+				spaceTab + "for (( i=2; i<$len; i=i+2 ))\n" + spaceTab + "do\n" +
+				spaceTab + spaceTab + "j=i+1\n" + "thecmd=${arr[i]}/${arr[j]}\n" + "commands+=(\"${thecmd}\")\n" + spaceTab + "done\n"
 
-		fmt.Println(header + afterAppsodyDevInit[0] + "_appsody_init()\n" + strings.Replace(afterAppsodyDevInit[1], "flags=()", extra, 1))
+			fmt.Println(header + afterAppsodyDevInit[0] + "_appsody_init()\n" + strings.Replace(afterAppsodyDevInit[1], "flags=()", extra, 1))
 
-	},
-}
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(bashCompletionCmd)
-
+	return bashCompletionCmd
 }

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -15,20 +15,20 @@ package cmd
 
 import "github.com/spf13/cobra"
 
-// debug Cmd represents the debug command
-var debugCmd = &cobra.Command{
-	Use:   "debug",
-	Short: "Run the local Appsody environment in debug mode",
-	Long:  `This starts a docker based continuous build environment for your project with debugging enabled.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+func newDebugCmd(rootConfig *RootCommandConfig) *cobra.Command {
+	config := &devCommonConfig{RootCommandConfig: rootConfig}
+	// debug Cmd represents the debug command
+	var debugCmd = &cobra.Command{
+		Use:   "debug",
+		Short: "Run the local Appsody environment in debug mode",
+		Long:  `This starts a docker based continuous build environment for your project with debugging enabled.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
 
-		Info.log("Running debug environment")
-		return commonCmd(cmd, args, "debug")
-	},
-}
+			Info.log("Running debug environment")
+			return commonCmd(config, "debug")
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(debugCmd)
-	addDevCommonFlags(debugCmd)
-
+	addDevCommonFlags(debugCmd, config)
+	return debugCmd
 }

--- a/cmd/deploy_delete.go
+++ b/cmd/deploy_delete.go
@@ -19,34 +19,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var deployConfigFile string
+func newDeleteDeploymentCmd(deployConfig *deployCommandConfig) *cobra.Command {
+	var deployConfigFile string
+	var deleteDeploymentCmd = &cobra.Command{
+		Use:   "delete",
+		Short: "Delete your deployed Appsody project from a Kubernetes cluster",
+		Long:  `This command deletes your deployed Appsody project from the configured Kubernetes cluster using your existing deployment manifest.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
 
-var deleteDeploymentCmd = &cobra.Command{
-	Use:   "delete",
-	Short: "Delete your deployed Appsody project from a Kubernetes cluster",
-	Long:  `This command deletes your deployed Appsody project from the configured Kubernetes cluster using your existing deployment manifest.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+			exists, err := Exists(deployConfigFile)
+			if err != nil {
+				return errors.Errorf("Error checking status of %s", deployConfigFile)
+			}
+			if !deployConfig.Dryrun && !exists {
+				return errors.Errorf("Cannot delete deployment. Deployment manifest not found: %s", deployConfigFile)
+			}
 
-		exists, err := Exists(deployConfigFile)
-		if err != nil {
-			return errors.Errorf("Error checking status of %s", deployConfigFile)
-		}
-		if !dryrun && !exists {
-			return errors.Errorf("Cannot delete deployment. Deployment manifest not found: %s", deployConfigFile)
-		}
+			Info.log("Deleting deployment using deployment manifest ", deployConfigFile)
+			err = KubeDelete(deployConfigFile, deployConfig.namespace, deployConfig.Dryrun)
+			if err != nil {
+				return err
+			}
+			Info.log("Deployment deleted")
+			return nil
+		},
+	}
 
-		Info.log("Deleting deployment using deployment manifest ", deployConfigFile)
-		err = KubeDelete(deployConfigFile)
-		if err != nil {
-			return err
-		}
-		Info.log("Deployment deleted")
-		return nil
-	},
-}
-
-func init() {
-	deployCmd.AddCommand(deleteDeploymentCmd)
 	deleteDeploymentCmd.PersistentFlags().StringVarP(&deployConfigFile, "file", "f", "app-deploy.yaml", "The file name to use for the deployment configuration.")
-
+	return deleteDeploymentCmd
 }

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -27,21 +27,20 @@ import (
 
 	"github.com/pkg/errors"
 
-	flag "github.com/spf13/pflag"
-
 	"github.com/spf13/cobra"
 )
 
-var disableWatcher bool
-var containerName string
-var depsVolumeName string
-var ports []string
-var publishAllPorts bool
-var interactive bool
-var dockerNetwork string
-var dockerOptions string
-var nameFlags *flag.FlagSet
-var commonFlags *flag.FlagSet
+type devCommonConfig struct {
+	*RootCommandConfig
+	disableWatcher  bool
+	containerName   string
+	depsVolumeName  string
+	ports           []string
+	publishAllPorts bool
+	interactive     bool
+	dockerNetwork   string
+	dockerOptions   string
+}
 
 func checkDockerRunOptions(options []string) error {
 	fmt.Println("testing docker options", options)
@@ -59,67 +58,54 @@ func checkDockerRunOptions(options []string) error {
 	return nil
 
 }
-func buildCommonFlags() {
-	if commonFlags == nil || nameFlags == nil {
-		commonFlags = flag.NewFlagSet("", flag.ContinueOnError)
-		nameFlags = flag.NewFlagSet("", flag.ContinueOnError)
-		//curDir, err := os.Getwd()
-		//if err != nil {
-		//	Error.log("Error getting current directory ", err)
-		//	os.Exit(1)
-		//}
-		projectName, perr := getProjectName()
 
-		if perr != nil {
-			if pmsg, ok := perr.(*NotAnAppsodyProject); ok {
-				Debug.log("Cannot retrieve the project name - continuing: ", perr)
-			} else {
-				Error.logf("Error occurred retrieving project name... exiting: %s", pmsg)
-				os.Exit(1)
-			}
+func addNameFlag(cmd *cobra.Command, flagVar *string, config *RootCommandConfig) {
+	projectName, perr := getProjectName(config)
+	if perr != nil {
+		if pmsg, ok := perr.(*NotAnAppsodyProject); ok {
+			//Debug.log("Cannot retrieve the project name - continuing: ", perr)
+		} else {
+			Error.logf("Error occurred retrieving project name... exiting: %s", pmsg)
+			os.Exit(1)
 		}
-		//defaultName := filepath.Base(curDir) + "-dev"
-		defaultName := projectName + "-dev"
-		nameFlags.StringVar(&containerName, "name", defaultName, "Assign a name to your development container.")
-		//defaultDepsVolume := filepath.Base(curDir) + "-deps"
-		defaultDepsVolume := projectName + "-deps"
-		commonFlags.StringVar(&dockerNetwork, "network", "", "Specify the network for docker to use.")
-		commonFlags.StringVar(&depsVolumeName, "deps-volume", defaultDepsVolume, "Docker volume to use for dependencies. Mounts to APPSODY_DEPS dir.")
-		commonFlags.StringArrayVarP(&ports, "publish", "p", nil, "Publish the container's ports to the host. The stack's exposed ports will always be published, but you can publish addition ports or override the host ports with this option.")
-		commonFlags.BoolVarP(&publishAllPorts, "publish-all", "P", false, "Publish all exposed ports to random ports")
-		commonFlags.BoolVar(&disableWatcher, "no-watcher", false, "Disable file watching, regardless of container environment variable settings.")
-		commonFlags.BoolVarP(&interactive, "interactive", "i", false, "Attach STDIN to the container for interactive TTY mode")
-		commonFlags.StringVar(&dockerOptions, "docker-options", "", "Specify the docker run options to use.  Value must be in \"\".")
 	}
 
+	defaultName := projectName + "-dev"
+	cmd.PersistentFlags().StringVar(flagVar, "name", defaultName, "Assign a name to your development container.")
 }
 
-func addNameFlags(cmd *cobra.Command) {
+func addDevCommonFlags(cmd *cobra.Command, config *devCommonConfig) {
 
-	buildCommonFlags()
-	cmd.PersistentFlags().AddFlagSet(nameFlags)
-
-}
-
-func addDevCommonFlags(cmd *cobra.Command) {
-
-	buildCommonFlags()
-	addNameFlags(cmd)
-	cmd.PersistentFlags().AddFlagSet(commonFlags)
-
-}
-
-func commonCmd(cmd *cobra.Command, args []string, mode string) error {
-	setupErr := setupConfig()
-	if setupErr != nil {
-		return setupErr
+	projectName, perr := getProjectName(config.RootCommandConfig)
+	if perr != nil {
+		if pmsg, ok := perr.(*NotAnAppsodyProject); ok {
+			// Debug.log("Cannot retrieve the project name - continuing: ", perr)
+		} else {
+			Error.logf("Error occurred retrieving project name... exiting: %s", pmsg)
+			os.Exit(1)
+		}
 	}
-	projectDir, perr := getProjectDir()
+	defaultDepsVolume := projectName + "-deps"
+
+	addNameFlag(cmd, &config.containerName, config.RootCommandConfig)
+	cmd.PersistentFlags().StringVar(&config.dockerNetwork, "network", "", "Specify the network for docker to use.")
+	cmd.PersistentFlags().StringVar(&config.depsVolumeName, "deps-volume", defaultDepsVolume, "Docker volume to use for dependencies. Mounts to APPSODY_DEPS dir.")
+	cmd.PersistentFlags().StringArrayVarP(&config.ports, "publish", "p", nil, "Publish the container's ports to the host. The stack's exposed ports will always be published, but you can publish addition ports or override the host ports with this option.")
+	cmd.PersistentFlags().BoolVarP(&config.publishAllPorts, "publish-all", "P", false, "Publish all exposed ports to random ports")
+	cmd.PersistentFlags().BoolVar(&config.disableWatcher, "no-watcher", false, "Disable file watching, regardless of container environment variable settings.")
+	cmd.PersistentFlags().BoolVarP(&config.interactive, "interactive", "i", false, "Attach STDIN to the container for interactive TTY mode")
+	cmd.PersistentFlags().StringVar(&config.dockerOptions, "docker-options", "", "Specify the docker run options to use.  Value must be in \"\".")
+
+}
+
+func commonCmd(config *devCommonConfig, mode string) error {
+
+	projectDir, perr := getProjectDir(config.RootCommandConfig)
 	if perr != nil {
 		return perr
 
 	}
-	projectConfig, configErr := getProjectConfig()
+	projectConfig, configErr := getProjectConfig(config.RootCommandConfig)
 	if configErr != nil {
 		return configErr
 	}
@@ -133,22 +119,22 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 	Debug.log("Project directory: ", projectDir)
 
 	var cmdArgs []string
-	pullErr := pullImage(platformDefinition)
+	pullErr := pullImage(platformDefinition, config.RootCommandConfig)
 	if pullErr != nil {
 		return pullErr
 	}
 
-	volumeMaps, volumeErr := getVolumeArgs()
+	volumeMaps, volumeErr := getVolumeArgs(config.RootCommandConfig)
 	if volumeErr != nil {
 		return volumeErr
 	}
 	// Mount the APPSODY_DEPS cache volume if it exists
-	depsEnvVar, envErr := GetEnvVar("APPSODY_DEPS")
+	depsEnvVar, envErr := GetEnvVar("APPSODY_DEPS", config.RootCommandConfig)
 	if envErr != nil {
 		return envErr
 	}
 	if depsEnvVar != "" {
-		depsMount := depsVolumeName + ":" + depsEnvVar
+		depsMount := config.depsVolumeName + ":" + depsEnvVar
 		Debug.log("Adding dependency cache to volume mounts: ", depsMount)
 		volumeMaps = append(volumeMaps, "-v", depsMount)
 	}
@@ -159,7 +145,7 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 		Debug.log("Overriding appsody-controller mount with APPSODY_MOUNT_CONTROLLER env variable: ", destController)
 	} else {
 		// Copy the controller from the installation directory to the home (.appsody)
-		destController = filepath.Join(getHome(), "appsody-controller")
+		destController = filepath.Join(getHome(config.RootCommandConfig), "appsody-controller")
 		// Debug.log("Attempting to load the controller from ", destController)
 		//if _, err := os.Stat(destController); os.IsNotExist(err) {
 		// Always copy it from the executable dir
@@ -202,7 +188,7 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 
 			//Construct the appsody-controller mount
 			sourceController := filepath.Join(binaryLocation, "appsody-controller")
-			if dryrun {
+			if config.Dryrun {
 				Info.logf("Dry Run - Skipping copy of controller binary from %s to %s", sourceController, destController)
 			} else {
 				Debug.log("Attempting to copy the source controller from: ", sourceController)
@@ -228,7 +214,7 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	go func() {
 		<-c
-		err := dockerStop(containerName)
+		err := dockerStop(config.containerName, config.Dryrun)
 		if err != nil {
 			Error.log(err)
 		}
@@ -236,20 +222,20 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 	}()
 
 	cmdArgs = []string{"--rm"}
-	validPorts, portError := checkPortInput(ports)
+	validPorts, portError := checkPortInput(config.ports)
 	if !validPorts {
 		return errors.Errorf("Ports provided as input to the command are not valid: %v\n", portError)
 	}
 	var portsErr error
-	cmdArgs, portsErr = processPorts(cmdArgs)
+	cmdArgs, portsErr = processPorts(cmdArgs, config)
 	if portsErr != nil {
 		return portsErr
 	}
-	cmdArgs = append(cmdArgs, "--name", containerName)
-	if dockerNetwork != "" {
-		cmdArgs = append(cmdArgs, "--network", dockerNetwork)
+	cmdArgs = append(cmdArgs, "--name", config.containerName)
+	if config.dockerNetwork != "" {
+		cmdArgs = append(cmdArgs, "--network", config.dockerNetwork)
 	}
-	runAsLocal, boolErr := getEnvVarBool("APPSODY_USER_RUN_AS_LOCAL")
+	runAsLocal, boolErr := getEnvVarBool("APPSODY_USER_RUN_AS_LOCAL", config.RootCommandConfig)
 	if boolErr != nil {
 		return boolErr
 	}
@@ -262,7 +248,9 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 	if len(volumeMaps) > 0 {
 		cmdArgs = append(cmdArgs, volumeMaps...)
 	}
-	if dockerOptions != "" {
+	if config.dockerOptions != "" {
+		Debug.logf("User provided Docker options: \"%s\"", config.dockerOptions)
+		dockerOptions := config.dockerOptions
 		dockerOptions = strings.TrimPrefix(dockerOptions, " ")
 		dockerOptions = strings.TrimSuffix(dockerOptions, " ")
 		dockerOptionsCmd := strings.Split(dockerOptions, " ")
@@ -272,19 +260,19 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 		}
 		cmdArgs = append(cmdArgs, dockerOptionsCmd...)
 	}
-	if interactive {
+	if config.interactive {
 		cmdArgs = append(cmdArgs, "-i")
 	}
 	cmdArgs = append(cmdArgs, "-t", "--entrypoint", "/appsody/appsody-controller", platformDefinition, "--mode="+mode)
-	if verbose {
+	if config.Verbose {
 		cmdArgs = append(cmdArgs, "-v")
 	}
-	if disableWatcher {
+	if config.disableWatcher {
 		cmdArgs = append(cmdArgs, "--no-watcher")
 	}
-	Debug.logf("Attempting to start image %s with container name %s", platformDefinition, containerName)
-	execCmd, err := DockerRunAndListen(cmdArgs, Container)
-	if dryrun {
+	Debug.logf("Attempting to start image %s with container name %s", platformDefinition, config.containerName)
+	execCmd, err := DockerRunAndListen(cmdArgs, Container, config.interactive, config.Verbose, config.Dryrun)
+	if config.Dryrun {
 		Info.log("Dry Run - Skipping execCmd.Wait")
 	} else {
 		if err == nil {
@@ -310,18 +298,18 @@ func commonCmd(cmd *cobra.Command, args []string, mode string) error {
 
 }
 
-func processPorts(cmdArgs []string) ([]string, error) {
+func processPorts(cmdArgs []string, config *devCommonConfig) ([]string, error) {
 
 	var exposedPortsMapping []string
 
-	dockerExposedPorts, portsErr := getExposedPorts()
+	dockerExposedPorts, portsErr := getExposedPorts(config.RootCommandConfig)
 	if portsErr != nil {
 		return cmdArgs, portsErr
 	}
 	Debug.log("Exposed ports provided by the docker file", dockerExposedPorts)
 	// if the container port is not in the lised of exposed ports add it to the list
 
-	containerPort, envErr := GetEnvVar("PORT")
+	containerPort, envErr := GetEnvVar("PORT", config.RootCommandConfig)
 	if envErr != nil {
 		return cmdArgs, envErr
 	}
@@ -340,7 +328,7 @@ func processPorts(cmdArgs []string) ([]string, error) {
 		}
 	}
 
-	if publishAllPorts {
+	if config.publishAllPorts {
 		cmdArgs = append(cmdArgs, "-P")
 		// user specified to publish all EXPOSE ports to random ports with -P, so clear this list so we don't add them with -p
 		dockerExposedPorts = []string{}
@@ -350,17 +338,17 @@ func processPorts(cmdArgs []string) ([]string, error) {
 		}
 	}
 
-	Debug.log("Published ports provided as inputs: ", ports)
-	for i := 0; i < len(ports); i++ { // this is the list of input -p's
+	Debug.log("Published ports provided as inputs: ", config.ports)
+	for i := 0; i < len(config.ports); i++ { // this is the list of input -p's
 
-		exposedPortsMapping = append(exposedPortsMapping, ports[i])
+		exposedPortsMapping = append(exposedPortsMapping, config.ports[i])
 
 	}
 	// see if there are any exposed ports (including container port) for which there are no overrides and add those to the list
 	for i := 0; i < len(dockerExposedPorts); i++ {
 		overrideFound := false
-		for j := 0; j < len(ports); j++ {
-			portMapping := strings.Split(ports[j], ":")
+		for j := 0; j < len(config.ports); j++ {
+			portMapping := strings.Split(config.ports[j], ":")
 			if dockerExposedPorts[i] == portMapping[1] {
 				overrideFound = true
 			}

--- a/cmd/docker_commands.go
+++ b/cmd/docker_commands.go
@@ -8,21 +8,21 @@ import (
 	"strings"
 )
 
-func DockerRunAndListen(args []string, logger appsodylogger) (*exec.Cmd, error) {
+func DockerRunAndListen(args []string, logger appsodylogger, interactive bool, verbose bool, dryrun bool) (*exec.Cmd, error) {
 	var runArgs = []string{"run"}
 	runArgs = append(runArgs, args...)
-	return RunDockerCommandAndListen(runArgs, logger)
+	return RunDockerCommandAndListen(runArgs, logger, interactive, verbose, dryrun)
 }
 
-func DockerBuild(args []string, logger appsodylogger) error {
+func DockerBuild(args []string, logger appsodylogger, verbose bool, dryrun bool) error {
 	var buildArgs = []string{"build"}
 	buildArgs = append(buildArgs, args...)
-	return RunDockerCommandAndWait(buildArgs, logger)
+	return RunDockerCommandAndWait(buildArgs, logger, verbose, dryrun)
 }
 
-func RunDockerCommandAndWait(args []string, logger appsodylogger) error {
+func RunDockerCommandAndWait(args []string, logger appsodylogger, verbose bool, dryrun bool) error {
 
-	cmd, err := RunDockerCommandAndListen(args, logger)
+	cmd, err := RunDockerCommandAndListen(args, logger, false, verbose, dryrun)
 	if err != nil {
 		return err
 	}
@@ -35,7 +35,7 @@ func RunDockerCommandAndWait(args []string, logger appsodylogger) error {
 
 }
 
-func RunDockerCommandAndListen(args []string, logger appsodylogger) (*exec.Cmd, error) {
+func RunDockerCommandAndListen(args []string, logger appsodylogger, interactive bool, verbose bool, dryrun bool) (*exec.Cmd, error) {
 	var execCmd *exec.Cmd
 	var command = "docker"
 	var err error
@@ -73,7 +73,7 @@ func RunDockerCommandAndListen(args []string, logger appsodylogger) (*exec.Cmd, 
 			for consoleScanner.Scan() {
 				text := consoleScanner.Text()
 				if lastByteNewline && (verbose || logger != Info) {
-					os.Stdout.WriteString("[" + string(logger) + "] ")
+					os.Stdout.WriteString("[" + logger.name + "] ")
 				}
 				os.Stdout.WriteString(text)
 				lastByteNewline = text == "\n"

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -22,12 +22,11 @@ import (
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
 	"github.com/spf13/cobra/doc"
-	flag "github.com/spf13/pflag"
 )
 
 //generate Doc file (.md) for cmds in package
 
-func generateDoc(commandDocFile string) error {
+func generateDoc(commandDocFile string, rootCmd *cobra.Command) error {
 
 	if commandDocFile == "" {
 		return errors.New("no docFile specified")
@@ -77,21 +76,28 @@ func generateDoc(commandDocFile string) error {
 
 }
 
-// docs command is used to generate markdown file for all the appsody commands
-var docsCmd = &cobra.Command{
-	Use:    "docs",
-	Hidden: true,
-	RunE: func(cmd *cobra.Command, args []string) error {
+func newDocsCmd(rootConfig *RootCommandConfig, rootCmd *cobra.Command) *cobra.Command {
 
-		Debug.log("Running appsody docs command.")
-		err := generateDoc(docFile)
-		if err != nil {
-			return errors.Errorf("appsody docs command failed with error: %v", err)
+	var docFile string
+	// docs command is used to generate markdown file for all the appsody commands
+	var docsCmd = &cobra.Command{
+		Use:    "docs",
+		Hidden: true,
+		RunE: func(cmd *cobra.Command, args []string) error {
 
-		}
-		Debug.log("appsody docs command completed successfully.")
-		return nil
-	},
+			Debug.log("Running appsody docs command.")
+			err := generateDoc(docFile, rootCmd)
+			if err != nil {
+				return errors.Errorf("appsody docs command failed with error: %v", err)
+
+			}
+			Debug.log("appsody docs command completed successfully.")
+			return nil
+		},
+	}
+
+	docsCmd.PersistentFlags().StringVar(&docFile, "docFile", "", "Specify the file to contain the generated documentation.")
+	return docsCmd
 }
 
 func appendChildren(commandArray []*cobra.Command, cmd *cobra.Command) []*cobra.Command {
@@ -113,14 +119,4 @@ func appendChildren(commandArray []*cobra.Command, cmd *cobra.Command) []*cobra.
 		}
 	}
 	return commandArray
-}
-
-var docFile string
-
-func init() {
-	rootCmd.AddCommand(docsCmd)
-	docFlags := flag.NewFlagSet("", flag.ContinueOnError)
-
-	docFlags.StringVar(&docFile, "docFile", "", "Specify the file to contain the generated documentation.")
-	docsCmd.PersistentFlags().AddFlagSet(docFlags)
 }

--- a/cmd/docs.go
+++ b/cmd/docs.go
@@ -47,7 +47,7 @@ func generateDoc(commandDocFile string, rootCmd *cobra.Command) error {
 	}
 
 	defer docFile.Close()
-	preAmble := "---\ntitle: CLI Reference\npath: /docs/using-appsody/cli-commands\n---\n# Appsody CLI\n"
+	preAmble := "---\ntitle: CLI Reference\n---\n\n# Appsody CLI\n"
 	preAmbleBytes := []byte(preAmble)
 	_, preambleErr := docFile.Write(preAmbleBytes)
 	if preambleErr != nil {

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -26,290 +26,298 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var targetDir string
-var buildah bool
-var extractContainerName string
+type extractCommandConfig struct {
+	*RootCommandConfig
+	targetDir            string
+	extractContainerName string
+}
 
-var extractCmd = &cobra.Command{
-	Use:   "extract",
-	Short: "Extract the stack and your Appsody project to a local directory",
-	Long: `This copies the full project, stack plus app, into a local directory
+func newExtractCmd(rootConfig *RootCommandConfig) *cobra.Command {
+	config := &extractCommandConfig{RootCommandConfig: rootConfig}
+
+	var extractCmd = &cobra.Command{
+		Use:   "extract",
+		Short: "Extract the stack and your Appsody project to a local directory",
+		Long: `This copies the full project, stack plus app, into a local directory
 in preparation to build the final container image.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return extract(config)
+		},
+	}
 
-		setupErr := setupConfig()
-		if setupErr != nil {
-			return setupErr
-		}
-		projectName, perr := getProjectName()
-		if perr != nil {
-			return errors.Errorf("%v", perr)
-		}
-		projectConfig, projectErr := getProjectConfig()
-		if projectErr != nil {
-			return projectErr
-		}
-		Info.log("Extracting project from development environment")
+	extractCmd.PersistentFlags().StringVar(&config.targetDir, "target-dir", "", "Directory path to place the extracted files. This dir must not exist, it will be created.")
+	extractCmd.PersistentFlags().BoolVar(&rootConfig.Buildah, "buildah", false, "Extract project using buildah primitives instead of docker.")
+	defaultName := defaultExtractContainerName(rootConfig)
+	extractCmd.PersistentFlags().StringVar(&config.extractContainerName, "name", defaultName, "Assign a name to your development container.")
+	return extractCmd
+}
 
-		if targetDir != "" {
-			// the user specified a target dir, quit if it already exists
-			targetDir, _ = filepath.Abs(targetDir)
-			Debug.log("Checking if target-dir exists: ", targetDir)
-			targetExists, err := Exists(targetDir)
-			if err != nil {
-				return errors.Errorf("Error checking target directory: %v", err)
-			}
-			if targetExists {
-				return errors.Errorf("Cannot extract to an existing target-dir: %s", targetDir)
+func extract(config *extractCommandConfig) error {
+	extractContainerName := config.extractContainerName
+	if extractContainerName == "" {
+		extractContainerName = defaultExtractContainerName(config.RootCommandConfig)
+	}
 
-			}
-			targetDirParent := filepath.Dir(targetDir)
-			targetDirParentExists, err := Exists(targetDirParent)
-			if err != nil {
-				return errors.Errorf("Error checking directory: %v", err)
-			}
-			if !targetDirParentExists {
-				return errors.Errorf("%s does not exist", targetDirParent)
-			}
+	projectName, perr := getProjectName(config.RootCommandConfig)
+	if perr != nil {
+		return errors.Errorf("%v", perr)
+	}
+	projectConfig, projectErr := getProjectConfig(config.RootCommandConfig)
+	if projectErr != nil {
+		return projectErr
+	}
+	Info.log("Extracting project from development environment")
+
+	targetDir := config.targetDir
+	if targetDir != "" {
+		// the user specified a target dir, quit if it already exists
+		targetDir, _ = filepath.Abs(targetDir)
+		Debug.log("Checking if target-dir exists: ", targetDir)
+		targetExists, err := Exists(targetDir)
+		if err != nil {
+			return errors.Errorf("Error checking target directory: %v", err)
 		}
+		if targetExists {
+			return errors.Errorf("Cannot extract to an existing target-dir: %s", targetDir)
 
-		extractDir := filepath.Join(getHome(), "extract")
-		extractDirExists, err := Exists(extractDir)
+		}
+		targetDirParent := filepath.Dir(targetDir)
+		targetDirParentExists, err := Exists(targetDirParent)
 		if err != nil {
 			return errors.Errorf("Error checking directory: %v", err)
 		}
-		if !extractDirExists {
-			if dryrun {
-				Info.log("Dry Run - Skip creating extract dir: ", extractDir)
-			} else {
-				Debug.log("Creating extract dir: ", extractDir)
-				err = os.MkdirAll(extractDir, os.ModePerm)
-				if err != nil {
-					return errors.Errorf("Error creating directories %s %v", extractDir, err)
-				}
-			}
+		if !targetDirParentExists {
+			return errors.Errorf("%s does not exist", targetDirParent)
 		}
-		extractDir = filepath.Join(extractDir, projectName)
-		extractDirExists, err = Exists(extractDir)
-		if err != nil {
-			return errors.Errorf("Error checking directory: %v", err)
-		}
-		if extractDirExists {
-			if dryrun {
-				Info.log("Dry Run - Skip deleting extract dir: ", extractDir)
-			} else {
-				Debug.log("Deleting extract dir: ", extractDir)
-				os.RemoveAll(extractDir)
-			}
-		}
+	}
 
-		if buildah {
-			// Buildah fails if the destination does not exist.
+	extractDir := filepath.Join(getHome(config.RootCommandConfig), "extract")
+	extractDirExists, err := Exists(extractDir)
+	if err != nil {
+		return errors.Errorf("Error checking directory: %v", err)
+	}
+	if !extractDirExists {
+		if config.Dryrun {
+			Info.log("Dry Run - Skip creating extract dir: ", extractDir)
+		} else {
 			Debug.log("Creating extract dir: ", extractDir)
 			err = os.MkdirAll(extractDir, os.ModePerm)
 			if err != nil {
 				return errors.Errorf("Error creating directories %s %v", extractDir, err)
 			}
 		}
-
-		stackImage := projectConfig.Platform
-
-		pullErr := pullImage(stackImage)
-		if pullErr != nil {
-			return pullErr
-		}
-
-		containerProjectDir, containerProjectDirErr := getExtractDir()
-		if containerProjectDirErr != nil {
-			return containerProjectDirErr
-		}
-		Debug.log("Container project dir: ", containerProjectDir)
-
-		volumeMaps, volumeErr := getVolumeArgs()
-		if volumeErr != nil {
-			return volumeErr
-		}
-		cmdName := "docker"
-		if buildah {
-			cmdName = "buildah"
-		}
-		var appDir string
-		cmdArgs := []string{"--name", extractContainerName}
-		if len(volumeMaps) > 0 {
-			cmdArgs = append(cmdArgs, volumeMaps...)
-		}
-
-		if runtime.GOOS != "windows" {
-			// On Linux and OS/X we run docker create or buildah from
-			if buildah {
-				cmdArgs = append([]string{"from"}, cmdArgs...)
-			} else {
-				cmdArgs = append([]string{"create"}, cmdArgs...)
-			}
-			cmdArgs = append(cmdArgs, stackImage)
-			err = execAndWaitReturnErr(cmdName, cmdArgs, Debug)
-			if err != nil {
-
-				if buildah {
-					Error.log("buildah from command failed: ", err)
-				} else {
-					Error.log("docker create command failed: ", err)
-				}
-				removeErr := containerRemove(extractContainerName)
-				Error.log("Error in containerRemove", removeErr)
-				return err
-
-			}
-			appDir = extractContainerName + ":" + containerProjectDir
-
+	}
+	extractDir = filepath.Join(extractDir, projectName)
+	extractDirExists, err = Exists(extractDir)
+	if err != nil {
+		return errors.Errorf("Error checking directory: %v", err)
+	}
+	if extractDirExists {
+		if config.Dryrun {
+			Info.log("Dry Run - Skip deleting extract dir: ", extractDir)
 		} else {
-			// On Windows, we need to run the container to copy of the /project dir in /tmp/project
-			// and navigate all the symlinks using cp -rL
-			// then extract /tmp/project and remove the container
-
-			bashCmd := "cp -rfL " + filepath.ToSlash(containerProjectDir) + " " + filepath.ToSlash(filepath.Join("/tmp", containerProjectDir))
-
-			Debug.log("Attempting to run ", bashCmd, " on image: ", stackImage, " with args: ", cmdArgs)
-			_, err = DockerRunBashCmd(cmdArgs, stackImage, bashCmd)
-			if err != nil {
-				Debug.log("Error attempting to run copy command ", bashCmd, " on image ", stackImage, ": ", err)
-
-				removeErr := containerRemove(extractContainerName)
-				if removeErr != nil {
-					Error.log("containerRemove error ", removeErr)
-				}
-
-				return errors.Errorf("Error attempting to run copy command %s on image %s: %v", bashCmd, stackImage, err)
-
-			}
-			//If everything went fine, we need to set the source project directory to /tmp/...
-			appDir = extractContainerName + ":" + filepath.Join("/tmp", containerProjectDir)
+			Debug.log("Deleting extract dir: ", extractDir)
+			os.RemoveAll(extractDir)
 		}
-		cmdArgs = []string{"cp", appDir, extractDir}
-		if buildah {
-			appDir = containerProjectDir
-			cmdName = "/bin/sh"
-			script := fmt.Sprintf("x=`buildah mount %s`; cp -rf $x/%s/* %s", extractContainerName, appDir, extractDir)
-			cmdArgs = []string{"-c", script}
-		}
-		err = execAndWaitReturnErr(cmdName, cmdArgs, Debug)
+	}
+
+	if config.Buildah {
+		// Buildah fails if the destination does not exist.
+		Debug.log("Creating extract dir: ", extractDir)
+		err = os.MkdirAll(extractDir, os.ModePerm)
 		if err != nil {
-			if buildah {
-				Error.log("buildah mount / copy command failed: ", err)
-			} else {
-				Error.log("docker cp command failed: ", err)
-			}
+			return errors.Errorf("Error creating directories %s %v", extractDir, err)
+		}
+	}
 
-			removeErr := containerRemove(extractContainerName)
+	stackImage := projectConfig.Platform
+
+	pullErr := pullImage(stackImage, config.RootCommandConfig)
+	if pullErr != nil {
+		return pullErr
+	}
+
+	containerProjectDir, containerProjectDirErr := getExtractDir(config.RootCommandConfig)
+	if containerProjectDirErr != nil {
+		return containerProjectDirErr
+	}
+	Debug.log("Container project dir: ", containerProjectDir)
+
+	volumeMaps, volumeErr := getVolumeArgs(config.RootCommandConfig)
+	if volumeErr != nil {
+		return volumeErr
+	}
+	cmdName := "docker"
+	if config.Buildah {
+		cmdName = "buildah"
+	}
+	var appDir string
+	cmdArgs := []string{"--name", extractContainerName}
+	if len(volumeMaps) > 0 {
+		cmdArgs = append(cmdArgs, volumeMaps...)
+	}
+
+	if runtime.GOOS != "windows" {
+		// On Linux and OS/X we run docker create or buildah from
+		if config.Buildah {
+			cmdArgs = append([]string{"from"}, cmdArgs...)
+		} else {
+			cmdArgs = append([]string{"create"}, cmdArgs...)
+		}
+		cmdArgs = append(cmdArgs, stackImage)
+		err = execAndWaitReturnErr(cmdName, cmdArgs, Debug, config.Dryrun)
+		if err != nil {
+
+			if config.Buildah {
+				Error.log("buildah from command failed: ", err)
+			} else {
+				Error.log("docker create command failed: ", err)
+			}
+			removeErr := containerRemove(extractContainerName, config.Buildah, config.Dryrun)
+			Error.log("Error in containerRemove", removeErr)
+			return err
+
+		}
+		appDir = extractContainerName + ":" + containerProjectDir
+
+	} else {
+		// On Windows, we need to run the container to copy of the /project dir in /tmp/project
+		// and navigate all the symlinks using cp -rL
+		// then extract /tmp/project and remove the container
+
+		bashCmd := "cp -rfL " + filepath.ToSlash(containerProjectDir) + " " + filepath.ToSlash(filepath.Join("/tmp", containerProjectDir))
+
+		Debug.log("Attempting to run ", bashCmd, " on image: ", stackImage, " with args: ", cmdArgs)
+		_, err = DockerRunBashCmd(cmdArgs, stackImage, bashCmd, config.RootCommandConfig)
+		if err != nil {
+			Debug.log("Error attempting to run copy command ", bashCmd, " on image ", stackImage, ": ", err)
+
+			removeErr := containerRemove(extractContainerName, config.Buildah, config.Dryrun)
 			if removeErr != nil {
 				Error.log("containerRemove error ", removeErr)
 			}
-			if buildah {
-				return errors.Errorf("buildah mount / copy command failed: %v", err)
-			}
-			return errors.Errorf("docker cp command failed: %v", err)
+
+			return errors.Errorf("Error attempting to run copy command %s on image %s: %v", bashCmd, stackImage, err)
+
+		}
+		//If everything went fine, we need to set the source project directory to /tmp/...
+		appDir = extractContainerName + ":" + filepath.Join("/tmp", containerProjectDir)
+	}
+	cmdArgs = []string{"cp", appDir, extractDir}
+	if config.Buildah {
+		appDir = containerProjectDir
+		cmdName = "/bin/sh"
+		script := fmt.Sprintf("x=`buildah mount %s`; cp -rf $x/%s/* %s", extractContainerName, appDir, extractDir)
+		cmdArgs = []string{"-c", script}
+	}
+	err = execAndWaitReturnErr(cmdName, cmdArgs, Debug, config.Dryrun)
+	if err != nil {
+		if config.Buildah {
+			Error.log("buildah mount / copy command failed: ", err)
+		} else {
+			Error.log("docker cp command failed: ", err)
 		}
 
-		// A class of systems (e.g:- RHEL 7.6) exhibit situations wherein
-		// the bindmount volumes are not propagated to the child containers
-		// Accommodate those systems as well, by performing local copies
-		// for the locations that are resident in the host.
-		// ref: https://github.com/containers/buildah/issues/1821
-		if buildah {
-			for _, item := range volumeMaps {
-				if strings.Contains(item, ":") {
-					Debug.log("Appsody mount: ", item)
-					var src = strings.Split(item, ":")[0]
-					var dest = strings.Split(item, ":")[1]
-					if strings.EqualFold(src, ".") {
-						src, err = os.Getwd()
-						if err != nil {
-							return errors.Errorf("Error getting cwd: %v", err)
-						}
-					}
-					dest = strings.Replace(dest, appDir, extractDir, -1)
-					Debug.log("Local-adjusted mount destination: ", dest)
-					fileInfo, err := os.Lstat(src)
-					if err != nil {
-						return errors.Errorf("Error lstat: %v", err)
-					}
-					var mkdir string
-					if fileInfo.IsDir() {
-						mkdir = dest
-					} else {
-						mkdir = filepath.Dir(dest)
-					}
-					err = os.MkdirAll(mkdir, os.ModePerm)
-					if err != nil {
-						return errors.Errorf("Error creating directories %s %v", extractDir, err)
-					}
-
-					fileInfo, err = os.Lstat(src)
-					if err != nil {
-						return errors.Errorf("project file check error %v", err)
-					}
-					Debug.log("Copy source: ", src)
-					Debug.log("Copy destination: ", dest)
-					if fileInfo.IsDir() {
-						err = copyDir(src+"/.", dest)
-						if err != nil {
-							return errors.Errorf("folder copy error %v", err)
-						}
-					} else {
-						err = CopyFile(src, dest)
-						if err != nil {
-							return errors.Errorf("file copy error %v", err)
-						}
-					}
-					Debug.log("Copied ", src, " to ", dest)
-				}
-			}
-		}
-
-		removeErr := containerRemove(extractContainerName)
+		removeErr := containerRemove(extractContainerName, config.Buildah, config.Dryrun)
 		if removeErr != nil {
 			Error.log("containerRemove error ", removeErr)
 		}
-		if targetDir == "" {
-			if !dryrun {
-				Info.log("Project extracted to ", extractDir)
-			}
-		} else {
-			if dryrun {
-				Info.log("Dry Run - Skip moving ", extractDir, " to ", targetDir)
-			} else {
-				err = MoveDir(extractDir, targetDir)
-				if err != nil {
-					return errors.Errorf("Extract failed when moving %s to %s %v", extractDir, targetDir, err)
+		if config.Buildah {
+			return errors.Errorf("buildah mount / copy command failed: %v", err)
+		}
+		return errors.Errorf("docker cp command failed: %v", err)
+	}
 
+	// A class of systems (e.g:- RHEL 7.6) exhibit situations wherein
+	// the bindmount volumes are not propagated to the child containers
+	// Accommodate those systems as well, by performing local copies
+	// for the locations that are resident in the host.
+	// ref: https://github.com/containers/buildah/issues/1821
+	if config.Buildah {
+		for _, item := range volumeMaps {
+			if strings.Contains(item, ":") {
+				Debug.log("Appsody mount: ", item)
+				var src = strings.Split(item, ":")[0]
+				var dest = strings.Split(item, ":")[1]
+				if strings.EqualFold(src, ".") {
+					// This should probably be using config.ProjectDir instead of os.Getwd()
+					src, err = os.Getwd()
+					if err != nil {
+						return errors.Errorf("Error getting cwd: %v", err)
+					}
 				}
-				Info.log("Project extracted to ", targetDir)
+				dest = strings.Replace(dest, appDir, extractDir, -1)
+				Debug.log("Local-adjusted mount destination: ", dest)
+				fileInfo, err := os.Lstat(src)
+				if err != nil {
+					return errors.Errorf("Error lstat: %v", err)
+				}
+				var mkdir string
+				if fileInfo.IsDir() {
+					mkdir = dest
+				} else {
+					mkdir = filepath.Dir(dest)
+				}
+				err = os.MkdirAll(mkdir, os.ModePerm)
+				if err != nil {
+					return errors.Errorf("Error creating directories %s %v", extractDir, err)
+				}
+
+				fileInfo, err = os.Lstat(src)
+				if err != nil {
+					return errors.Errorf("project file check error %v", err)
+				}
+				Debug.log("Copy source: ", src)
+				Debug.log("Copy destination: ", dest)
+				if fileInfo.IsDir() {
+					err = copyDir(src+"/.", dest)
+					if err != nil {
+						return errors.Errorf("folder copy error %v", err)
+					}
+				} else {
+					err = CopyFile(src, dest)
+					if err != nil {
+						return errors.Errorf("file copy error %v", err)
+					}
+				}
+				Debug.log("Copied ", src, " to ", dest)
 			}
 		}
-		return nil
-	},
+	}
+
+	removeErr := containerRemove(extractContainerName, config.Buildah, config.Dryrun)
+	if removeErr != nil {
+		Error.log("containerRemove error ", removeErr)
+	}
+	if targetDir == "" {
+		if !config.Dryrun {
+			Info.log("Project extracted to ", extractDir)
+		}
+	} else {
+		if config.Dryrun {
+			Info.log("Dry Run - Skip moving ", extractDir, " to ", targetDir)
+		} else {
+			err = MoveDir(extractDir, targetDir)
+			if err != nil {
+				return errors.Errorf("Extract failed when moving %s to %s %v", extractDir, targetDir, err)
+
+			}
+			Info.log("Project extracted to ", targetDir)
+		}
+	}
+	return nil
 }
 
-func init() {
-	rootCmd.AddCommand(extractCmd)
-	extractCmd.PersistentFlags().StringVar(&targetDir, "target-dir", "", "Directory path to place the extracted files. This dir must not exist, it will be created.")
-	extractCmd.PersistentFlags().BoolVar(&buildah, "buildah", false, "Extract project using buildah primitives instead of docker.")
-	// curDir, err := os.Getwd()
-	// if err != nil {
-	//		Error.log("Error getting current directory ", err)
-	//	os.Exit(1)
-	//}
-	//defaultName := filepath.Base(curDir) + "-extract"
-	projectName, perr := getProjectName()
+func defaultExtractContainerName(config *RootCommandConfig) string {
+	projectName, perr := getProjectName(config)
 
 	if perr != nil {
 		if pmsg, ok := perr.(*NotAnAppsodyProject); ok {
-			Debug.log("Cannot retrieve the project name - continuing: ", perr)
+			//Debug.log("Cannot retrieve the project name - continuing: ", perr)
 		} else {
 			Error.log("Error occurred retrieving project name... exiting: ", pmsg)
 			os.Exit(1)
 		}
 	}
-	defaultName := projectName + "-extract"
-	extractCmd.PersistentFlags().StringVar(&extractContainerName, "name", defaultName, "Assign a name to your development container.")
+	return projectName + "-extract"
 }

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -31,19 +31,24 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
+type initCommandConfig struct {
+	*RootCommandConfig
 	overwrite  bool
 	noTemplate bool
-)
+}
+
+// these are global constants
 var whiteListDotDirectories = []string{"github", "vscode", "settings", "metadata"}
 var whiteListDotFiles = []string{"git", "project", "DS_Store", "classpath", "factorypath", "gitattributes", "gitignore", "cw-settings", "cw-extension"}
 
-// initCmd represents the init command
+func newInitCmd(rootConfig *RootCommandConfig) *cobra.Command {
+	config := &initCommandConfig{RootCommandConfig: rootConfig}
 
-var initCmd = &cobra.Command{
-	Use:   "init [stack] or [repository]/[stack] [template]",
-	Short: "Initialize an Appsody project with a stack and template app",
-	Long: `This creates a new Appsody project in a local directory or sets up the local dev environment of an existing Appsody project.
+	// initCmd represents the init command
+	var initCmd = &cobra.Command{
+		Use:   "init [stack] or [repository]/[stack] [template]",
+		Short: "Initialize an Appsody project with a stack and template app",
+		Long: `This creates a new Appsody project in a local directory or sets up the local dev environment of an existing Appsody project.
 
 If the [repository] is not specified the default repository will be used. If no [template] is specified, the default template will be used.
 With the [stack], [repository]/[stack], [stack] [template] or [repository]/[stack] [template] arguments, this command will setup a new Appsody project. It will create an Appsody stack config file, unzip a template app, and run the stack init script to setup the local dev environment. It is typically run on an empty directory and may fail
@@ -54,197 +59,203 @@ If keyword "none" is specified instead of a [template], the project will be init
 
 Without the [stack] argument, this command must be run on an existing Appsody project and will only run the stack init script to
 setup the local dev environment.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		setupErr := setupConfig()
-		if setupErr != nil {
-			return setupErr
-		}
-		if noTemplate {
-			Warning.log("The --no-template flag has been deprecated.  Please specify a template value of \"none\" instead.")
-		}
-		//var index RepoIndex
-		var repos RepositoryFile
-		if _, err := repos.getRepos(); err != nil {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var stack string
+			var template string
+			if len(args) >= 1 {
+				stack = args[0]
+			}
+			if len(args) >= 2 {
+				template = args[1]
+			}
+			return initAppsody(stack, template, config)
+		},
+	}
+
+	initCmd.PersistentFlags().BoolVar(&config.overwrite, "overwrite", false, "Download and extract the template project, overwriting existing files.  This option is not intended to be used in Appsody project directories.")
+	initCmd.PersistentFlags().BoolVar(&config.noTemplate, "no-template", false, "Only create the .appsody-config.yaml file. Do not unzip the template project. [Deprecated]")
+	return initCmd
+}
+
+func initAppsody(stack string, template string, config *initCommandConfig) error {
+
+	noTemplate := config.noTemplate
+	if noTemplate {
+		Warning.log("The --no-template flag has been deprecated.  Please specify a template value of \"none\" instead.")
+	}
+	//var index RepoIndex
+	var repos RepositoryFile
+	if _, err := repos.getRepos(config.RootCommandConfig); err != nil {
+		return err
+	}
+	var proceedWithTemplate bool
+
+	err := CheckPrereqs()
+	if err != nil {
+		Warning.logf("Failed to check prerequisites: %v\n", err)
+	}
+
+	//err = index.getIndex()
+
+	indices, err := repos.GetIndices()
+
+	if err != nil {
+		Error.logf("The following indices could not be read, skipping:\n%v", err)
+	}
+	if len(indices) == 0 {
+		return errors.Errorf("Your stack repository is empty - please use `appsody repo add` to add a repository.")
+	}
+	var index *RepoIndex
+
+	if stack != "" {
+		var projectName string
+		projectParm := stack
+
+		repoName, projectType, err := parseProjectParm(projectParm, config.RootCommandConfig)
+		if err != nil {
 			return err
 		}
-		var proceedWithTemplate bool
+		if !repos.Has(repoName) {
+			return errors.Errorf("Repository %s is not in configured list of repositories", repoName)
+		}
+		var templateName string
+		var inputTemplateName string
+		if template != "" {
 
-		err := CheckPrereqs()
-		if err != nil {
-			Warning.logf("Failed to check prerequisites: %v\n", err)
+			inputTemplateName = template
+			if inputTemplateName == "none" {
+				noTemplate = true
+			}
+
 		}
 
-		//err = index.getIndex()
+		templateName = inputTemplateName // so we can keep track
 
-		indices, err := repos.GetIndices()
+		Debug.log("Attempting to locate stack ", projectType, " in repo ", repoName)
+		index = indices[repoName]
+		projectFound := false
+		stackFound := false
 
-		if err != nil {
-			Error.logf("The following indices could not be read, skipping:\n%v", err)
+		if strings.Compare(index.APIVersion, supportedIndexAPIVersion) == 1 {
+			Warning.log("The repository .yaml for " + repoName + " has a more recent APIVersion than the current Appsody CLI supports (" + supportedIndexAPIVersion + "), it is strongly suggested that you update your Appsody CLI to the latest version.")
 		}
-		if len(indices) == 0 {
-			return errors.Errorf("Your stack repository is empty - please use `appsody repo add` to add a repository.")
+		if len(index.Projects[projectType]) >= 1 { //V1 repos
+			projectFound = true
+			//return errors.Errorf("Could not find a stack with the id \"%s\" in repository \"%s\". Run `appsody list` to see the available stacks or -h for help.", projectType, repoName)
+			Debug.log("Project ", projectType, " found in repo ", repoName)
+
+			// need to check template name vs default
+			if !noTemplate && !(templateName == "" || templateName == index.Projects[projectType][0].DefaultTemplate) {
+				return errors.Errorf("template name is not \"none\" and does not match %s.", index.Projects[projectType][0].DefaultTemplate)
+			}
+			projectName = index.Projects[projectType][0].URLs[0]
+
 		}
-		var index *RepoIndex
+		for _, stack := range index.Stacks {
+			if stack.ID == projectType {
+				stackFound = true
+				Debug.log("Stack ", projectType, " found in repo ", repoName)
+				URL := ""
+				if templateName == "" || templateName == "none" {
+					templateName = stack.DefaultTemplate
+					if templateName == "" {
+						return errors.Errorf("Cannot proceed, no template or \"none\" was specified and there is no default template.")
+					}
+				}
+				URL = findTemplateURL(stack, templateName)
 
-		if len(args) >= 1 {
-			var projectName string
-			projectParm := args[0]
+				projectName = URL
+			}
+		}
+		if !projectFound && !stackFound {
+			return errors.Errorf("Could not find a stack with the id \"%s\" in repository \"%s\". Run `appsody list` to see the available stacks or -h for help.", projectType, repoName)
+		}
 
-			repoName, projectType, err := parseProjectParm(projectParm)
+		if projectName == "" && inputTemplateName != "none" {
+			return errors.Errorf("Could not find a template \"%s\" for stack id \"%s\" in repository \"%s\"", templateName, projectType, repoName)
+		}
+
+		// 1. Check for empty directory
+		dir := config.ProjectDir
+		appsodyConfigFile := filepath.Join(dir, ".appsody-config.yaml")
+
+		_, err = os.Stat(appsodyConfigFile)
+		if err == nil {
+			return errors.New("cannot run `appsody init <stack>` on an existing appsody project")
+
+		}
+
+		if noTemplate && !(inputTemplateName == "" || inputTemplateName == "none") {
+
+			return errors.Errorf("cannot specify `appsody init <stack> <template>` with both a template and --no-template")
+
+		}
+
+		if noTemplate || config.overwrite {
+			proceedWithTemplate = true
+		} else {
+			proceedWithTemplate, err = isFileLaydownSafe(dir)
 			if err != nil {
 				return err
 			}
-			if !repos.Has(repoName) {
-				return errors.Errorf("Repository %s is not in configured list of repositories", repoName)
-			}
-			var templateName string
-			var inputTemplateName string
-			if len(args) >= 2 {
+		}
 
-				inputTemplateName = args[1]
-				if inputTemplateName == "none" {
-					noTemplate = true
-				}
-
-			}
-
-			templateName = inputTemplateName // so we can keep track
-
-			Debug.log("Attempting to locate stack ", projectType, " in repo ", repoName)
-			index = indices[repoName]
-			projectFound := false
-			stackFound := false
-
-			if strings.Compare(index.APIVersion, supportedIndexAPIVersion) == 1 {
-				Warning.log("The repository .yaml for " + repoName + " has a more recent APIVersion than the current Appsody CLI supports (" + supportedIndexAPIVersion + "), it is strongly suggested that you update your Appsody CLI to the latest version.")
-			}
-			if len(index.Projects[projectType]) >= 1 { //V1 repos
-				projectFound = true
-				//return errors.Errorf("Could not find a stack with the id \"%s\" in repository \"%s\". Run `appsody list` to see the available stacks or -h for help.", projectType, repoName)
-				Debug.log("Project ", projectType, " found in repo ", repoName)
-
-				// need to check template name vs default
-				if !noTemplate && !(templateName == "" || templateName == index.Projects[projectType][0].DefaultTemplate) {
-					return errors.Errorf("template name is not \"none\" and does not match %s.", index.Projects[projectType][0].DefaultTemplate)
-				}
-				projectName = index.Projects[projectType][0].URLs[0]
-
-			}
-			for _, stack := range index.Stacks {
-				if stack.ID == projectType {
-					stackFound = true
-					Debug.log("Stack ", projectType, " found in repo ", repoName)
-					URL := ""
-					if templateName == "" || templateName == "none" {
-						templateName = stack.DefaultTemplate
-						if templateName == "" {
-							return errors.Errorf("Cannot proceed, no template or \"none\" was specified and there is no default template.")
-						}
-					}
-					URL = findTemplateURL(stack, templateName)
-
-					projectName = URL
-				}
-			}
-			if !projectFound && !stackFound {
-				return errors.Errorf("Could not find a stack with the id \"%s\" in repository \"%s\". Run `appsody list` to see the available stacks or -h for help.", projectType, repoName)
-			}
-
-			if projectName == "" && inputTemplateName != "none" {
-				return errors.Errorf("Could not find a template \"%s\" for stack id \"%s\" in repository \"%s\"", templateName, projectType, repoName)
-			}
-
-			// 1. Check for empty directory
-			dir, err := os.Getwd()
-			if err != nil {
-				return errors.Errorf("Error getting current directory %v", err)
-			}
-			appsodyConfigFile := filepath.Join(dir, ".appsody-config.yaml")
-
-			_, err = os.Stat(appsodyConfigFile)
-			if err == nil {
-				return errors.New("cannot run `appsody init <stack>` on an existing appsody project")
-
-			}
-
-			if noTemplate && !(inputTemplateName == "" || inputTemplateName == "none") {
-
-				return errors.Errorf("cannot specify `appsody init <stack> <template>` with both a template and --no-template")
-
-			}
-
-			if noTemplate || overwrite {
-				proceedWithTemplate = true
-			} else {
-				proceedWithTemplate, err = isFileLaydownSafe(dir)
-				if err != nil {
-					return err
-				}
-			}
-
-			if !overwrite && !proceedWithTemplate {
-				Error.log("Non-empty directory found with files which may conflict with the template project.")
-				Info.log("It is recommended that you run `appsody init <stack>` in an empty directory.")
-				Info.log("If you wish to proceed and possibly overwrite files in the current directory, try again with the --overwrite option.")
-				return errors.New("non-empty directory found with files which may conflict with the template project")
-
-			}
-
-			Info.log("Running appsody init...")
-			Info.logf("Downloading %s template project from %s", projectType, projectName)
-			filename := projectType + ".tar.gz"
-
-			err = downloadFileToDisk(projectName, filename)
-			if err != nil {
-				return errors.Errorf("Error downloading tar %v", err)
-
-			}
-			Info.log("Download complete. Extracting files from ", filename)
-			//if noTemplate
-			errUntar := untar(filename, noTemplate)
-
-			if dryrun {
-				Info.logf("Dry Run - Skipping remove of temporary file for project type: %s project name: %s", projectType, projectName)
-			} else {
-				err = os.Remove(filename)
-				if err != nil {
-					Warning.log("Unable to remove temporary file ", filename)
-				}
-			}
-			if errUntar != nil {
-				Error.log("Error extracting project template: ", errUntar)
-				Info.log("It is recommended that you run `appsody init <stack>` in an empty directory.")
-				Info.log("If you wish to proceed and overwrite files in the current directory, try again with the --overwrite option.")
-				// this leave the tar file in the dir
-				return errors.Errorf("Error extracting project template: %v", errUntar)
-
-			}
+		if !config.overwrite && !proceedWithTemplate {
+			Error.log("Non-empty directory found with files which may conflict with the template project.")
+			Info.log("It is recommended that you run `appsody init <stack>` in an empty directory.")
+			Info.log("If you wish to proceed and possibly overwrite files in the current directory, try again with the --overwrite option.")
+			return errors.New("non-empty directory found with files which may conflict with the template project")
 
 		}
-		err = install()
+
+		Info.log("Running appsody init...")
+		Info.logf("Downloading %s template project from %s", projectType, projectName)
+		filename := projectType + ".tar.gz"
+
+		err = downloadFileToDisk(projectName, filename, config.Dryrun)
 		if err != nil {
-			return err
-		}
-		Info.log("Successfully initialized Appsody project")
-		return nil
-	},
-}
+			return errors.Errorf("Error downloading tar %v", err)
 
-func init() {
-	rootCmd.AddCommand(initCmd)
-	initCmd.PersistentFlags().BoolVar(&overwrite, "overwrite", false, "Download and extract the template project, overwriting existing files.  This option is not intended to be used in Appsody project directories.")
-	initCmd.PersistentFlags().BoolVar(&noTemplate, "no-template", false, "Only create the .appsody-config.yaml file. Do not unzip the template project. [Deprecated]")
+		}
+		Info.log("Download complete. Extracting files from ", filename)
+		//if noTemplate
+		errUntar := untar(filename, noTemplate, config.overwrite, config.Dryrun)
+
+		if config.Dryrun {
+			Info.logf("Dry Run - Skipping remove of temporary file for project type: %s project name: %s", projectType, projectName)
+		} else {
+			err = os.Remove(filename)
+			if err != nil {
+				Warning.log("Unable to remove temporary file ", filename)
+			}
+		}
+		if errUntar != nil {
+			Error.log("Error extracting project template: ", errUntar)
+			Info.log("It is recommended that you run `appsody init <stack>` in an empty directory.")
+			Info.log("If you wish to proceed and overwrite files in the current directory, try again with the --overwrite option.")
+			// this leave the tar file in the dir
+			return errors.Errorf("Error extracting project template: %v", errUntar)
+
+		}
+
+	}
+	err = install(config)
+	if err != nil {
+		return err
+	}
+	Info.log("Successfully initialized Appsody project")
+	return nil
 }
 
 //Runs the .appsody-init.sh/bat files if necessary
-func install() error {
+func install(config *initCommandConfig) error {
 	Info.log("Setting up the development environment")
-	projectDir, perr := getProjectDir()
+	projectDir, perr := getProjectDir(config.RootCommandConfig)
 	if perr != nil {
 		return errors.Errorf("%v", perr)
 
 	}
-	projectConfig, configErr := getProjectConfig()
+	projectConfig, configErr := getProjectConfig(config.RootCommandConfig)
 	if configErr != nil {
 		return configErr
 	}
@@ -252,7 +263,7 @@ func install() error {
 
 	Debug.logf("Setting up the development environment for projectDir: %s and platform: %s", projectDir, platformDefinition)
 
-	err := extractAndInitialize()
+	err := extractAndInitialize(config)
 	if err != nil {
 		// For some reason without this sleep, the [InitScript] output log would get cut off and
 		// intermixed with the following Warning logs when verbose logging. Adding this sleep as a workaround.
@@ -265,7 +276,7 @@ func install() error {
 	return nil
 }
 
-func downloadFileToDisk(url string, destFile string) error {
+func downloadFileToDisk(url string, destFile string, dryrun bool) error {
 	if dryrun {
 		Info.logf("Dry Run -Skipping download of url: %s to destination %s", url, destFile)
 
@@ -284,7 +295,7 @@ func downloadFileToDisk(url string, destFile string) error {
 	return nil
 }
 
-func untar(file string, noTemplate bool) error {
+func untar(file string, noTemplate bool, overwrite bool, dryrun bool) error {
 
 	if dryrun {
 		Info.log("Dry Run - Skipping untar of file:  ", file)
@@ -448,7 +459,7 @@ func preCheckTar(file string) error {
 	}
 	return err
 }
-func extractAndInitialize() error {
+func extractAndInitialize(config *initCommandConfig) error {
 
 	var err error
 
@@ -461,12 +472,12 @@ func extractAndInitialize() error {
 	//Determine if we need to run extract
 	//We run it only if there is an initialization script to run locally
 	//Checking if the script is present on the image
-	projectConfig, configErr := getProjectConfig()
+	projectConfig, configErr := getProjectConfig(config.RootCommandConfig)
 	if configErr != nil {
 		return configErr
 	}
 	stackImage := projectConfig.Platform
-	containerProjectDir, containerProjectDirErr := getExtractDir()
+	containerProjectDir, containerProjectDirErr := getExtractDir(config.RootCommandConfig)
 	if containerProjectDirErr != nil {
 		return containerProjectDirErr
 	}
@@ -474,7 +485,7 @@ func extractAndInitialize() error {
 	cmdOptions := []string{"--rm"}
 	Debug.log("Attempting to run ", bashCmd, " on image ", stackImage, " with options: ", cmdOptions)
 	//DockerRunBashCmd has a pullImage call
-	scriptFindOut, err := DockerRunBashCmd(cmdOptions, stackImage, bashCmd)
+	scriptFindOut, err := DockerRunBashCmd(cmdOptions, stackImage, bashCmd, config.RootCommandConfig)
 	if err != nil {
 		Debug.log("Failed to run the find command for the ", scriptFileName, " on the stack image: ", stackImage)
 		return fmt.Errorf("Failed to run the docker find command: %s", err)
@@ -488,7 +499,7 @@ func extractAndInitialize() error {
 	workdir := ".appsody_init"
 
 	// run the extract command here
-	if !dryrun {
+	if !config.Dryrun {
 		workdirExists, err := Exists(workdir)
 		if workdirExists && err == nil {
 			err = os.RemoveAll(workdir)
@@ -496,10 +507,9 @@ func extractAndInitialize() error {
 				return fmt.Errorf("Could not remove temp dir %s  %s", workdir, err)
 			}
 		}
-		// set the --target-dir flag for extract
-		targetDir = workdir
-
-		extractError := extractCmd.RunE(extractCmd, nil)
+		extractConfig := &extractCommandConfig{RootCommandConfig: config.RootCommandConfig}
+		extractConfig.targetDir = workdir
+		extractError := extract(extractConfig)
 		if extractError != nil {
 			return extractError
 		}
@@ -513,13 +523,13 @@ func extractAndInitialize() error {
 
 	if scriptExists && err == nil { // if it doesn't exist, don't run it
 		Debug.log("Running appsody_init script ", scriptFile)
-		err = execAndWaitWithWorkDirReturnErr(scriptFile, nil, InitScript, workdir)
+		err = execAndWaitWithWorkDirReturnErr(scriptFile, nil, InitScript, workdir, config.Dryrun)
 		if err != nil {
 			return err
 		}
 	}
 
-	if !dryrun {
+	if !config.Dryrun {
 		Debug.log("Removing ", workdir)
 		err = os.RemoveAll(workdir)
 		if err != nil {
@@ -530,15 +540,15 @@ func extractAndInitialize() error {
 	return err
 }
 
-func parseProjectParm(projectParm string) (string, string, error) {
+func parseProjectParm(projectParm string, config *RootCommandConfig) (string, string, error) {
 	parms := strings.Split(projectParm, "/")
 	if len(parms) == 1 {
 		Debug.log("Non-fully qualified stack - retrieving default repo...")
 		var r RepositoryFile
-		if _, err := r.getRepos(); err != nil {
+		if _, err := r.getRepos(config); err != nil {
 			return "", "", err
 		}
-		defaultRepoName, err := r.GetDefaultRepoName()
+		defaultRepoName, err := r.GetDefaultRepoName(config)
 		if err != nil {
 			return "", parms[0], err
 		}

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -19,54 +19,47 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// listCmd represents the list command
-var listCmd = &cobra.Command{
-	Use:   "list [repository]",
-	Short: "List the Appsody stacks available to init",
-	Long:  `This command lists all the stacks available in your repositories. If you omit the  optional [repository] parameter, the stacks for all the repositories are listed. If you specify the repository name [repository], only the stacks in that repository will be listed.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		var repos RepositoryFile
+func newListCmd(rootConfig *RootCommandConfig) *cobra.Command {
+	// listCmd represents the list command
+	var listCmd = &cobra.Command{
+		Use:   "list [repository]",
+		Short: "List the Appsody stacks available to init",
+		Long:  `This command lists all the stacks available in your repositories. If you omit the  optional [repository] parameter, the stacks for all the repositories are listed. If you specify the repository name [repository], only the stacks in that repository will be listed.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var repos RepositoryFile
 
-		setupErr := setupConfig()
-		if setupErr != nil {
-			return setupErr
-		}
-
-		if _, err := repos.getRepos(); err != nil {
-			return err
-		}
-		//var index RepoIndex
-		if len(args) < 1 {
-			projects, err := repos.listProjects()
-			if err != nil {
-				return errors.Errorf("%v", err)
-			}
-			if len(unsupportedRepos) > 0 {
-				Warning.log("The following repositories .yaml have an  APIVersion greater than "+supportedIndexAPIVersion+" which your installed Appsody CLI supports, it is strongly suggested that you update your Appsody CLI to the latest version: ", unsupportedRepos)
-			}
-			Info.log("\n", projects)
-		} else {
-			repoName := args[0]
-			_, err := repos.getRepos()
-			if err != nil {
+			if _, err := repos.getRepos(rootConfig); err != nil {
 				return err
 			}
-			repoProjects, err := repos.listRepoProjects(repoName)
-			if err != nil {
-				return err
+			//var index RepoIndex
+			if len(args) < 1 {
+				projects, err := repos.listProjects(rootConfig)
+				if err != nil {
+					return errors.Errorf("%v", err)
+				}
+				if len(rootConfig.UnsupportedRepos) > 0 {
+					Warning.log("The following repositories .yaml have an  APIVersion greater than "+supportedIndexAPIVersion+" which your installed Appsody CLI supports, it is strongly suggested that you update your Appsody CLI to the latest version: ", rootConfig.UnsupportedRepos)
+				}
+				Info.log("\n", projects)
+			} else {
+				repoName := args[0]
+				_, err := repos.getRepos(rootConfig)
+				if err != nil {
+					return err
+				}
+				repoProjects, err := repos.listRepoProjects(repoName, rootConfig)
+				if err != nil {
+					return err
+				}
+				if len(rootConfig.UnsupportedRepos) > 0 {
+					Warning.log("The following repositories are of APIVersion greater than "+supportedIndexAPIVersion+" which your installed Appsody CLI supports, it is strongly suggested that you update your Appsody CLI to the latest version: ", rootConfig.UnsupportedRepos)
+				}
+
+				Info.log("\n", repoProjects)
 			}
-			if len(unsupportedRepos) > 0 {
-				Warning.log("The following repositories are of APIVersion greater than "+supportedIndexAPIVersion+" which your installed Appsody CLI supports, it is strongly suggested that you update your Appsody CLI to the latest version: ", unsupportedRepos)
-			}
 
-			Info.log("\n", repoProjects)
-		}
-
-		return nil
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(listCmd)
-
+			return nil
+		},
+	}
+	return listCmd
 }

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -26,9 +26,32 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var operatorYamlName = "appsody-app-operator.yaml"
-var appsodyCRDName = "appsody-app-crd.yaml"
-var operatorRBACName = "appsody-app-cluster-rbac.yaml"
+const operatorYamlName = "appsody-app-operator.yaml"
+const appsodyCRDName = "appsody-app-crd.yaml"
+const operatorRBACName = "appsody-app-cluster-rbac.yaml"
+
+type operatorCommandConfig struct {
+	*RootCommandConfig
+	namespace string
+}
+
+func newOperatorCmd(rootConfig *RootCommandConfig) *cobra.Command {
+	operatorConfig := &operatorCommandConfig{RootCommandConfig: rootConfig}
+	var operatorCmd = &cobra.Command{
+		Use:   "operator",
+		Short: "Install or uninstall the Appsody operator from your Kubernetes cluster.",
+		Long:  `This command allows you to "install" or "uninstall" the Appsody operator from the configured Kubernetes cluster. An installed Appsody operator is required to deploy your Appsody projects.`,
+	}
+
+	// rootCmd.AddCommand(operatorCmd)
+	//operatorCmd.AddCommand(installCmd)
+	//operatorCmd.AddCommand(uninstallCmd)
+	operatorCmd.PersistentFlags().StringVarP(&operatorConfig.namespace, "namespace", "n", "default", "The namespace in which the operator will run.")
+	//operatorCmd.PersistentFlags().StringVarP(&watchspace, "watchspace", "w", "''", "The namespace which the operator will watch. Use '' for all namespaces.")
+	operatorCmd.AddCommand(newOperatorInstallCmd(operatorConfig))
+	operatorCmd.AddCommand(newOperatorUninstallCmd(operatorConfig))
+	return operatorCmd
+}
 
 func downloadOperatorYaml(url string, operatorNamespace string, watchNamespace string, target string) (string, error) {
 
@@ -57,7 +80,7 @@ func downloadOperatorYaml(url string, operatorNamespace string, watchNamespace s
 	return target, nil
 }
 
-func downloadRBACYaml(url string, operatorNamespace string, target string) (string, error) {
+func downloadRBACYaml(url string, operatorNamespace string, target string, dryrun bool) (string, error) {
 	if dryrun {
 		Info.log("Skipping download of RBAC yaml: ", url)
 		return "", nil
@@ -116,8 +139,8 @@ func downloadCRDYaml(url string, target string) (string, error) {
 	return file, nil
 }
 
-func getDeployConfigDir() (string, error) {
-	deployConfigDir := filepath.Join(getHome(), "deploy")
+func getDeployConfigDir(rootConfig *RootCommandConfig) (string, error) {
+	deployConfigDir := filepath.Join(getHome(rootConfig), "deploy")
 	deployConfigDirExists, err := Exists(deployConfigDir)
 	if err != nil {
 		return "", errors.Errorf("Error checking directory: %v", err)
@@ -132,18 +155,4 @@ func getDeployConfigDir() (string, error) {
 
 	}
 	return deployConfigDir, nil
-}
-
-var operatorCmd = &cobra.Command{
-	Use:   "operator",
-	Short: "Install or uninstall the Appsody operator from your Kubernetes cluster.",
-	Long:  `This command allows you to "install" or "uninstall" the Appsody operator from the configured Kubernetes cluster. An installed Appsody operator is required to deploy your Appsody projects.`,
-}
-
-func init() {
-	rootCmd.AddCommand(operatorCmd)
-	//operatorCmd.AddCommand(installCmd)
-	//operatorCmd.AddCommand(uninstallCmd)
-	operatorCmd.PersistentFlags().StringVarP(&namespace, "namespace", "n", "default", "The namespace in which the operator will run.")
-	//operatorCmd.PersistentFlags().StringVarP(&watchspace, "watchspace", "w", "''", "The namespace which the operator will watch. Use '' for all namespaces.")
 }

--- a/cmd/operator_install.go
+++ b/cmd/operator_install.go
@@ -22,111 +22,117 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var all bool
-
-// installCmd represents the "appsody deploy install" command
-var installCmd = &cobra.Command{
-	Use:   "install",
-	Short: "Install the Appsody Operator into the configured Kubernetes cluster",
-	Long:  ``,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		err := initConfig()
-		if err != nil {
-			return err
-		}
-
-		operatorNamespace := "default"
-		watchNamespace := "''"
-		if namespace != "" {
-			operatorNamespace = namespace
-		}
-		if watchspace == "" {
-			watchNamespace = operatorNamespace
-		}
-		if watchspace != "" {
-			watchNamespace = watchspace
-		}
-		if all {
-			watchNamespace = ""
-		}
-		Debug.log("watchNamespace is:  ", watchNamespace)
-		operatorExists, existsErr := operatorExistsInNamespace(operatorNamespace)
-		if existsErr != nil {
-			return existsErr
-		}
-		if operatorExists {
-			existingOperatorWatchspace, err := getOperatorWatchspace(operatorNamespace)
-			if err != nil {
-				Debug.log("Could not retrieve the watchspace of this operator - this should never happen...")
-			}
-			if existingOperatorWatchspace == "" {
-				existingOperatorWatchspace = "all namespaces"
-			}
-			return errors.Errorf("An operator already exists in namespace %s and it is watching the %s namespace.", operatorNamespace, existingOperatorWatchspace)
-		}
-
-		watchExists, existingNamespace, watchExistsErr := operatorExistsWithWatchspace(watchNamespace)
-		if watchExistsErr != nil {
-
-			return watchExistsErr
-		}
-		if watchExists {
-			return errors.Errorf("An operator watching namespace %s or all namespaces already exists in namespace %s", watchNamespace, existingNamespace)
-		}
-
-		deployConfigDir, err := getDeployConfigDir()
-		if err != nil {
-			return errors.Errorf("Error getting deploy config dir: %v", err)
-		}
-
-		var crdURL = getOperatorHome() + "/" + appsodyCRDName
-		appsodyCRD := filepath.Join(deployConfigDir, appsodyCRDName)
-		var file string
-
-		file, err = downloadCRDYaml(crdURL, appsodyCRD)
-		if err != nil {
-			return err
-		}
-
-		err = KubeApply(file)
-		if err != nil {
-			return err
-		}
-		rbacYaml := filepath.Join(deployConfigDir, operatorRBACName)
-		var rbacURL = getOperatorHome() + "/" + operatorRBACName
-		if (operatorNamespace != watchNamespace) || all {
-			Debug.log("Downloading: ", rbacURL)
-			file, err = downloadRBACYaml(rbacURL, operatorNamespace, rbacYaml)
-			if err != nil {
-				return err
-			}
-
-			err = KubeApply(file)
-			if err != nil {
-				return err
-			}
-		}
-
-		operatorYaml := filepath.Join(deployConfigDir, operatorYamlName)
-		var operatorURL = getOperatorHome() + "/" + operatorYamlName
-		file, err = downloadOperatorYaml(operatorURL, operatorNamespace, watchNamespace, operatorYaml)
-		if err != nil {
-			return err
-		}
-
-		err = KubeApply(file)
-		if err != nil {
-			return err
-		}
-
-		Info.log("Appsody operator deployed to Kubernetes")
-		return nil
-	},
+type operatorInstallCommandConfig struct {
+	*operatorCommandConfig
+	all        bool
+	watchspace string
 }
 
-func init() {
-	operatorCmd.AddCommand(installCmd)
-	installCmd.PersistentFlags().StringVarP(&watchspace, "watchspace", "w", "", "The namespace which the operator will watch.")
-	installCmd.PersistentFlags().BoolVar(&all, "watch-all", false, "The operator will watch all namespaces.")
+func newOperatorInstallCmd(operatorConfig *operatorCommandConfig) *cobra.Command {
+	config := &operatorInstallCommandConfig{operatorCommandConfig: operatorConfig}
+	// installCmd represents the "appsody deploy install" command
+	var installCmd = &cobra.Command{
+		Use:   "install",
+		Short: "Install the Appsody Operator into the configured Kubernetes cluster",
+		Long:  ``,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return operatorInstall(config)
+		},
+	}
 
+	installCmd.PersistentFlags().StringVarP(&config.watchspace, "watchspace", "w", "", "The namespace which the operator will watch.")
+	installCmd.PersistentFlags().BoolVar(&config.all, "watch-all", false, "The operator will watch all namespaces.")
+	return installCmd
+}
+
+func operatorInstall(config *operatorInstallCommandConfig) error {
+	namespace := config.namespace
+	watchspace := config.watchspace
+
+	operatorNamespace := "default"
+	watchNamespace := "''"
+	if namespace != "" {
+		operatorNamespace = namespace
+	}
+	if watchspace == "" {
+		watchNamespace = operatorNamespace
+	}
+	if watchspace != "" {
+		watchNamespace = watchspace
+	}
+	if config.all {
+		watchNamespace = ""
+	}
+	Debug.log("watchNamespace is:  ", watchNamespace)
+	operatorExists, existsErr := operatorExistsInNamespace(operatorNamespace, config.Dryrun)
+	if existsErr != nil {
+		return existsErr
+	}
+	if operatorExists {
+		existingOperatorWatchspace, err := getOperatorWatchspace(operatorNamespace, config.Dryrun)
+		if err != nil {
+			Debug.log("Could not retrieve the watchspace of this operator - this should never happen...")
+		}
+		if existingOperatorWatchspace == "" {
+			existingOperatorWatchspace = "all namespaces"
+		}
+		return errors.Errorf("An operator already exists in namespace %s and it is watching the %s namespace.", operatorNamespace, existingOperatorWatchspace)
+	}
+
+	watchExists, existingNamespace, watchExistsErr := operatorExistsWithWatchspace(watchNamespace, config.Dryrun)
+	if watchExistsErr != nil {
+
+		return watchExistsErr
+	}
+	if watchExists {
+		return errors.Errorf("An operator watching namespace %s or all namespaces already exists in namespace %s", watchNamespace, existingNamespace)
+	}
+
+	deployConfigDir, err := getDeployConfigDir(config.RootCommandConfig)
+	if err != nil {
+		return errors.Errorf("Error getting deploy config dir: %v", err)
+	}
+
+	var crdURL = getOperatorHome(config.RootCommandConfig) + "/" + appsodyCRDName
+	appsodyCRD := filepath.Join(deployConfigDir, appsodyCRDName)
+	var file string
+
+	file, err = downloadCRDYaml(crdURL, appsodyCRD)
+	if err != nil {
+		return err
+	}
+
+	err = KubeApply(file, config.namespace, config.Dryrun)
+	if err != nil {
+		return err
+	}
+	rbacYaml := filepath.Join(deployConfigDir, operatorRBACName)
+	var rbacURL = getOperatorHome(config.RootCommandConfig) + "/" + operatorRBACName
+	if (operatorNamespace != watchNamespace) || config.all {
+		Debug.log("Downloading: ", rbacURL)
+		file, err = downloadRBACYaml(rbacURL, operatorNamespace, rbacYaml, config.Dryrun)
+		if err != nil {
+			return err
+		}
+
+		err = KubeApply(file, config.namespace, config.Dryrun)
+		if err != nil {
+			return err
+		}
+	}
+
+	operatorYaml := filepath.Join(deployConfigDir, operatorYamlName)
+	var operatorURL = getOperatorHome(config.RootCommandConfig) + "/" + operatorYamlName
+	file, err = downloadOperatorYaml(operatorURL, operatorNamespace, watchNamespace, operatorYaml)
+	if err != nil {
+		return err
+	}
+
+	err = KubeApply(file, config.namespace, config.Dryrun)
+	if err != nil {
+		return err
+	}
+
+	Info.log("Appsody operator deployed to Kubernetes")
+	return nil
 }

--- a/cmd/operator_utils.go
+++ b/cmd/operator_utils.go
@@ -21,24 +21,24 @@ import (
 )
 
 //RunKubeGet issues kubectl get <arg>
-func RunKubeGet(args []string) (string, error) {
+func RunKubeGet(args []string, dryrun bool) (string, error) {
 	Info.log("Attempting to get resource from Kubernetes ...")
 	kargs := []string{"get"}
 	kargs = append(kargs, args...)
-	return RunKube(kargs)
+	return RunKube(kargs, dryrun)
 
 }
 
 //RunKubeDelete issues kubectl delete <args>
-func RunKubeDelete(args []string) (string, error) {
+func RunKubeDelete(args []string, dryrun bool) (string, error) {
 	Info.log("Attempting to delete resource from Kubernetes ...")
 	kargs := []string{"delete"}
 	kargs = append(kargs, args...)
-	return RunKube(kargs)
+	return RunKube(kargs, dryrun)
 }
 
 //RunKube runs a generic kubectl command
-func RunKube(kargs []string) (string, error) {
+func RunKube(kargs []string, dryrun bool) (string, error) {
 	kcmd := "kubectl"
 	if dryrun {
 		Info.log("Dry run - skipping execution of: ", kcmd, " ", strings.Join(kargs, " "))
@@ -118,13 +118,13 @@ func downloadRBACYaml(url string, operatorNamespace string, target string) (stri
 	return target, nil
 }
 */
-func operatorExistsInNamespace(operatorNamespace string) (bool, error) {
+func operatorExistsInNamespace(operatorNamespace string, dryrun bool) (bool, error) {
 
 	// check to see if this namespace already has an appsody-operator
 	//var args = []string{"deployment", "appsody-operator", "-n", operatorNamespace}
 	var args = []string{"deployments", "-o=jsonpath='{.items[?(@.metadata.name==\"appsody-operator\")].metadata.namespace}'", "-n", operatorNamespace}
 
-	getOutput, getErr := RunKubeGet(args)
+	getOutput, getErr := RunKubeGet(args, dryrun)
 	if getErr != nil {
 		Debug.log("Received an err: ", getErr)
 		return false, getErr
@@ -139,10 +139,10 @@ func operatorExistsInNamespace(operatorNamespace string) (bool, error) {
 }
 
 // Check to see if any other operator is watching the watchNameSpace
-func operatorExistsWithWatchspace(watchNamespace string) (bool, string, error) {
+func operatorExistsWithWatchspace(watchNamespace string, dryrun bool) (bool, string, error) {
 	Debug.log("Looking for an operator matching watchspace: ", watchNamespace)
 	var deploymentsWithOperatorsGetArgs = []string{"deployments", "-o=jsonpath='{.items[?(@.metadata.name==\"appsody-operator\")].metadata.namespace}'", "--all-namespaces"}
-	getOutput, getErr := RunKubeGet(deploymentsWithOperatorsGetArgs)
+	getOutput, getErr := RunKubeGet(deploymentsWithOperatorsGetArgs, dryrun)
 	if getErr != nil {
 		return false, "", getErr
 	}
@@ -159,7 +159,7 @@ func operatorExistsWithWatchspace(watchNamespace string) (bool, string, error) {
 	Debug.log("deployments with operators: ", deployments)
 	for _, deploymentNamespace := range deployments {
 		var getDeploymentWatchNamespaceArgs = []string{"deployment", "-o=jsonpath='{.items[?(@.metadata.name==\"appsody-operator\")].spec.template.spec.containers[0].env[?(@.name==\"WATCH_NAMESPACE\")].value}'", "-n", deploymentNamespace}
-		getOutput, getErr = RunKubeGet(getDeploymentWatchNamespaceArgs)
+		getOutput, getErr = RunKubeGet(getDeploymentWatchNamespaceArgs, dryrun)
 		Debug.logf("Deployment: %s is watching namespace %s", deploymentNamespace, getOutput)
 		if getErr != nil {
 			return false, "", getErr
@@ -177,40 +177,40 @@ func operatorExistsWithWatchspace(watchNamespace string) (bool, string, error) {
 	}
 	return false, "", nil
 }
-func operatorCount() (int, error) {
+func operatorCount(dryrun bool) (int, error) {
 	var getAllOperatorsArgs = []string{"deployments", "-o=jsonpath='{.items[?(@.metadata.name==\"appsody-operator\")].metadata.name}'", "--all-namespaces"}
-	getOutput, getErr := RunKubeGet(getAllOperatorsArgs)
+	getOutput, getErr := RunKubeGet(getAllOperatorsArgs, dryrun)
 	if getErr != nil {
 		return 0, getErr
 	}
 	return strings.Count(getOutput, "appsody-operator"), nil
 }
 
-func appsodyApplicationCount(namespace string) (int, error) {
+func appsodyApplicationCount(namespace string, dryrun bool) (int, error) {
 	var getAppsodyAppsArgs = []string{"AppsodyApplication", "-o=jsonpath='{.items[*].kind}'"}
 	if namespace == "" {
 		getAppsodyAppsArgs = append(getAppsodyAppsArgs, "--all-namespaces")
 	} else {
 		getAppsodyAppsArgs = append(getAppsodyAppsArgs, "-n", namespace)
 	}
-	getOutput, getErr := RunKubeGet(getAppsodyAppsArgs)
+	getOutput, getErr := RunKubeGet(getAppsodyAppsArgs, dryrun)
 	if getErr != nil {
 		return 0, getErr
 	}
 	return strings.Count(getOutput, "AppsodyApplication"), nil
 }
 
-func deleteAppsodyApps(namespace string) (string, error) {
+func deleteAppsodyApps(namespace string, dryrun bool) (string, error) {
 	var deleteAppsodyAppsArgs = []string{"AppsodyApplication", "--all"}
 	if namespace != "" {
 		deleteAppsodyAppsArgs = append(deleteAppsodyAppsArgs, "-n", namespace)
 	}
-	return RunKubeDelete(deleteAppsodyAppsArgs)
+	return RunKubeDelete(deleteAppsodyAppsArgs, dryrun)
 
 }
 
-func getOperatorWatchspace(namespace string) (string, error) {
-	operatorExists, existsErr := operatorExistsInNamespace(namespace)
+func getOperatorWatchspace(namespace string, dryrun bool) (string, error) {
+	operatorExists, existsErr := operatorExistsInNamespace(namespace, dryrun)
 	if existsErr != nil {
 		return "", existsErr
 	}
@@ -219,12 +219,12 @@ func getOperatorWatchspace(namespace string) (string, error) {
 	}
 	var args = []string{"deployments", "-o=jsonpath='{.items[?(@.metadata.name==\"appsody-operator\")].spec.template.spec.containers[0].env[?(@.name==\"WATCH_NAMESPACE\")].value}'", "-n", namespace}
 
-	getOutput, getErr := RunKubeGet(args)
+	getOutput, getErr := RunKubeGet(args, dryrun)
 	if getErr != nil {
 		Debug.log("Received an err: ", getErr)
 		return "", getErr
 	}
-	watchspace = strings.Trim(getOutput, "'")
+	watchspace := strings.Trim(getOutput, "'")
 	if watchspace == "" {
 		Debug.log("This operator watches the entire cluster ")
 	}

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -32,32 +32,30 @@ type StackContainer struct {
 	containerName string
 }
 
-// psCmd represents the ps command
-var psCmd = &cobra.Command{
-	Use:   "ps",
-	Short: "List the appsody containers running in the local docker environment",
-	Long:  `This command lists all stack-based containers, that are currently running in the local docker envionment.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+func newPsCmd(rootConfig *RootCommandConfig) *cobra.Command {
+	// psCmd represents the ps command
+	var psCmd = &cobra.Command{
+		Use:   "ps",
+		Short: "List the appsody containers running in the local docker environment",
+		Long:  `This command lists all stack-based containers, that are currently running in the local docker envionment.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
 
-		setupErr := setupConfig()
-		if setupErr != nil {
-			return setupErr
-		}
+			containers, err := listContainers()
+			if err != nil {
+				return err
+			}
 
-		containers, err := listContainers()
-		if err != nil {
-			return err
-		}
-
-		table, err := formatTable(containers)
-		if err != nil {
-			return errors.Errorf("%v", err)
-		}
-		if table != "" {
-			Info.log(table)
-		}
-		return nil
-	},
+			table, err := formatTable(containers)
+			if err != nil {
+				return errors.Errorf("%v", err)
+			}
+			if table != "" {
+				Info.log(table)
+			}
+			return nil
+		},
+	}
+	return psCmd
 }
 
 func listContainers() ([]StackContainer, error) {
@@ -125,8 +123,4 @@ func formatTable(containers []StackContainer) (string, error) {
 	}
 
 	return table.String(), nil
-}
-
-func init() {
-	rootCmd.AddCommand(psCmd)
 }

--- a/cmd/repo.go
+++ b/cmd/repo.go
@@ -122,57 +122,51 @@ func (e indexErrors) Error() string {
 	return myerrors
 }
 
-var unsupportedRepos []string
-var (
-	supportedIndexAPIVersion = "v2"
-)
-
-var (
-	appsodyHubURL = "https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml"
-)
-var (
+const (
+	supportedIndexAPIVersion  = "v2"
+	appsodyHubURL             = "https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml"
 	experimentalRepositoryURL = "https://github.com/appsody/stacks/releases/latest/download/experimental-index.yaml"
 )
 
-// repoCmd represents the repo command
-var repoCmd = &cobra.Command{
-	Use:   "repo",
-	Short: "Manage your Appsody repositories",
-	Long:  ``,
+func newRepoCmd(rootConfig *RootCommandConfig) *cobra.Command {
+	// repoCmd represents the repo command
+	var repoCmd = &cobra.Command{
+		Use:   "repo",
+		Short: "Manage your Appsody repositories",
+		Long:  ``,
+	}
+	repoCmd.AddCommand(
+		newRepoAddCmd(rootConfig),
+		newRepoListCmd(rootConfig),
+		newRepoRemoveCmd(rootConfig),
+		newRepoDefaultCmd(rootConfig),
+	)
+	return repoCmd
 }
 
-func getHome() string {
-	return cliConfig.GetString("home")
+func getHome(rootConfig *RootCommandConfig) string {
+	return rootConfig.CliConfig.GetString("home")
 }
 
-func getRepoDir() string {
-	return filepath.Join(getHome(), "repository")
+func getRepoDir(rootConfig *RootCommandConfig) string {
+	return filepath.Join(getHome(rootConfig), "repository")
 }
 
-func getRepoFileLocation() string {
-	return filepath.Join(getRepoDir(), "repository.yaml")
+func getRepoFileLocation(rootConfig *RootCommandConfig) string {
+	return filepath.Join(getRepoDir(rootConfig), "repository.yaml")
 }
-
-func init() {
-	rootCmd.AddCommand(repoCmd)
-}
-
-var ensureConfigRun = false
 
 // Locate or create config structure in $APPSODY_HOME
-func ensureConfig() error {
-	if ensureConfigRun {
-		return nil
-	}
+func ensureConfig(rootConfig *RootCommandConfig) error {
 	directories := []string{
-		getHome(),
-		getRepoDir(),
+		getHome(rootConfig),
+		getRepoDir(rootConfig),
 	}
 
 	for _, p := range directories {
 		if fi, err := os.Stat(p); err != nil {
 
-			if dryrun {
+			if rootConfig.Dryrun {
 				Info.log("Dry Run - Skipping create of directory ", p)
 			} else {
 				Debug.log("Creating ", p)
@@ -189,10 +183,10 @@ func ensureConfig() error {
 	}
 
 	// Repositories file
-	var repoFileLocation = getRepoFileLocation()
+	var repoFileLocation = getRepoFileLocation(rootConfig)
 	if file, err := os.Stat(repoFileLocation); err != nil {
 
-		if dryrun {
+		if rootConfig.Dryrun {
 			Info.log("Dry Run - Skipping creation of appsodyhub repo: ", appsodyHubURL)
 		} else {
 
@@ -215,9 +209,9 @@ func ensureConfig() error {
 		return errors.Errorf("%s must be a file, not a directory ", repoFileLocation)
 	}
 
-	defaultConfigFile := getDefaultConfigFile()
+	defaultConfigFile := getDefaultConfigFile(rootConfig)
 	if _, err := os.Stat(defaultConfigFile); err != nil {
-		if dryrun {
+		if rootConfig.Dryrun {
 			Info.log("Dry Run - Skip creation of default config file ", defaultConfigFile)
 		} else {
 			Debug.log("Creating ", defaultConfigFile)
@@ -228,18 +222,16 @@ func ensureConfig() error {
 		}
 	}
 
-	if dryrun {
+	if rootConfig.Dryrun {
 		Info.log("Dry Run - Skip writing config file ", defaultConfigFile)
 	} else {
 		Debug.log("Writing config file ", defaultConfigFile)
-		if err := cliConfig.WriteConfig(); err != nil {
+		if err := rootConfig.CliConfig.WriteConfig(); err != nil {
 			return errors.Errorf("Writing default config file %s", err)
 
 		}
 	}
-	ensureConfigRun = true
 	return nil
-
 }
 
 func downloadFile(href string, writer io.Writer) error {
@@ -309,14 +301,14 @@ func downloadIndex(url string) (*RepoIndex, error) {
 	return &index, nil
 }
 
-func (index *RepoIndex) listProjects(repoName string) (string, error) {
+func (index *RepoIndex) listProjects(repoName string, config *RootCommandConfig) (string, error) {
 	var Stacks = []Stack{}
 	table := uitable.New()
 	table.MaxColWidth = 60
 	table.Wrap = true
 	if strings.Compare(index.APIVersion, supportedIndexAPIVersion) == 1 {
-		Debug.log("Adding unsupported repoistory", repoName)
-		unsupportedRepos = append(unsupportedRepos, repoName)
+		Debug.log("Adding unsupported repository", repoName)
+		config.UnsupportedRepos = append(config.UnsupportedRepos, repoName)
 	}
 	table.AddRow("REPO", "ID", "VERSION  ", "TEMPLATES", "DESCRIPTION")
 
@@ -330,14 +322,14 @@ func (index *RepoIndex) listProjects(repoName string) (string, error) {
 	}
 	return table.String(), nil
 }
-func (r *RepositoryFile) listRepoProjects(repoName string) (string, error) {
+func (r *RepositoryFile) listRepoProjects(repoName string, config *RootCommandConfig) (string, error) {
 	if repo := r.GetRepo(repoName); repo != nil {
 		url := repo.URL
 		index, err := downloadIndex(url)
 		if err != nil {
 			return "", err
 		}
-		tableString, err := index.listProjects(repoName)
+		tableString, err := index.listProjects(repoName, config)
 		if err != nil {
 			return "", err
 		}
@@ -346,8 +338,8 @@ func (r *RepositoryFile) listRepoProjects(repoName string) (string, error) {
 	return "", errors.New("cannot locate repository named " + repoName)
 }
 
-func (r *RepositoryFile) getRepos() (*RepositoryFile, error) {
-	var repoFileLocation = getRepoFileLocation()
+func (r *RepositoryFile) getRepos(rootConfig *RootCommandConfig) (*RepositoryFile, error) {
+	var repoFileLocation = getRepoFileLocation(rootConfig)
 	repoReader, err := ioutil.ReadFile(repoFileLocation)
 	if err != nil {
 		if os.IsNotExist(err) {
@@ -365,14 +357,14 @@ func (r *RepositoryFile) getRepos() (*RepositoryFile, error) {
 	return r, nil
 }
 
-func (r *RepositoryFile) listRepos() (string, error) {
+func (r *RepositoryFile) listRepos(rootConfig *RootCommandConfig) (string, error) {
 	var entries = []RepositoryEntry{}
 	table := uitable.New()
 	table.MaxColWidth = 1024
 	table.AddRow("NAME", "URL")
 	for _, value := range r.Repositories {
 		repoName := value.Name
-		defaultRepoName, err := r.GetDefaultRepoName()
+		defaultRepoName, err := r.GetDefaultRepoName(rootConfig)
 		if err != nil {
 			return "", err
 		}
@@ -428,7 +420,7 @@ func (r *RepositoryFile) HasURL(url string) bool {
 	}
 	return false
 }
-func (r *RepositoryFile) GetDefaultRepoName() (string, error) {
+func (r *RepositoryFile) GetDefaultRepoName(rootConfig *RootCommandConfig) (string, error) {
 	// Check if there are any repos first
 	if len(r.Repositories) < 1 {
 		return "", errors.New("your $HOME/.appsody/repository/repository.yaml contains no repositories")
@@ -452,7 +444,7 @@ func (r *RepositoryFile) GetDefaultRepoName() (string, error) {
 		repo.IsDefault = true
 		repoName = repo.Name
 	}
-	if err := r.WriteFile(getRepoFileLocation()); err != nil {
+	if err := r.WriteFile(getRepoFileLocation(rootConfig)); err != nil {
 		return "", err
 	}
 	Info.log("Your default repository is now set to ", repoName)
@@ -469,7 +461,7 @@ func (r *RepositoryFile) Remove(name string) {
 	}
 }
 
-func (r *RepositoryFile) SetDefaultRepoName(name string, defaultRepoName string) (string, error) {
+func (r *RepositoryFile) SetDefaultRepoName(name string, defaultRepoName string, rootConfig *RootCommandConfig) (string, error) {
 	var repoName string
 	for index, rf := range r.Repositories {
 		//set current default repo to false
@@ -482,7 +474,7 @@ func (r *RepositoryFile) SetDefaultRepoName(name string, defaultRepoName string)
 			repoName = rf.Name
 		}
 	}
-	if err := r.WriteFile(getRepoFileLocation()); err != nil {
+	if err := r.WriteFile(getRepoFileLocation(rootConfig)); err != nil {
 		return "", err
 	}
 	Info.log("Your default repository is now set to ", repoName)
@@ -559,7 +551,7 @@ func (index *RepoIndex) buildStacksFromIndex(repoName string, Stacks []Stack) ([
 	return Stacks, nil
 }
 
-func (r *RepositoryFile) listProjects() (string, error) {
+func (r *RepositoryFile) listProjects(rootConfig *RootCommandConfig) (string, error) {
 	var Stacks = []Stack{}
 	table := uitable.New()
 	table.MaxColWidth = 60
@@ -575,8 +567,8 @@ func (r *RepositoryFile) listProjects() (string, error) {
 		for repoName, index := range indices {
 
 			if strings.Compare(index.APIVersion, supportedIndexAPIVersion) == 1 {
-				Debug.log("Adding unsupported repoistory", repoName)
-				unsupportedRepos = append(unsupportedRepos, repoName)
+				Debug.log("Adding unsupported repository", repoName)
+				rootConfig.UnsupportedRepos = append(rootConfig.UnsupportedRepos, repoName)
 			}
 
 			var errStack error
@@ -590,7 +582,7 @@ func (r *RepositoryFile) listProjects() (string, error) {
 	} else {
 		return "", errors.New("there are no repositories in your configuration")
 	}
-	defaultRepoName, err := r.GetDefaultRepoName()
+	defaultRepoName, err := r.GetDefaultRepoName(rootConfig)
 	if err != nil {
 		return "", err
 	}

--- a/cmd/repo_list.go
+++ b/cmd/repo_list.go
@@ -18,31 +18,26 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// repo list represent repo list cmd
-var repoListCmd = &cobra.Command{
-	Use:   "list",
-	Short: "List configured Appsody repositories",
-	Long:  `List configured Appsody repositories. An asterisk denotes the default repository.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
-		var repos RepositoryFile
-		setupErr := setupConfig()
-		if setupErr != nil {
-			return setupErr
-		}
-		_, repoErr := repos.getRepos()
-		if repoErr != nil {
-			return repoErr
-		}
-		repoList, err := repos.listRepos()
-		if err != nil {
-			return err
-		}
-		Info.log("\n", repoList)
-		return nil
-	},
-}
+func newRepoListCmd(config *RootCommandConfig) *cobra.Command {
+	// repo list represent repo list cmd
+	var repoListCmd = &cobra.Command{
+		Use:   "list",
+		Short: "List configured Appsody repositories",
+		Long:  `List configured Appsody repositories. An asterisk denotes the default repository.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var repos RepositoryFile
 
-func init() {
-	repoCmd.AddCommand(repoListCmd)
-
+			_, repoErr := repos.getRepos(config)
+			if repoErr != nil {
+				return repoErr
+			}
+			repoList, err := repos.listRepos(config)
+			if err != nil {
+				return err
+			}
+			Info.log("\n", repoList)
+			return nil
+		},
+	}
+	return repoListCmd
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -33,21 +33,27 @@ import (
 	"github.com/spf13/viper"
 )
 
-var (
-	// VERSION is set during build
-	VERSION         string
-	cfgFile         string
-	cliConfig       *viper.Viper
-	APIVersionV1    = "v1"
-	dryrun          bool
-	verbose         bool
-	klogInitialized = false
-)
+var VERSION string
+
+const APIVersionV1 = "v1"
+
+type RootCommandConfig struct {
+	CfgFile          string
+	Dryrun           bool
+	Verbose          bool
+	CliConfig        *viper.Viper
+	Buildah          bool
+	ProjectConfig    *ProjectConfig
+	ProjectDir       string
+	UnsupportedRepos []string
+
+	// package scoped, these are mostly for caching
+	setupConfigRun bool
+	imagePulled    map[string]bool
+}
 
 // Regular expression to match ANSI terminal commands so that we can remove them from the log
 const ansi = "[\u001B\u009B][[\\]()#;?]*(?:(?:(?:[a-zA-Z\\d]*(?:;[-a-zA-Z\\d\\/#&.:=?%@~_\\s]*)*)?(\u0007|^G))|(?:(?:\\d{1,4}(?:;\\d{0,4})*)?[\\dA-PR-TZcf-ntqry=><~]))"
-
-var ansiRegexp = regexp.MustCompile(ansi)
 
 func homeDir() (string, error) {
 	home, err := homedir.Dir()
@@ -58,74 +64,79 @@ func homeDir() (string, error) {
 	return home, nil
 }
 
-var operatorHome = "https://github.com/appsody/appsody-operator/releases/latest/download"
+const operatorHome = "https://github.com/appsody/appsody-operator/releases/latest/download"
 
-var rootCmd = &cobra.Command{
-	Use:           "appsody",
-	SilenceErrors: true,
-	SilenceUsage:  true,
-	Short:         "Appsody CLI",
-	Long: `The Appsody command-line tool (CLI) enables the rapid development of cloud native applications.
+func newRootCmd(projectDir string, args []string) (*cobra.Command, error) {
+	rootConfig := &RootCommandConfig{}
+	rootConfig.ProjectDir = projectDir
+	rootCmd := &cobra.Command{
+		Use:           "appsody",
+		SilenceErrors: true,
+		SilenceUsage:  true,
+		Short:         "Appsody CLI",
+		Long: `The Appsody command-line tool (CLI) enables the rapid development of cloud native applications.
 
 Complete documentation is available at https://appsody.dev`,
-	//Run: no run action for the root command
+		//Run: no run action for the root command
+	}
+
+	rootCmd.PersistentFlags().StringVar(&rootConfig.CfgFile, "config", "", "config file (default is $HOME/.appsody/.appsody.yaml)")
+	rootCmd.PersistentFlags().BoolVarP(&rootConfig.Verbose, "verbose", "v", false, "Turns on debug output and logging to a file in $HOME/.appsody/logs")
+	rootCmd.PersistentFlags().BoolVar(&rootConfig.Dryrun, "dryrun", false, "Turns on dry run mode")
+
+	// parse the root flags and init logging before adding all the other commands in case those log messages
+	rootCmd.SetArgs(args)
+	_ = rootCmd.ParseFlags(args) // ignore flag errors here because we haven't added all the commands
+	initLogging(rootConfig)
+
+	rootCmd.AddCommand(
+		newInitCmd(rootConfig),
+		newBuildCmd(rootConfig),
+		newExtractCmd(rootConfig),
+		newCompletionCmd(rootCmd),
+		newDebugCmd(rootConfig),
+		newDeployCmd(rootConfig),
+		newDocsCmd(rootConfig, rootCmd),
+		newListCmd(rootConfig),
+		newOperatorCmd(rootConfig),
+		newPsCmd(rootConfig),
+		newRepoCmd(rootConfig),
+		newRunCmd(rootConfig),
+		newStackCmd(rootConfig),
+		newStopCmd(rootConfig),
+		newTestCmd(rootConfig),
+		newVersionCmd(rootCmd),
+	)
+
+	setupErr := setupConfig(args, rootConfig)
+	if setupErr != nil {
+		return rootCmd, setupErr
+	}
+	return rootCmd, nil
 }
 
-func setupConfig() error {
-	err := initConfig()
+func setupConfig(args []string, config *RootCommandConfig) error {
+	if config.setupConfigRun {
+		return nil
+	}
+	err := InitConfig(config)
 	if err != nil {
 		return err
 	}
-	err = ensureConfig()
+	err = ensureConfig(config)
 	if err != nil {
 		return err
 	}
 
-	checkTime()
-	setNewIndexURL()
+	checkTime(config)
+	setNewIndexURL(config)
+	config.setupConfigRun = true
 	return nil
 }
 
-func init() {
-	// Don't run this on help commands
-	// TODO - instead of the isHelpCommand() check, we should delay the config init/ensure until we really need the config
-	if !isHelpCommand() {
-		cobra.OnInitialize(initLogging)
-		//cobra.OnInitialize(initConfig)
-		//cobra.OnInitialize(ensureConfig)
-	}
+func InitConfig(config *RootCommandConfig) error {
 
-	rootCmd.PersistentFlags().StringVar(&cfgFile, "config", "", "config file (default is $HOME/.appsody/.appsody.yaml)")
-	// Added for logging
-	rootCmd.PersistentFlags().BoolVarP(&verbose, "verbose", "v", false, "Turns on debug output and logging to a file in $HOME/.appsody/logs")
-
-	rootCmd.PersistentFlags().BoolVar(&dryrun, "dryrun", false, "Turns on dry run mode")
-
-}
-
-func isHelpCommand() bool {
-	if len(os.Args) <= 1 {
-		return true
-	}
-	if os.Args[1] == "help" {
-		return true
-	}
-	for _, arg := range os.Args {
-		if arg == "-h" || arg == "--help" {
-			return true
-		}
-	}
-	return false
-}
-
-var initConfigRun = false
-
-func initConfig() error {
-	Debug.log("Running with command line args: appsody ", strings.Join(os.Args[1:], " "))
-	if initConfigRun {
-		return nil
-	}
-	cliConfig = viper.New()
+	cliConfig := viper.New()
 	homeDirectory, dirErr := homeDir()
 	if dirErr != nil {
 		return dirErr
@@ -135,9 +146,9 @@ func initConfig() error {
 	cliConfig.SetDefault("operator", operatorHome)
 	cliConfig.SetDefault("tektonserver", "")
 	cliConfig.SetDefault("lastversioncheck", "none")
-	if cfgFile != "" {
+	if config.CfgFile != "" {
 		// Use config file from the flag.
-		cliConfig.SetConfigFile(cfgFile)
+		cliConfig.SetConfigFile(config.CfgFile)
 	} else {
 		// Search config in home directory with name ".hello-cobra" (without extension).
 		cliConfig.AddConfigPath(cliConfig.GetString("home"))
@@ -150,38 +161,60 @@ func initConfig() error {
 	// If a config file is found, read it in.
 	// Ignore errors, if the config isn't found, we will create a default later
 	_ = cliConfig.ReadInConfig()
-	initConfigRun = true
+	config.CliConfig = cliConfig
 	return nil
 }
 
-func getDefaultConfigFile() string {
-	return filepath.Join(cliConfig.GetString("home"), ".appsody.yaml")
+func getDefaultConfigFile(config *RootCommandConfig) string {
+	return filepath.Join(config.CliConfig.GetString("home"), ".appsody.yaml")
 }
 
 func Execute(version string) {
-	VERSION = version
-
-	if err := rootCmd.Execute(); err != nil {
-		Error.log(err)
+	dir, err := os.Getwd()
+	if err != nil {
+		fmt.Println("Error getting current directory: ", err)
+		os.Exit(1)
+	}
+	if err := ExecuteE(version, dir, os.Args); err != nil {
 		os.Exit(1)
 	}
 }
 
-type appsodylogger string
+func ExecuteE(version string, projectDir string, args []string) error {
+	VERSION = version
+	rootCmd, err := newRootCmd(projectDir, args[1:])
+	if err != nil {
+		Error.log(err)
+	}
+	Debug.log("Running with command line args: appsody ", strings.Join(args[1:], " "))
+	err = rootCmd.Execute()
+	if err != nil {
+		Error.log(err)
+	}
+	return err
+}
+
+type appsodylogger struct {
+	name            string
+	verbose         bool
+	klogInitialized bool
+}
 type stackTracer interface {
 	StackTrace() errors.StackTrace
 }
 
 // define the logging levels
 var (
-	Info       appsodylogger = "Info"
-	Warning    appsodylogger = "Warning"
-	Error      appsodylogger = "Error"
-	Debug      appsodylogger = "Debug"
-	Container  appsodylogger = "Container"
-	InitScript appsodylogger = "InitScript"
-	DockerLog  appsodylogger = "Docker"
+	Info       = appsodylogger{name: "Info"}
+	Warning    = appsodylogger{name: "Warning"}
+	Error      = appsodylogger{name: "Error"}
+	Debug      = appsodylogger{name: "Debug"}
+	Container  = appsodylogger{name: "Container"}
+	InitScript = appsodylogger{name: "InitScript"}
+	DockerLog  = appsodylogger{name: "Docker"}
 )
+
+var allLoggers = []*appsodylogger{&Info, &Warning, &Error, &Debug, &Container, &InitScript, &DockerLog}
 
 func (l appsodylogger) log(args ...interface{}) {
 	msgString := fmt.Sprint(args...)
@@ -214,16 +247,16 @@ func (l appsodylogger) LogfSkipConsole(fmtString string, args ...interface{}) {
 }
 
 func (l appsodylogger) internalLog(msgString string, skipConsole bool, args ...interface{}) {
-	if l == Debug && !verbose {
+	if l == Debug && !l.verbose {
 		return
 	}
 
-	if verbose || l != Info {
-		msgString = "[" + string(l) + "] " + msgString
+	if l.verbose || l != Info {
+		msgString = "[" + string(l.name) + "] " + msgString
 	}
 
 	// if verbose and any of the args are of type error, print the stack traces
-	if verbose {
+	if l.verbose {
 		for _, arg := range args {
 			st, ok := arg.(stackTracer)
 			if ok {
@@ -244,18 +277,20 @@ func (l appsodylogger) internalLog(msgString string, skipConsole bool, args ...i
 	}
 
 	// Print to log file
-	if verbose && klogInitialized {
+	if l.verbose && l.klogInitialized {
 		// Remove ansi commands
+		ansiRegexp := regexp.MustCompile(ansi)
 		msgString = ansiRegexp.ReplaceAllString(msgString, "")
 		klog.InfoDepth(2, msgString)
 		klog.Flush()
 	}
 }
 
-func initLogging() {
-
-	if verbose {
-		// this is an initizer method and currently you can not return an error from them
+func initLogging(config *RootCommandConfig) {
+	if config.Verbose {
+		for _, l := range allLoggers {
+			l.verbose = true
+		}
 
 		homeDirectory, dirErr := homeDir()
 		if dirErr != nil {
@@ -283,7 +318,10 @@ func initLogging() {
 		_ = klogFlags.Set("log_file", pathString)
 		_ = klogFlags.Set("logtostderr", "false")
 		_ = klogFlags.Set("alsologtostderr", "false")
-		klogInitialized = true
+
+		for _, l := range allLoggers {
+			l.klogInitialized = true
+		}
 		Debug.log("Logging to file ", pathString)
 	}
 }

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -18,17 +18,17 @@ import (
 	"github.com/spf13/cobra"
 )
 
-func dockerStop(imageName string) error {
+func dockerStop(imageName string, dryrun bool) error {
 	cmdName := "docker"
 	cmdArgs := []string{"stop", imageName}
-	err := execAndWait(cmdName, cmdArgs, Debug)
+	err := execAndWait(cmdName, cmdArgs, Debug, dryrun)
 	if err != nil {
 		return err
 	}
 	return nil
 }
 
-func containerRemove(imageName string) error {
+func containerRemove(imageName string, buildah bool, dryrun bool) error {
 	cmdName := "docker"
 	//Added "-f" to force removal if container is still running or image has containers
 	cmdArgs := []string{"rm", imageName, "-f"}
@@ -36,7 +36,7 @@ func containerRemove(imageName string) error {
 		cmdName = "buildah"
 		cmdArgs = []string{"rm", imageName}
 	}
-	err := execAndWait(cmdName, cmdArgs, Debug)
+	err := execAndWait(cmdName, cmdArgs, Debug, dryrun)
 	if err != nil {
 		return err
 	}
@@ -44,20 +44,21 @@ func containerRemove(imageName string) error {
 
 }
 
-// runCmd represents the run command
-var runCmd = &cobra.Command{
-	Use:   "run",
-	Short: "Run the local Appsody environment for your project",
-	Long:  `This starts a docker based continuous build environment for your project.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+func newRunCmd(rootConfig *RootCommandConfig) *cobra.Command {
+	config := &devCommonConfig{RootCommandConfig: rootConfig}
+	// runCmd represents the run command
+	var runCmd = &cobra.Command{
+		Use:   "run",
+		Short: "Run the local Appsody environment for your project",
+		Long:  `This starts a docker based continuous build environment for your project.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
 
-		Info.log("Running development environment...")
-		return commonCmd(cmd, args, "run")
+			Info.log("Running development environment...")
+			return commonCmd(config, "run")
 
-	},
-}
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(runCmd)
-	addDevCommonFlags(runCmd)
+	addDevCommonFlags(runCmd, config)
+	return runCmd
 }

--- a/cmd/stack.go
+++ b/cmd/stack.go
@@ -18,13 +18,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var stackCmd = &cobra.Command{
-	Use:   "stack",
-	Short: "Tools to help create and test Appsody stacks",
-	Long:  ``,
-}
-
-func init() {
-	rootCmd.AddCommand(stackCmd)
-
+func newStackCmd(rootConfig *RootCommandConfig) *cobra.Command {
+	var stackCmd = &cobra.Command{
+		Use:   "stack",
+		Short: "Tools to help create and test Appsody stacks",
+		Long:  ``,
+	}
+	stackCmd.AddCommand(newStackLintCmd(rootConfig))
+	return stackCmd
 }

--- a/cmd/stack_lint_dockerfile_stack.go
+++ b/cmd/stack_lint_dockerfile_stack.go
@@ -56,10 +56,12 @@ func getENVDockerfile(stackPath string) (dockerfileStack map[string]string) {
 	return dockerfileMap
 }
 
-func lintDockerFileStack(stackPath string) {
+func lintDockerFileStack(stackPath string) (int, int) {
 	mendatoryEnvironmentVariables := [...]string{"APPSODY_MOUNTS", "APPSODY_RUN"}
 	optionalEnvironmentVariables := [...]string{"APPSODY_DEBUG", "APPSODY_TEST", "APPSODY_DEPS", "APPSODY_PROJECT_DIR"}
 
+	stackLintErrorCount := 0
+	stackLintWarningCount := 0
 	arg := filepath.Join(stackPath, "image/Dockerfile-stack")
 
 	Info.log("Linting Dockerfile-stack: ", arg)
@@ -142,4 +144,5 @@ func lintDockerFileStack(stackPath string) {
 			}
 		}
 	}
+	return stackLintErrorCount, stackLintWarningCount
 }

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -18,31 +18,30 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// stopCmd represents the stop command
-var stopCmd = &cobra.Command{
-	Use:   "stop",
-	Short: "Stops the local Appsody docker container for your project",
-	Long: `Stop the local Appsody docker container for your project.
+func newStopCmd(rootConfig *RootCommandConfig) *cobra.Command {
+	var containerName string
+	// stopCmd represents the stop command
+	var stopCmd = &cobra.Command{
+		Use:   "stop",
+		Short: "Stops the local Appsody docker container for your project",
+		Long: `Stop the local Appsody docker container for your project.
 
 Stops the docker container specified by the --name flag. 
 If --name is not specified, the container name is determined from the current working directory (see default below).
 To see a list of all your running docker containers, run the command "docker ps". The name is in the last column.`,
 
-	RunE: func(cmd *cobra.Command, args []string) error {
+		RunE: func(cmd *cobra.Command, args []string) error {
 
-		Info.log("Stopping development environment")
-		err := dockerStop(containerName)
-		if err != nil {
-			return err
-		}
-		//dockerRemove(imageName) is not needed due to --rm flag
-		//os.Exit(1)
-		return nil
-	},
-}
-
-func init() {
-	rootCmd.AddCommand(stopCmd)
-	addNameFlags(stopCmd)
-
+			Info.log("Stopping development environment")
+			err := dockerStop(containerName, rootConfig.Dryrun)
+			if err != nil {
+				return err
+			}
+			//dockerRemove(imageName) is not needed due to --rm flag
+			//os.Exit(1)
+			return nil
+		},
+	}
+	addNameFlag(stopCmd, &containerName, rootConfig)
+	return stopCmd
 }

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -15,20 +15,20 @@ package cmd
 
 import "github.com/spf13/cobra"
 
-// testCmd represents the test command
-var testCmd = &cobra.Command{
-	Use:   "test",
-	Short: "Test your project in the local Appsody environment",
-	Long:  `This starts a docker container for your project and runs your test in it.`,
-	RunE: func(cmd *cobra.Command, args []string) error {
+func newTestCmd(rootConfig *RootCommandConfig) *cobra.Command {
+	config := &devCommonConfig{RootCommandConfig: rootConfig}
+	// testCmd represents the test command
+	var testCmd = &cobra.Command{
+		Use:   "test",
+		Short: "Test your project in the local Appsody environment",
+		Long:  `This starts a docker container for your project and runs your test in it.`,
+		RunE: func(cmd *cobra.Command, args []string) error {
 
-		Info.log("Running test environment")
-		return commonCmd(cmd, args, "test")
-	},
-}
+			Info.log("Running test environment")
+			return commonCmd(config, "test")
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(testCmd)
-	addDevCommonFlags(testCmd)
-
+	addDevCommonFlags(testCmd, config)
+	return testCmd
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -46,16 +46,9 @@ type NotAnAppsodyProject string
 
 func (e NotAnAppsodyProject) Error() string { return string(e) }
 
-var (
-	ConfigFile = ".appsody-config.yaml"
-)
+const ConfigFile = ".appsody-config.yaml"
 
-var (
-	LatestVersionURL = "https://github.com/appsody/appsody/releases/latest"
-)
-
-var imagePulled = make(map[string]bool)
-var projectConfig *ProjectConfig
+const LatestVersionURL = "https://github.com/appsody/appsody/releases/latest"
 
 const workDirNotSet = ""
 
@@ -72,25 +65,25 @@ func Exists(path string) (bool, error) {
 	return true, err
 }
 
-func GetEnvVar(searchEnvVar string) (string, error) {
+func GetEnvVar(searchEnvVar string, config *RootCommandConfig) (string, error) {
 	// TODO cache this so the buildah / docker inspect command only runs once per cli invocation
 
 	// Docker and Buildah produce slightly different output
 	// for `inspect` command. Array of maps vs. maps
 	var dataBuildah map[string]interface{}
 	var dataDocker []map[string]interface{}
-	projectConfig, projectConfigErr := getProjectConfig()
+	projectConfig, projectConfigErr := getProjectConfig(config)
 	if projectConfigErr != nil {
 		return "", projectConfigErr
 	}
 	imageName := projectConfig.Platform
-	pullErrs := pullImage(imageName)
+	pullErrs := pullImage(imageName, config)
 	if pullErrs != nil {
 		return "", pullErrs
 	}
 	cmdName := "docker"
 	cmdArgs := []string{"image", "inspect", imageName}
-	if buildah {
+	if config.Buildah {
 		cmdName = "buildah"
 		cmdArgs = []string{"inspect", "--format={{.Config}}", imageName}
 	}
@@ -104,13 +97,13 @@ func GetEnvVar(searchEnvVar string) (string, error) {
 
 	var err error
 	var envVars []interface{}
-	if buildah {
+	if config.Buildah {
 		err = json.Unmarshal([]byte(inspectOut), &dataBuildah)
 		if err != nil {
 			return "", errors.New("error unmarshaling data from inspect command - exiting")
 		}
-		config := dataBuildah["config"].(map[string]interface{})
-		envVars = config["Env"].([]interface{})
+		buildahConfig := dataBuildah["config"].(map[string]interface{})
+		envVars = buildahConfig["Env"].([]interface{})
 
 	} else {
 		err = json.Unmarshal([]byte(inspectOut), &dataDocker)
@@ -118,9 +111,9 @@ func GetEnvVar(searchEnvVar string) (string, error) {
 			return "", errors.New("error unmarshaling data from inspect command - exiting")
 
 		}
-		config := dataDocker[0]["Config"].(map[string]interface{})
+		dockerConfig := dataDocker[0]["Config"].(map[string]interface{})
 
-		envVars = config["Env"].([]interface{})
+		envVars = dockerConfig["Env"].([]interface{})
 	}
 
 	Debug.log("Number of environment variables in stack image: ", len(envVars))
@@ -144,17 +137,17 @@ func GetEnvVar(searchEnvVar string) (string, error) {
 
 }
 
-func getEnvVarBool(searchEnvVar string) (bool, error) {
-	strVal, envErr := GetEnvVar(searchEnvVar)
+func getEnvVarBool(searchEnvVar string, config *RootCommandConfig) (bool, error) {
+	strVal, envErr := GetEnvVar(searchEnvVar, config)
 	if envErr != nil {
 		return false, envErr
 	}
 	return strings.Compare(strings.TrimSpace(strings.ToUpper(strVal)), "TRUE") == 0, nil
 }
 
-func getEnvVarInt(searchEnvVar string) (int, error) {
+func getEnvVarInt(searchEnvVar string, config *RootCommandConfig) (int, error) {
 
-	strVal, envErr := GetEnvVar(searchEnvVar)
+	strVal, envErr := GetEnvVar(searchEnvVar, config)
 	if envErr != nil {
 		return 0, envErr
 	}
@@ -166,8 +159,8 @@ func getEnvVarInt(searchEnvVar string) (int, error) {
 
 }
 
-func getExtractDir() (string, error) {
-	extractDir, envErr := GetEnvVar("APPSODY_PROJECT_DIR")
+func getExtractDir(config *RootCommandConfig) (string, error) {
+	extractDir, envErr := GetEnvVar("APPSODY_PROJECT_DIR", config)
 	if envErr != nil {
 		return "", envErr
 	}
@@ -178,9 +171,9 @@ func getExtractDir() (string, error) {
 	return extractDir, nil
 }
 
-func getVolumeArgs() ([]string, error) {
+func getVolumeArgs(config *RootCommandConfig) ([]string, error) {
 	volumeArgs := []string{}
-	stackMounts, envErr := GetEnvVar("APPSODY_MOUNTS")
+	stackMounts, envErr := GetEnvVar("APPSODY_MOUNTS", config)
 	if envErr != nil {
 		return nil, envErr
 	}
@@ -197,7 +190,7 @@ func getVolumeArgs() ([]string, error) {
 		homeDir = homeDirOverride
 		homeDirOverridden = true
 	}
-	projectDir, perr := getProjectDir()
+	projectDir, perr := getProjectDir(config)
 	if perr != nil {
 		return volumeArgs, perr
 
@@ -256,67 +249,59 @@ func mountExistsLocally(mount string) bool {
 	return fileExists
 }
 
-func getProjectDir() (string, error) {
-	dir, err := os.Getwd()
-	if err != nil {
-		Error.log("Error getting current directory: ", err)
-		return "", err
-	}
-	appsodyConfig := filepath.Join(dir, ConfigFile)
+func getProjectDir(config *RootCommandConfig) (string, error) {
+	appsodyConfig := filepath.Join(config.ProjectDir, ConfigFile)
 	projectDir, err := Exists(appsodyConfig)
 	if err != nil {
 		Error.log(err)
 		return "", err
 	}
 	if !projectDir {
-
-		Debug.log("Current dir is not an appsody project.")
-		// +
-		// "Run `appsody init <stack>` to setup an appsody project. Run `appsody list` to see the available stacks.")
 		var e NotAnAppsodyProject = "The current directory is not a valid appsody project. Run `appsody init <stack>` to create one. Run `appsody list` to see the available stacks."
 		return "", &e
 	}
-	return dir, nil
+	return config.ProjectDir, nil
 }
 
-func getProjectConfig() (ProjectConfig, error) {
-	if projectConfig == nil {
-		dir, perr := getProjectDir()
+func getProjectConfig(config *RootCommandConfig) (ProjectConfig, error) {
+	if config.ProjectConfig == nil {
+		dir, perr := getProjectDir(config)
 		if perr != nil {
 			var tempProjectConfig ProjectConfig
 			return tempProjectConfig, errors.Errorf("The current directory is not a valid appsody project. Run appsody init <stack> to create one: %v", perr)
 
 		}
 		appsodyConfig := filepath.Join(dir, ConfigFile)
-		viper.SetConfigFile(appsodyConfig)
+		v := viper.New()
+		v.SetConfigFile(appsodyConfig)
 		Debug.log("Project config file set to: ", appsodyConfig)
-		err := viper.ReadInConfig()
+		err := v.ReadInConfig()
 		if err != nil {
 			var tempProjectConfig ProjectConfig
 			return tempProjectConfig, errors.Errorf("Error reading project config %v", err)
 
 		}
-		stack := viper.GetString("stack")
+		stack := v.GetString("stack")
 		Debug.log("Project stack from config file: ", stack)
-		imageRepo := cliConfig.GetString("images")
+		imageRepo := config.CliConfig.GetString("images")
 		Debug.log("Image repository set to: ", imageRepo)
 		if imageRepo != "index.docker.io" {
 			stack = imageRepo + "/" + stack
 		}
 		Debug.log("Pulling stack image as: ", stack)
-		projectConfig = &ProjectConfig{stack}
+		config.ProjectConfig = &ProjectConfig{stack}
 	}
-	return *projectConfig, nil
+	return *config.ProjectConfig, nil
 }
 
-func getOperatorHome() string {
-	operatorHome := cliConfig.GetString("operator")
+func getOperatorHome(config *RootCommandConfig) string {
+	operatorHome := config.CliConfig.GetString("operator")
 	Debug.log("Operator home set to: ", operatorHome)
 	return operatorHome
 }
 
-func getProjectName() (string, error) {
-	projectDir, err := getProjectDir()
+func getProjectName(config *RootCommandConfig) (string, error) {
+	projectDir, err := getProjectDir(config)
 	if err != nil {
 		return "my-project", err
 	}
@@ -325,13 +310,13 @@ func getProjectName() (string, error) {
 	return projectName, nil
 }
 
-func execAndWait(command string, args []string, logger appsodylogger) error {
+func execAndWait(command string, args []string, logger appsodylogger, dryrun bool) error {
 
-	return execAndWaitWithWorkDir(command, args, logger, workDirNotSet)
+	return execAndWaitWithWorkDir(command, args, logger, workDirNotSet, dryrun)
 }
-func execAndWaitWithWorkDir(command string, args []string, logger appsodylogger, workdir string) error {
+func execAndWaitWithWorkDir(command string, args []string, logger appsodylogger, workdir string, dryrun bool) error {
 
-	err := execAndWaitWithWorkDirReturnErr(command, args, logger, workdir)
+	err := execAndWaitWithWorkDirReturnErr(command, args, logger, workdir, dryrun)
 	if err != nil {
 		return errors.Errorf("Error running %s command: %v", command, err)
 
@@ -445,16 +430,16 @@ func UserHomeDir() string {
 	return homeDir
 }
 
-func getExposedPorts() ([]string, error) {
+func getExposedPorts(config *RootCommandConfig) ([]string, error) {
 	// TODO cache this so the docker inspect command only runs once per cli invocation
 	var data []map[string]interface{}
 	var portValues []string
-	projectConfig, projectConfigErr := getProjectConfig()
+	projectConfig, projectConfigErr := getProjectConfig(config)
 	if projectConfigErr != nil {
 		return nil, projectConfigErr
 	}
 	imageName := projectConfig.Platform
-	pullErrs := pullImage(imageName)
+	pullErrs := pullImage(imageName, config)
 	if pullErrs != nil {
 		return nil, pullErrs
 	}
@@ -472,10 +457,10 @@ func getExposedPorts() ([]string, error) {
 		return portValues, errors.Errorf("Error unmarshaling data from inspect command - exiting %v", err)
 	}
 
-	config := data[0]["Config"].(map[string]interface{})
+	dockerConfig := data[0]["Config"].(map[string]interface{})
 
-	if config["ExposedPorts"] != nil {
-		exposedPorts := config["ExposedPorts"].(map[string]interface{})
+	if dockerConfig["ExposedPorts"] != nil {
+		exposedPorts := dockerConfig["ExposedPorts"].(map[string]interface{})
 
 		portValues = make([]string, 0, len(exposedPorts))
 		for k := range exposedPorts {
@@ -488,7 +473,7 @@ func getExposedPorts() ([]string, error) {
 }
 
 //GenKnativeYaml generates a simple yaml for KNative serving
-func GenKnativeYaml(yamlTemplate string, deployPort int, serviceName string, deployImage string, pullImage bool) (fileName string, yamlErr error) {
+func GenKnativeYaml(yamlTemplate string, deployPort int, serviceName string, deployImage string, pullImage bool, configFile string, dryrun bool) (fileName string, yamlErr error) {
 	// KNative serving YAML representation in a struct
 	type Y struct {
 		APIVersion string `yaml:"apiVersion"`
@@ -599,7 +584,7 @@ spec:
 }
 
 // DockerTag tags a docker image
-func DockerTag(imageToTag string, tag string) error {
+func DockerTag(imageToTag string, tag string, dryrun bool) error {
 	Info.log("Tagging Docker image as ", tag)
 	cmdName := "docker"
 	cmdArgs := []string{"image", "tag", imageToTag, tag}
@@ -618,7 +603,7 @@ func DockerTag(imageToTag string, tag string) error {
 }
 
 //DockerPush pushes a docker image to a docker registry (assumes that the user has done docker login)
-func DockerPush(imageToPush string) error {
+func DockerPush(imageToPush string, dryrun bool) error {
 	Info.log("Pushing docker image ", imageToPush)
 	cmdName := "docker"
 	cmdArgs := []string{"push", imageToPush}
@@ -637,10 +622,10 @@ func DockerPush(imageToPush string) error {
 }
 
 // DockerRunBashCmd issues a shell command in a docker image, overriding its entrypoint
-func DockerRunBashCmd(options []string, image string, bashCmd string) (cmdOutput string, err error) {
+func DockerRunBashCmd(options []string, image string, bashCmd string, config *RootCommandConfig) (cmdOutput string, err error) {
 	cmdName := "docker"
 	var cmdArgs []string
-	pullErrs := pullImage(image)
+	pullErrs := pullImage(image, config)
 	if pullErrs != nil {
 		return "", pullErrs
 	}
@@ -662,7 +647,7 @@ func DockerRunBashCmd(options []string, image string, bashCmd string) (cmdOutput
 }
 
 //KubeGet issues kubectl get <arg>
-func KubeGet(args []string) (string, error) {
+func KubeGet(args []string, namespace string, dryrun bool) (string, error) {
 	Info.log("Attempting to get resource from Kubernetes ...")
 	kcmd := "kubectl"
 	kargs := []string{"get"}
@@ -685,7 +670,7 @@ func KubeGet(args []string) (string, error) {
 }
 
 //KubeApply issues kubectl apply -f <filename>
-func KubeApply(fileToApply string) error {
+func KubeApply(fileToApply string, namespace string, dryrun bool) error {
 	Info.log("Attempting to apply resource in Kubernetes ...")
 	kcmd := "kubectl"
 	kargs := []string{"apply", "-f", fileToApply}
@@ -709,7 +694,7 @@ func KubeApply(fileToApply string) error {
 }
 
 //KubeDelete issues kubectl delete -f <filename>
-func KubeDelete(fileToApply string) error {
+func KubeDelete(fileToApply string, namespace string, dryrun bool) error {
 	Info.log("Attempting to delete resource from Kubernetes...")
 	kcmd := "kubectl"
 	kargs := []string{"delete", "-f", fileToApply}
@@ -737,10 +722,10 @@ func KubeDelete(fileToApply string) error {
 }
 
 //KubeGetNodePortURL kubectl get svc <service> -o jsonpath=http://{.status.loadBalancer.ingress[0].hostname}:{.spec.ports[0].nodePort} and prints the return URL
-func KubeGetNodePortURL(service string) (url string, err error) {
+func KubeGetNodePortURL(service string, namespace string, dryrun bool) (url string, err error) {
 	kargs := append([]string{"svc"}, service)
 	kargs = append(kargs, "-o", "jsonpath=http://{.status.loadBalancer.ingress[0].hostname}:{.spec.ports[0].nodePort}")
-	out, err := KubeGet(kargs)
+	out, err := KubeGet(kargs, namespace, dryrun)
 	// Performing the kubectl apply
 	if err != nil {
 		return "", errors.Errorf("Failed to find deployed service IP and Port: %s", err)
@@ -749,10 +734,10 @@ func KubeGetNodePortURL(service string) (url string, err error) {
 }
 
 //KubeGetRouteURL issues kubectl get svc <service> -o jsonpath=http://{.status.loadBalancer.ingress[0].hostname}:{.spec.ports[0].nodePort} and prints the return URL
-func KubeGetRouteURL(service string) (url string, err error) {
+func KubeGetRouteURL(service string, namespace string, dryrun bool) (url string, err error) {
 	kargs := append([]string{"route"}, service)
 	kargs = append(kargs, "-o", "jsonpath={.status.ingress[0].host}")
-	out, err := KubeGet(kargs)
+	out, err := KubeGet(kargs, namespace, dryrun)
 	// Performing the kubectl apply
 	if err != nil {
 		return "", errors.Errorf("Failed to find deployed service IP and Port: %s", err)
@@ -761,7 +746,7 @@ func KubeGetRouteURL(service string) (url string, err error) {
 }
 
 //KubeGetKnativeURL issues kubectl get rt <service> -o jsonpath="{.status.url}" and prints the return URL
-func KubeGetKnativeURL(service string) (url string, err error) {
+func KubeGetKnativeURL(service string, namespace string, dryrun bool) (url string, err error) {
 	kcmd := "kubectl"
 	kargs := append([]string{"get", "rt"}, service)
 	kargs = append(kargs, "-o", "jsonpath=\"{.status.url}\"")
@@ -783,16 +768,16 @@ func KubeGetKnativeURL(service string) (url string, err error) {
 }
 
 //KubeGetDeploymentURL searches for an exposed hostname and port for the deployed service
-func KubeGetDeploymentURL(service string) (url string, err error) {
-	url, err = KubeGetKnativeURL(service)
+func KubeGetDeploymentURL(service string, namespace string, dryrun bool) (url string, err error) {
+	url, err = KubeGetKnativeURL(service, namespace, dryrun)
 	if err == nil {
 		return url, nil
 	}
-	url, err = KubeGetRouteURL(service)
+	url, err = KubeGetRouteURL(service, namespace, dryrun)
 	if err == nil {
 		return url, nil
 	}
-	url, err = KubeGetNodePortURL(service)
+	url, err = KubeGetNodePortURL(service, namespace, dryrun)
 	if err == nil {
 		return url, nil
 	}
@@ -803,7 +788,7 @@ func KubeGetDeploymentURL(service string) (url string, err error) {
 //pullCmd
 // enable extract to use `buildah` sequences for image extraction.
 // Pull the given docker image
-func pullCmd(imageToPull string) error {
+func pullCmd(imageToPull string, buildah bool, dryrun bool) error {
 	cmdName := "docker"
 	if buildah {
 		cmdName = "buildah"
@@ -814,7 +799,7 @@ func pullCmd(imageToPull string) error {
 		return nil
 	}
 	Debug.log("Pulling docker image ", imageToPull)
-	err := execAndWaitReturnErr(cmdName, pullArgs, Debug)
+	err := execAndWaitReturnErr(cmdName, pullArgs, Debug, dryrun)
 	if err != nil {
 		Warning.log("Docker image pull failed: ", err)
 		return err
@@ -843,14 +828,16 @@ func checkDockerImageExistsLocally(imageToPull string) bool {
 //pullImage
 // pulls buildah / docker image, if APPSODY_PULL_POLICY set to IFNOTPRESENT
 //it checks for image in local repo and pulls if not in the repo
-func pullImage(imageToPull string) error {
-
-	Debug.logf("%s image pulled status: %t", imageToPull, imagePulled[imageToPull])
-	if imagePulled[imageToPull] {
+func pullImage(imageToPull string, config *RootCommandConfig) error {
+	if config.imagePulled == nil {
+		config.imagePulled = make(map[string]bool)
+	}
+	Debug.logf("%s image pulled status: %t", imageToPull, config.imagePulled[imageToPull])
+	if config.imagePulled[imageToPull] {
 		Debug.log("Image has been pulled already: ", imageToPull)
 		return nil
 	}
-	imagePulled[imageToPull] = true
+	config.imagePulled[imageToPull] = true
 
 	localImageFound := false
 	pullPolicyAlways := true
@@ -866,7 +853,7 @@ func pullImage(imageToPull string) error {
 	}
 
 	if pullPolicyAlways || (!pullPolicyAlways && !localImageFound) {
-		err := pullCmd(imageToPull)
+		err := pullCmd(imageToPull, config.Buildah, config.Dryrun)
 		if err != nil {
 			if pullPolicyAlways {
 				localImageFound = checkDockerImageExistsLocally(imageToPull)
@@ -883,7 +870,7 @@ func pullImage(imageToPull string) error {
 	return nil
 }
 
-func execAndListenWithWorkDirReturnErr(command string, args []string, logger appsodylogger, workdir string) (*exec.Cmd, error) {
+func execAndListenWithWorkDirReturnErr(command string, args []string, logger appsodylogger, workdir string, dryrun bool) (*exec.Cmd, error) {
 	var execCmd *exec.Cmd
 	var err error
 	if dryrun {
@@ -931,16 +918,16 @@ func execAndListenWithWorkDirReturnErr(command string, args []string, logger app
 	return execCmd, err
 }
 
-func execAndWaitReturnErr(command string, args []string, logger appsodylogger) error {
-	return execAndWaitWithWorkDirReturnErr(command, args, logger, "")
+func execAndWaitReturnErr(command string, args []string, logger appsodylogger, dryrun bool) error {
+	return execAndWaitWithWorkDirReturnErr(command, args, logger, "", dryrun)
 }
-func execAndWaitWithWorkDirReturnErr(command string, args []string, logger appsodylogger, workdir string) error {
+func execAndWaitWithWorkDirReturnErr(command string, args []string, logger appsodylogger, workdir string, dryrun bool) error {
 	var err error
 	var execCmd *exec.Cmd
 	if dryrun {
 		Info.log("Dry Run - Skipping command: ", command, " ", strings.Join(args, " "))
 	} else {
-		execCmd, err = execAndListenWithWorkDirReturnErr(command, args, logger, workdir)
+		execCmd, err = execAndListenWithWorkDirReturnErr(command, args, logger, workdir, dryrun)
 		if err != nil {
 			return err
 		}
@@ -990,6 +977,7 @@ func checksum256TestFile(newFileName string, oldFileName string) (bool, error) {
 
 func getLatestVersion() string {
 	var version string
+	Debug.log("Getting latest version ", LatestVersionURL)
 	resp, err := http.Get(LatestVersionURL)
 	if err != nil {
 		Warning.log("Unable to check the most recent version of Appsody in GitHub.... continuing.")
@@ -999,13 +987,13 @@ func getLatestVersion() string {
 
 		version = r.FindString(url)
 	}
+	Debug.log("Got version ", version)
 	return version
 }
 
-func doVersionCheck() {
+func doVersionCheck(config *RootCommandConfig) {
 	var latest = getLatestVersion()
 	var currentTime = time.Now().Format("2006-01-02 15:04:05 -0700 MST")
-	configFile = getDefaultConfigFile()
 
 	if latest != "" && VERSION != "vlatest" && VERSION != latest {
 		switch os := runtime.GOOS; os {
@@ -1016,35 +1004,35 @@ func doVersionCheck() {
 		}
 	}
 
-	cliConfig.Set("lastversioncheck", currentTime)
-	if err := cliConfig.WriteConfig(); err != nil {
+	config.CliConfig.Set("lastversioncheck", currentTime)
+	if err := config.CliConfig.WriteConfig(); err != nil {
 		Error.logf("Writing default config file %s", err)
 
 	}
 }
 
-func getLastCheckTime() string {
-	return cliConfig.GetString("lastversioncheck")
+func getLastCheckTime(config *RootCommandConfig) string {
+	return config.CliConfig.GetString("lastversioncheck")
 }
 
-func checkTime() {
-	var lastCheckTime = getLastCheckTime()
+func checkTime(config *RootCommandConfig) {
+	var lastCheckTime = getLastCheckTime(config)
 
 	lastTime, err := time.Parse("2006-01-02 15:04:05 -0700 MST", lastCheckTime)
 	if err != nil {
 		Debug.logf("Could not parse the config file's lastversioncheck: %v. Continuing with a new version check...", err)
-		doVersionCheck()
+		doVersionCheck(config)
 	} else if time.Since(lastTime).Hours() > 24 {
-		doVersionCheck()
+		doVersionCheck(config)
 	}
 
 }
 
 // TEMPORARY CODE: sets the old v1 index to point to the new v2 index (latest)
 // this code should be removed when we think everyone is using the latest index.
-func setNewIndexURL() {
+func setNewIndexURL(config *RootCommandConfig) {
 
-	var repoFile = getRepoFileLocation()
+	var repoFile = getRepoFileLocation(config)
 	var oldIndexURL = "https://raw.githubusercontent.com/appsody/stacks/master/index.yaml"
 	var newIndexURL = "https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml"
 

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -44,7 +44,7 @@ func TestGenYAML(t *testing.T) {
 			testPortNum := test.testPortNum
 			testGetter := test.yamlTemplateGetter
 			testPullPolicy := test.testPullPolicy
-			yamlFileName, err := cmd.GenKnativeYaml(testGetter(), testPortNum, testServiceName, testImageName, testPullPolicy)
+			yamlFileName, err := cmd.GenKnativeYaml(testGetter(), testPortNum, testServiceName, testImageName, testPullPolicy, "app-deploy.yaml", false)
 			if err != nil {
 				t.Fatal("Can't generate the YAML for KNative serving deploy. Error: ", err)
 			}

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -18,16 +18,16 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// versionCmd represents the version command
-var versionCmd = &cobra.Command{
-	Use:   "version",
-	Short: "Show Appsody CLI version",
-	Long:  ``,
-	Run: func(cmd *cobra.Command, args []string) {
-		Info.log(rootCmd.Use, " ", VERSION)
-	},
-}
+func newVersionCmd(rootCmd *cobra.Command) *cobra.Command {
+	// versionCmd represents the version command
+	var versionCmd = &cobra.Command{
+		Use:   "version",
+		Short: "Show Appsody CLI version",
+		Long:  ``,
+		Run: func(cmd *cobra.Command, args []string) {
+			Info.log(rootCmd.Use, " ", VERSION)
+		},
+	}
 
-func init() {
-	rootCmd.AddCommand(versionCmd)
+	return versionCmd
 }

--- a/functest/extract_test.go
+++ b/functest/extract_test.go
@@ -107,8 +107,13 @@ func TestExtract(t *testing.T) {
 		if err != nil {
 			t.Fatal("Error changing directory: ", err)
 		}
-		mounts, _ := cmd.GetEnvVar("APPSODY_MOUNTS")
-		pDir, _ := cmd.GetEnvVar("APPSODY_PROJECT_DIR")
+		config := &cmd.RootCommandConfig{}
+		err = cmd.InitConfig(config)
+		if err != nil {
+			t.Fatal("Could not init appsody config", err)
+		}
+		mounts, _ := cmd.GetEnvVar("APPSODY_MOUNTS", config)
+		pDir, _ := cmd.GetEnvVar("APPSODY_PROJECT_DIR", config)
 
 		err = os.Chdir(oldDir)
 		if err != nil {


### PR DESCRIPTION
Fixes #378 

I've managed to remove all the global vars and init() functions. It isn't pretty, sorry for the large PR, but it is necessary. For now it is mostly passing around config structs as method parameters, but in the future I hope to continue refactoring this into proper objects.