### PR TITLE
Fix scaffold test

### DIFF
--- a/functest/init_test.go
+++ b/functest/init_test.go
@@ -369,7 +369,7 @@ func TestInitV2WithDefaultRepoSpecifiedTemplateNonDefault(t *testing.T) {
 	log.Println("Created project dir: " + projectDir)
 
 	// appsody init nodejs-express
-	_, err = cmdtest.RunAppsodyCmdExec([]string{"init", "appsodyhub/nodejs-express", "skaffold"}, projectDir)
+	_, err = cmdtest.RunAppsodyCmdExec([]string{"init", "appsodyhub/nodejs-express", "scaffold"}, projectDir)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
We updated the nodejs-express template from `skaffold` to `scaffold`, and the test had not been updated. This is currently failing in multiple PRs on the Linux builds, since we only run functional tests on Linux.