### PR TITLE
added --no-watcher to appsody test

### DIFF
--- a/cmd/stack_validate.go
+++ b/cmd/stack_validate.go
@@ -272,7 +272,7 @@ func TestTest(projectDir string) error {
 	Info.Log("******************************************")
 	Info.Log("Running appsody test")
 	Info.Log("******************************************")
-	_, err := RunAppsodyCmdExec([]string{"test"}, projectDir)
+	_, err := RunAppsodyCmdExec([]string{"test", "--no-watcher"}, projectDir)
 	return err
 }
 


### PR DESCRIPTION
adding this for stacks like python-flask that use the watcher during `test` which cause `test` to not return which causes `appsody stack validate` to hang forever