### PR TITLE
Fix testutils RunAppsodyCmd so it doesn't use os.Args or os.Getwd

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -180,18 +180,18 @@ func Execute(version string) {
 		fmt.Println("Error getting current directory: ", err)
 		os.Exit(1)
 	}
-	if err := ExecuteE(version, dir, os.Args); err != nil {
+	if err := ExecuteE(version, dir, os.Args[1:]); err != nil {
 		os.Exit(1)
 	}
 }
 
 func ExecuteE(version string, projectDir string, args []string) error {
 	VERSION = version
-	rootCmd, err := newRootCmd(projectDir, args[1:])
+	rootCmd, err := newRootCmd(projectDir, args)
 	if err != nil {
 		Error.log(err)
 	}
-	Debug.log("Running with command line args: appsody ", strings.Join(args[1:], " "))
+	Debug.log("Running with command line args: appsody ", strings.Join(args, " "))
 	err = rootCmd.Execute()
 	if err != nil {
 		Error.log(err)

--- a/functest/extract_test.go
+++ b/functest/extract_test.go
@@ -58,6 +58,11 @@ func TestExtract(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
+		// remove symlinks from the path
+		// on mac, TMPDIR is set to /var which is a symlink to /private/var.
+		//    Docker by default shares mounts with /private but not /var,
+		//    so resolving the symlinks ensures docker can mount the temp dir
+		projectDir, _ = filepath.EvalSymlinks(projectDir)
 
 		defer os.RemoveAll(projectDir)
 		log.Println("Created project dir: " + projectDir)


### PR DESCRIPTION
Fixes #434 