### PR TITLE
Refactor project name

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -265,7 +265,10 @@ func install(config *initCommandConfig) error {
 	if configErr != nil {
 		return configErr
 	}
-	if projectConfig.ProjectName == "" {
+
+	// save the project name to .appsody-config.yaml only if it doesn't already exist there
+	// or if the user specified --project-name on the command line
+	if projectConfig.ProjectName == "" || config.projectName != defaultProjectName(config.RootCommandConfig) {
 		err := saveProjectNameToConfig(config.projectName, config.RootCommandConfig)
 		if err != nil {
 			return err

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -85,6 +85,10 @@ func initAppsody(stack string, template string, config *initCommandConfig) error
 	if noTemplate {
 		Warning.log("The --no-template flag has been deprecated.  Please specify a template value of \"none\" instead.")
 	}
+	valid, err := IsValidProjectName(config.projectName)
+	if !valid {
+		return err
+	}
 	//var index RepoIndex
 	var repos RepositoryFile
 	if _, err := repos.getRepos(config.RootCommandConfig); err != nil {
@@ -92,7 +96,7 @@ func initAppsody(stack string, template string, config *initCommandConfig) error
 	}
 	var proceedWithTemplate bool
 
-	err := CheckPrereqs()
+	err = CheckPrereqs()
 	if err != nil {
 		Warning.logf("Failed to check prerequisites: %v\n", err)
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -258,7 +258,7 @@ func install(config *initCommandConfig) error {
 
 	}
 
-	err := setProjectName(projectDir, config.projectName)
+	err := saveProjectNameToConfig(config.projectName, config.RootCommandConfig)
 	if err != nil {
 		return errors.Errorf("%v", err)
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -589,7 +589,7 @@ func defaultProjectName(config *RootCommandConfig) string {
 		}
 	}
 
-	projectName, err := convertToValidContainerName(projectDirPath)
+	projectName, err := ConvertToValidProjectName(projectDirPath)
 	if err != nil {
 		Error.log(err)
 		os.Exit(1)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -258,23 +258,24 @@ func install(config *initCommandConfig) error {
 	Info.log("Setting up the development environment")
 	projectDir, perr := getProjectDir(config.RootCommandConfig)
 	if perr != nil {
-		return errors.Errorf("%v", perr)
-
+		return perr
 	}
 
-	err := saveProjectNameToConfig(config.projectName, config.RootCommandConfig)
-	if err != nil {
-		return errors.Errorf("%v", err)
-	}
 	projectConfig, configErr := getProjectConfig(config.RootCommandConfig)
 	if configErr != nil {
 		return configErr
+	}
+	if projectConfig.ProjectName == "" {
+		err := saveProjectNameToConfig(config.projectName, config.RootCommandConfig)
+		if err != nil {
+			return err
+		}
 	}
 	platformDefinition := projectConfig.Stack
 
 	Debug.logf("Setting up the development environment for projectDir: %s and platform: %s", projectDir, platformDefinition)
 
-	err = extractAndInitialize(config)
+	err := extractAndInitialize(config)
 	if err != nil {
 		// For some reason without this sleep, the [InitScript] output log would get cut off and
 		// intermixed with the following Warning logs when verbose logging. Adding this sleep as a workaround.

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -45,7 +45,6 @@ type RootCommandConfig struct {
 	Buildah          bool
 	ProjectConfig    *ProjectConfig
 	ProjectDir       string
-	projectName      string
 	UnsupportedRepos []string
 
 	// package scoped, these are mostly for caching
@@ -92,6 +91,10 @@ Complete documentation is available at https://appsody.dev`,
 	rootCmd.SetArgs(args)
 	_ = rootCmd.ParseFlags(args) // ignore flag errors here because we haven't added all the commands
 	initLogging(rootConfig)
+	setupErr := setupConfig(args, rootConfig)
+	if setupErr != nil {
+		return rootCmd, setupErr
+	}
 
 	rootCmd.AddCommand(
 		newInitCmd(rootConfig),
@@ -112,10 +115,6 @@ Complete documentation is available at https://appsody.dev`,
 		newVersionCmd(rootCmd),
 	)
 
-	setupErr := setupConfig(args, rootConfig)
-	if setupErr != nil {
-		return rootCmd, setupErr
-	}
 	appsodyOnK8S := os.Getenv("APPSODY_K8S_EXPERIMENTAL")
 	if appsodyOnK8S == "TRUE" {
 		rootConfig.Buildah = true

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -298,7 +298,7 @@ func IsValidProjectName(name string) (bool, error) {
 		if len(name) < 128 {
 			return match, nil
 		}
-		return false, errors.Errorf("Invalid project-name \"%s\". The name cannot be longer than 127 characters", name)
+		return false, errors.Errorf("Invalid project-name \"%s\". The name must be less than 128 characters", name)
 	}
 
 	return match, errors.Errorf("Invalid project-name \"%s\". The name must start with a lowercase letter, contain only lowercase letters, numbers, or dashes, and cannot end in a dash.", name)


### PR DESCRIPTION
Fixes #287 

Removed projectName from RootCommandConfig and use ProjectConfig.ProjectName instead
Removed setProjectName func and instead created a simpler saveProjectNameToConfig func
Simplify getProjectName