### PR TITLE
Fix regression that prevents config of alternative stack repositories

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -432,10 +432,10 @@ func getProjectConfig(config *RootCommandConfig) (*ProjectConfig, error) {
 		Debug.log("Project stack from config file: ", projectConfig.Stack)
 		imageRepo := config.CliConfig.GetString("images")
 		Debug.log("Image repository set to: ", imageRepo)
+		projectConfig.Stack = stack
 		if imageRepo != "index.docker.io" {
 			projectConfig.Stack = imageRepo + "/" + projectConfig.Stack
 		}
-		projectConfig.Stack = stack
 
 		config.ProjectConfig = &projectConfig
 	}


### PR DESCRIPTION
It looks like #375 broke the ability to set an alternative image repo for the stack images by setting `projectConfig.Stack = stack` after it has been updated with the config.

This PR moves this to before the custom config, allowing the config to override the default.