### PR TITLE
Fixing labels

### DIFF
--- a/cmd/git_utils.go
+++ b/cmd/git_utils.go
@@ -159,7 +159,18 @@ func RunGitConfigLocalRemoteOriginURL(upstream string, dryrun bool) (string, err
 
 	upstreamStart := strings.Split(upstream, "/")[0]
 	kargs := []string{"config", "--local", "remote." + upstreamStart + ".url"}
-	return RunGit(kargs, dryrun)
+	remote, err := RunGit(kargs, dryrun)
+	if err != nil {
+		return remote, err
+	}
+
+	// Convert ssh remote to https
+	if strings.Contains(remote, "git@") {
+		strings.Replace(remote, ":", "/", -1)
+		strings.Replace(remote, "git@", "https://", -1)
+	}
+
+	return remote, err
 }
 
 //RunGitLog issues git log
@@ -207,5 +218,7 @@ func RunGit(kargs []string, dryrun bool) (string, error) {
 		return "", errors.Errorf("git command failed: %s", string(kout[:]))
 	}
 	Debug.log("Command successful...")
-	return string(kout[:]), nil
+	result := string(kout[:])
+	strings.TrimRight(result, "\n")
+	return result, nil
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -633,7 +633,7 @@ func getGitLabels(config *RootCommandConfig) (map[string]string, error) {
 	}
 
 	var commitInfo = gitInfo.Commit
-	revisionKey := appsodyKeyPrefix + "revision"
+	revisionKey := ociKeyPrefix + "revision"
 	if commitInfo.SHA != "" {
 		labels[revisionKey] = commitInfo.SHA
 		if gitInfo.ChangesMade {


### PR DESCRIPTION
- Converting ssh git remotes to https
- Removing  `\n` from remote urls
- Correcting the prefix for the revision label
