### PR TITLE
Standardised most of the error propagation in utils.go

### DIFF
--- a/cmd/docker_commands.go
+++ b/cmd/docker_commands.go
@@ -6,6 +6,8 @@ import (
 	"os"
 	"os/exec"
 	"strings"
+
+	"github.com/pkg/errors"
 )
 
 func DockerRunAndListen(args []string, logger appsodylogger, interactive bool, verbose bool, dryrun bool) (*exec.Cmd, error) {
@@ -40,8 +42,8 @@ func RunDockerInspect(imageName string) (string, error) {
 	cmdArgs := []string{"image", "inspect", imageName}
 	Debug.Logf("About to run %s with args %s ", cmdName, cmdArgs)
 	inspectCmd := exec.Command(cmdName, cmdArgs...)
-	output, err := inspectCmd.Output()
-	return string(output), err
+	output, err := SeperateOutput(inspectCmd)
+	return output, err
 }
 
 func RunKubeCommandAndListen(args []string, logger appsodylogger, interactive bool, verbose bool, dryrun bool) (*exec.Cmd, error) {
@@ -98,10 +100,10 @@ func RunCommandAndListen(commandValue string, args []string, logger appsodylogge
 			}
 		}()
 
-		err = execCmd.Start()
+		out, err := SeperateOutput(execCmd)
 		if err != nil {
-			Debug.log("Error running ", command, " command: ", logScanner.Text(), err)
-			return nil, err
+			Debug.log("Error running ", command, " command: ", logScanner.Text(), out)
+			return nil, errors.Errorf(out)
 		}
 
 	}

--- a/cmd/docker_commands.go
+++ b/cmd/docker_commands.go
@@ -6,8 +6,6 @@ import (
 	"os"
 	"os/exec"
 	"strings"
-
-	"github.com/pkg/errors"
 )
 
 func DockerRunAndListen(args []string, logger appsodylogger, interactive bool, verbose bool, dryrun bool) (*exec.Cmd, error) {
@@ -100,10 +98,10 @@ func RunCommandAndListen(commandValue string, args []string, logger appsodylogge
 			}
 		}()
 
-		out, err := SeperateOutput(execCmd)
+		err = execCmd.Start()
 		if err != nil {
-			Debug.log("Error running ", command, " command: ", logScanner.Text(), out)
-			return nil, errors.Errorf(out)
+			Debug.log("Error running ", command, " command: ", logScanner.Text(), err)
+			return nil, err
 		}
 
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -486,7 +486,7 @@ func extractAndInitialize(config *initCommandConfig) error {
 		scriptFindOut, err := DockerRunBashCmd(cmdOptions, stackImage, bashCmd, config.RootCommandConfig)
 		if err != nil {
 			Debug.log("Failed to run the find command for the ", scriptFileName, " on the stack image: ", stackImage)
-			return fmt.Errorf("Failed to run the docker find command: %s", err)
+			return fmt.Errorf("Failed to run the docker find command: %s", scriptFindOut)
 		}
 
 		if scriptFindOut == "" {

--- a/cmd/testdata/default_repository_config/config.yaml
+++ b/cmd/testdata/default_repository_config/config.yaml
@@ -1,5 +1,5 @@
 home: testdata/default_repository_config
 images: index.docker.io
-lastversioncheck: 2019-10-17 17:32:59 +0100 BST
+lastversioncheck: 2019-10-28 13:33:19 +0000 GMT
 operator: https://github.com/appsody/appsody-operator/releases/latest/download
 tektonserver: ""

--- a/cmd/testdata/empty_repository_config/config.yaml
+++ b/cmd/testdata/empty_repository_config/config.yaml
@@ -1,5 +1,5 @@
 home: testdata/empty_repository_config
 images: index.docker.io
-lastversioncheck: 2019-10-07 13:27:24 +0100 BST
+lastversioncheck: 2019-10-28 13:33:18 +0000 GMT
 operator: https://github.com/appsody/appsody-operator/releases/latest/download
 tektonserver: ""

--- a/cmd/testdata/multiple_repository_config/config.yaml
+++ b/cmd/testdata/multiple_repository_config/config.yaml
@@ -1,5 +1,5 @@
 home: testdata/multiple_repository_config
 images: index.docker.io
-lastversioncheck: 2019-10-07 13:27:27 +0100 BST
+lastversioncheck: 2019-10-28 13:33:20 +0000 GMT
 operator: https://github.com/appsody/appsody-operator/releases/latest/download
 tektonserver: ""

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -677,7 +677,7 @@ func getStackLabels(config *RootCommandConfig) (map[string]string, error) {
 		} else {
 			inspectOut, inspectErr := RunDockerInspect(imageName)
 			if inspectErr != nil {
-				return config.cachedStackLabels, errors.Errorf("Could not inspect the image: %v", inspectErr)
+				return config.cachedStackLabels, errors.Errorf("Could not inspect the image: %s", inspectOut)
 			}
 			err := json.Unmarshal([]byte(inspectOut), &data)
 			if err != nil {
@@ -731,7 +731,7 @@ func getExposedPorts(config *RootCommandConfig) ([]string, error) {
 	} else {
 		inspectOut, inspectErr := RunDockerInspect(imageName)
 		if inspectErr != nil {
-			return portValues, errors.Errorf("Could not inspect the image: %v", inspectErr)
+			return portValues, errors.Errorf("Could not inspect the image: %s", inspectOut)
 		}
 		err := json.Unmarshal([]byte(inspectOut), &data)
 		if err != nil {
@@ -1883,6 +1883,7 @@ func SeperateOutput(cmd *exec.Cmd) (string, error) {
 
 	// If there was an error, return the stdErr & err
 	if err != nil {
+		Info.log("@@@@@@@@@@@", stdErr.String())
 		return err.Error() + ": " + strings.TrimSpace(stdErr.String()), err
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -108,7 +108,7 @@ func GetEnvVar(searchEnvVar string, config *RootCommandConfig) (string, error) {
 	}
 
 	inspectCmd := exec.Command(cmdName, cmdArgs...)
-	inspectOut, inspectErr := seperateOutput(inspectCmd)
+	inspectOut, inspectErr := SeperateOutput(inspectCmd)
 	if inspectErr != nil {
 		return "", errors.Errorf("Could not inspect the image: %s", inspectOut)
 	}
@@ -1283,7 +1283,7 @@ func DockerTag(imageToTag string, tag string, dryrun bool) error {
 		return nil
 	}
 	tagCmd := exec.Command(cmdName, cmdArgs...)
-	kout, kerr := seperateOutput(tagCmd)
+	kout, kerr := SeperateOutput(tagCmd)
 	if kerr != nil {
 		return errors.Errorf("docker image tag failed: %s", kout)
 	}
@@ -1302,7 +1302,7 @@ func DockerPush(imageToPush string, dryrun bool) error {
 	}
 
 	pushCmd := exec.Command(cmdName, cmdArgs...)
-	kout, kerr := seperateOutput(pushCmd)
+	kout, kerr := SeperateOutput(pushCmd)
 	if kerr != nil {
 		return errors.Errorf("docker push failed: %s", kout)
 	}
@@ -1326,7 +1326,7 @@ func DockerRunBashCmd(options []string, image string, bashCmd string, config *Ro
 	Info.log("Running command: ", cmdName, " ", strings.Join(cmdArgs, " "))
 	dockerCmd := exec.Command(cmdName, cmdArgs...)
 
-	kout, kerr := seperateOutput(dockerCmd)
+	kout, kerr := SeperateOutput(dockerCmd)
 	if kerr != nil {
 		return kout, kerr
 	}
@@ -1349,7 +1349,7 @@ func KubeGet(args []string, namespace string, dryrun bool) (string, error) {
 	}
 	Info.log("Running command: ", kcmd, " ", strings.Join(kargs, " "))
 	execCmd := exec.Command(kcmd, kargs...)
-	kout, kerr := seperateOutput(execCmd)
+	kout, kerr := SeperateOutput(execCmd)
 	if kerr != nil {
 		return "", errors.Errorf("kubectl get failed: %s", kout)
 	}
@@ -1371,7 +1371,7 @@ func KubeApply(fileToApply string, namespace string, dryrun bool) error {
 	}
 	Info.log("Running command: ", kcmd, " ", strings.Join(kargs, " "))
 	execCmd := exec.Command(kcmd, kargs...)
-	kout, kerr := seperateOutput(execCmd)
+	kout, kerr := SeperateOutput(execCmd)
 	if kerr != nil {
 		return errors.Errorf("kubectl apply failed: %s", kout)
 	}
@@ -1395,7 +1395,7 @@ func KubeDelete(fileToApply string, namespace string, dryrun bool) error {
 	Info.log("Running command: ", kcmd, " ", strings.Join(kargs, " "))
 	execCmd := exec.Command(kcmd, kargs...)
 
-	kout, kerr := seperateOutput(execCmd)
+	kout, kerr := SeperateOutput(execCmd)
 	if kerr != nil {
 		return errors.Errorf("kubectl delete failed: %s", kout)
 	}
@@ -1442,7 +1442,7 @@ func KubeGetKnativeURL(service string, namespace string, dryrun bool) (url strin
 	}
 	Info.log("Running command: ", kcmd, " ", strings.Join(kargs, " "))
 	execCmd := exec.Command(kcmd, kargs...)
-	kout, kerr := seperateOutput(execCmd)
+	kout, kerr := SeperateOutput(execCmd)
 	if kerr != nil {
 		return "", errors.Errorf("kubectl get failed: %s", kout)
 	}
@@ -1493,7 +1493,7 @@ func checkDockerImageExistsLocally(imageToPull string) bool {
 	cmdName := "docker"
 	cmdArgs := []string{"image", "ls", "-q", imageToPull}
 	imagelsCmd := exec.Command(cmdName, cmdArgs...)
-	imagelsOut, imagelsErr := seperateOutput(imagelsCmd)
+	imagelsOut, imagelsErr := SeperateOutput(imagelsCmd)
 	Debug.log("Docker image ls command output: ", imagelsOut)
 
 	if imagelsErr != nil {
@@ -1875,7 +1875,7 @@ func Targz(source, target string) error {
 		})
 }
 
-func seperateOutput(cmd *exec.Cmd) (string, error) {
+func SeperateOutput(cmd *exec.Cmd) (string, error) {
 	var stdErr, stdOut bytes.Buffer
 	cmd.Stderr = &stdErr
 	cmd.Stdout = &stdOut

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1883,7 +1883,6 @@ func SeperateOutput(cmd *exec.Cmd) (string, error) {
 
 	// If there was an error, return the stdErr & err
 	if err != nil {
-		Info.log("@@@@@@@@@@@", stdErr.String())
 		return err.Error() + ": " + strings.TrimSpace(stdErr.String()), err
 	}
 

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -204,8 +204,8 @@ var invalidCmdsTest = []struct {
 	args     []string
 	expected string
 }{
-	{"ls", []string{"invalidname"}, "ls: invalidname: No such file or directory"},
-	{"cp", []string{"invalidname", "alsoinavalidname"}, "cp: invalidname: No such file or directory"},
+	{"ls", []string{"invalidname"}, "No such file or directory"},
+	{"cp", []string{"invalidname", "alsoinavalidname"}, "No such file or directory"},
 }
 
 func TestInvalidCmdOutput(t *testing.T) {

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -204,8 +204,8 @@ var invalidCmdsTest = []struct {
 	args     []string
 	expected string
 }{
-	{"docker", []string{"inspect", "invalidname"}, "Error: No such object: invalidname"},
-	{"kubectl", []string{"apply", "-f", "invalidname"}, "error: the path \"invalidname\" does not exist"},
+	{"ls", []string{"invalidname"}, "ls: invalidname: No such file or directory"},
+	{"cp", []string{"invalidname", "alsoinavalidname"}, "cp: invalidname: No such file or directory"},
 }
 
 func TestInvalidCmdOutput(t *testing.T) {
@@ -217,9 +217,9 @@ func TestInvalidCmdOutput(t *testing.T) {
 		t.Run(fmt.Sprintf("Test Invalid "+test.cmd+" Command"), func(t *testing.T) {
 			out, err := cmd.SeperateOutput(invalidCmd)
 			if err == nil {
-				t.Error("Expected an error from ' ", test.cmd, strings.Join(test.args, " "), "' but did not return one.")
+				t.Error("Expected an error from '", test.cmd, strings.Join(test.args, " "), "' but it did not return one.")
 			} else if !strings.Contains(out, test.expected) {
-				t.Error("Expected the stdout to contain "+test.expected, out)
+				t.Error("Expected the stdout to contain '" + test.expected + "'. It actually contains: " + out)
 			}
 		})
 

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -17,6 +17,7 @@ package cmd_test
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"strings"
 	"testing"
 
@@ -196,4 +197,32 @@ func TestInvalidProjectNames(t *testing.T) {
 			}
 		})
 	}
+}
+
+var invalidCmdsTest = []struct {
+	cmd      string
+	args     []string
+	expected string
+}{
+	{"docker", []string{"inspect", "invalidname"}, "Error: No such object: invalidname"},
+	{"kubectl", []string{"apply", "-f", "invalidname"}, "error: the path \"invalidname\" does not exist"},
+}
+
+func TestInvalidCmdOutput(t *testing.T) {
+
+	for _, test := range invalidCmdsTest {
+
+		invalidCmd := exec.Command(test.cmd, test.args...)
+
+		t.Run(fmt.Sprintf("Test Invalid "+test.cmd+" Command"), func(t *testing.T) {
+			out, err := cmd.SeperateOutput(invalidCmd)
+			if err == nil {
+				t.Error("Expected an error from ' ", test.cmd, strings.Join(test.args, " "), "' but did not return one.")
+			} else if !strings.Contains(out, test.expected) {
+				t.Error("Expected the stdout to contain "+test.expected, out)
+			}
+		})
+
+	}
+
 }

--- a/functest/docker_commands_test.go
+++ b/functest/docker_commands_test.go
@@ -1,0 +1,72 @@
+// Copyright © 2019 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package functest
+
+import (
+	"fmt"
+	"strings"
+	"testing"
+
+	cmd "github.com/appsody/appsody/cmd"
+)
+
+var invalidDockerCmdsTest = []struct {
+	file     string
+	expected string
+}{
+	{"imageName", "invalid reference format: repository name must be lowercase"},
+	{"imagename", "No such image: imagename"},
+}
+
+func TestDockerInspect(t *testing.T) {
+
+	for _, test := range invalidDockerCmdsTest {
+
+		t.Run(fmt.Sprintf("Test Invalid DockerInspect"), func(t *testing.T) {
+			out, err := cmd.RunDockerInspect(test.file)
+
+			if err == nil {
+				t.Error("Expected an error from '", test.file, "' name but it did not return one.")
+			} else if !strings.Contains(out, test.expected) {
+				t.Error("Expected the stdout to contain '" + test.expected + "'. It actually contains: " + out)
+			}
+		})
+	}
+}
+
+var invalidCmdsTest = []struct {
+	args     []string
+	expected string
+}{
+	{[]string{"-f", "Dockerfile", "."}, "no such file or directory"},
+	{[]string{"-P", "Dockerfile", "."}, "unknown shorthand"},
+}
+
+func TestDockerBuild(t *testing.T) {
+
+	for _, test := range invalidCmdsTest {
+
+		err := cmd.DockerBuild(test.args, cmd.DockerLog, false, false)
+
+		t.Run(fmt.Sprintf("Test Invalid DockerBuild"), func(t *testing.T) {
+
+			if err == nil {
+				t.Error("Expected an error from 'docker ", strings.Join(test.args, " "), "' but it did not return one.")
+			} else if !strings.Contains(err.Error(), test.expected) {
+				t.Error("Expected the stdout to contain '", test.expected, "'. It actually contains: ", err.Error())
+			}
+		})
+	}
+
+}

--- a/functest/docker_commands_test.go
+++ b/functest/docker_commands_test.go
@@ -44,29 +44,3 @@ func TestDockerInspect(t *testing.T) {
 		})
 	}
 }
-
-var invalidCmdsTest = []struct {
-	args     []string
-	expected string
-}{
-	{[]string{"-f", "Dockerfile", "."}, "no such file or directory"},
-	{[]string{"-P", "Dockerfile", "."}, "unknown shorthand"},
-}
-
-func TestDockerBuild(t *testing.T) {
-
-	for _, test := range invalidCmdsTest {
-
-		err := cmd.DockerBuild(test.args, cmd.DockerLog, false, false)
-
-		t.Run(fmt.Sprintf("Test Invalid DockerBuild"), func(t *testing.T) {
-
-			if err == nil {
-				t.Error("Expected an error from 'docker ", strings.Join(test.args, " "), "' but it did not return one.")
-			} else if !strings.Contains(err.Error(), test.expected) {
-				t.Error("Expected the stdout to contain '", test.expected, "'. It actually contains: ", err.Error())
-			}
-		})
-	}
-
-}

--- a/functest/test_test.go
+++ b/functest/test_test.go
@@ -73,7 +73,7 @@ func TestTestSimple(t *testing.T) {
 			runChannel <- err
 		}()
 
-		waitForError := 60 // in seconds
+		waitForError := 20 // in seconds
 		stillWaiting := true
 		log.Println("Waiting to see if test will fail...")
 		for stillWaiting {

--- a/functest/test_test.go
+++ b/functest/test_test.go
@@ -73,7 +73,7 @@ func TestTestSimple(t *testing.T) {
 			runChannel <- err
 		}()
 
-		waitForError := 20 // in seconds
+		waitForError := 60 // in seconds
 		stillWaiting := true
 		log.Println("Waiting to see if test will fail...")
 		for stillWaiting {


### PR DESCRIPTION
Corrected instances where only stdErr was being propagated as an exit message to instead return stdOut along with stdErr.

Fixes: #462