### PR TITLE
build: support pushing to image registry

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -54,7 +54,6 @@ func newBuildCmd(rootConfig *RootCommandConfig) *cobra.Command {
 		Short: "Locally build a docker image of your appsody project",
 		Long:  `This allows you to build a local Docker image from your Appsody project. Extract is run before the docker build.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
 			return build(config)
 		},
 	}

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -28,7 +28,7 @@ type buildCommandConfig struct {
 	*RootCommandConfig
 	tag                string
 	dockerBuildOptions string
-	pushURL 		   string
+	pushURL            string
 	push               bool
 }
 
@@ -138,7 +138,7 @@ func build(config *buildCommandConfig) error {
 		err := DockerPush(pushImage, config.Dryrun)
 		if err != nil {
 			return errors.Errorf("Could not push the docker image - exiting. Error: %v", err)
-		} 
+		}
 		Info.log("Pushed docker image ", pushImage)
 	}
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -127,16 +127,15 @@ func build(config *buildCommandConfig) error {
 	}
 
 	pushImage := config.tag
-
 	if pushImage == "" {
 		return errors.Errorf("No tag name was specified, unable to push the docker image.")
-	} else {
-		dryrun := config.Dryrun
-		if config.push {
-			err := DockerPush(pushImage, dryrun)
-			if err != nil {
-				return errors.Errorf("Could not push the docker image - exiting. Error: %v", err)
-			}
+	}
+
+	dryrun := config.Dryrun
+	if config.push {
+		err := DockerPush(pushImage, dryrun)
+		if err != nil {
+			return errors.Errorf("Could not push the docker image - exiting. Error: %v", err)
 		}
 	}
 


### PR DESCRIPTION
Appsody build now includes a `--push` flag that triggers the push to the default image registry. This allows users to run `appsody build -t <my-repo>/<my-image> --push` which would upload the image to the "default registry" (i.e. the registry to which the docker CLI is currently logged in).

Fixes:#450