### PR TITLE
Adding more git labels for Openshift

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -143,7 +143,7 @@ func getLabels(config *buildCommandConfig) ([]string, error) {
 		return labels, err
 	}
 
-	gitLabels, err := getGitLabels(config.Dryrun)
+	gitLabels, err := getGitLabels(config.RootCommandConfig)
 	if err != nil {
 		Warning.log(err)
 	}

--- a/cmd/git_utils.go
+++ b/cmd/git_utils.go
@@ -23,10 +23,15 @@ import (
 )
 
 type CommitInfo struct {
-	Author string
-	SHA    string
-	Date   string
-	URL    string
+	Author         string
+	AuthorEmail    string
+	Committer      string
+	CommitterEmail string
+	SHA            string
+	Date           string
+	URL            string
+	Message        string
+	ContextDir     string "json:,omitempty"
 }
 
 type GitInfo struct {
@@ -81,7 +86,7 @@ func stringBetween(value string, pre string, post string) string {
 }
 
 //RunGitFindBranc issues git status
-func GetGitInfo(dryrun bool) (GitInfo, error) {
+func GetGitInfo(config *RootCommandConfig) (GitInfo, error) {
 	var gitInfo GitInfo
 	version, vErr := RunGitVersion(false)
 	if vErr != nil {
@@ -95,7 +100,7 @@ func GetGitInfo(dryrun bool) (GitInfo, error) {
 
 	kargs := []string{"status", "-sb"}
 
-	output, gitErr := RunGit(kargs, dryrun)
+	output, gitErr := RunGit(kargs, config.Dryrun)
 	if gitErr != nil {
 		return gitInfo, gitErr
 	}
@@ -135,7 +140,7 @@ func GetGitInfo(dryrun bool) (GitInfo, error) {
 	gitInfo.ChangesMade = changesMade
 
 	if gitInfo.Upstream != "" {
-		gitInfo.RemoteURL, gitErr = RunGitConfigLocalRemoteOriginURL(gitInfo.Upstream, dryrun)
+		gitInfo.RemoteURL, gitErr = RunGitConfigLocalRemoteOriginURL(gitInfo.Upstream, config.Dryrun)
 		if gitErr != nil {
 			Info.Logf("Could not construct repository URL %v", gitErr)
 		}
@@ -144,7 +149,7 @@ func GetGitInfo(dryrun bool) (GitInfo, error) {
 		Info.log("Unable to determine origin to compute repository URL")
 	}
 
-	gitInfo.Commit, gitErr = RunGitGetLastCommit(gitInfo.RemoteURL, dryrun)
+	gitInfo.Commit, gitErr = RunGitGetLastCommit(gitInfo.RemoteURL, config)
 	if gitErr != nil {
 		Info.log("Received error getting current commit: ", gitErr)
 
@@ -176,11 +181,11 @@ func RunGitConfigLocalRemoteOriginURL(upstream string, dryrun bool) (string, err
 }
 
 //RunGitLog issues git log
-func RunGitGetLastCommit(URL string, dryrun bool) (CommitInfo, error) {
-	//git log -n 1 --pretty=format:"{"author":"%cn","sha":"%h","date":"%cd”}”
-	kargs := []string{"log", "-n", "1", "--pretty=format:'{\"author\":\"%cn\",\"sha\":\"%H\",\"date\":\"%cd\"}'"}
+func RunGitGetLastCommit(URL string, config *RootCommandConfig) (CommitInfo, error) {
+	//git log -n 1 --pretty=format:"{"author":"%cn","sha":"%h","date":"%cd”,}”
+	kargs := []string{"log", "-n", "1", "--pretty=format:'{\"author\":\"%an\", \"authoremail\":\"%ae\", \"sha\":\"%H\", \"date\":\"%cd\", \"committer\":\"%cn\", \"committeremail\":\"%ce\", \"message\":\"%s\"}'"}
 	var commitInfo CommitInfo
-	commitStringInfo, gitErr := RunGit(kargs, dryrun)
+	commitStringInfo, gitErr := RunGit(kargs, config.Dryrun)
 	if gitErr != nil {
 		return commitInfo, gitErr
 	}
@@ -191,8 +196,20 @@ func RunGitGetLastCommit(URL string, dryrun bool) (CommitInfo, error) {
 	if URL != "" {
 		commitInfo.URL = stringBefore(URL, ".git") + "/commit/" + commitInfo.SHA
 	}
-	return commitInfo, nil
 
+	gitLocation, gitErr := exec.Command("git", "rev-parse", "--show-toplevel").Output()
+	if gitErr != nil {
+		return commitInfo, gitErr
+	}
+	gitLocationString := strings.Replace(string(gitLocation), "\n", "", 1)
+
+	projectDir, err := getProjectDir(config)
+	if err != nil {
+		return commitInfo, err
+	}
+	commitInfo.ContextDir = strings.Replace(projectDir, gitLocationString, "", 1)
+
+	return commitInfo, nil
 }
 
 //RunGitVersion

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -244,7 +244,7 @@ func newStackPackageCmd(rootConfig *RootCommandConfig) *cobra.Command {
 
 				cmdArgs := []string{"-t", buildImage}
 
-				labels, err := getLabelsForStackImage(stackID, buildImage, stackYaml, rootConfig.Dryrun)
+				labels, err := getLabelsForStackImage(stackID, buildImage, stackYaml, rootConfig)
 				if err != nil {
 					return err
 				}
@@ -340,10 +340,10 @@ func newStackPackageCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	return stackPackageCmd
 }
 
-func getLabelsForStackImage(stackID string, buildImage string, stackYaml StackYaml, dryrun bool) ([]string, error) {
+func getLabelsForStackImage(stackID string, buildImage string, stackYaml StackYaml, config *RootCommandConfig) ([]string, error) {
 	var labels []string
 
-	gitLabels, err := getGitLabels(dryrun)
+	gitLabels, err := getGitLabels(config)
 	if err != nil {
 		Warning.log(err)
 	}
@@ -365,8 +365,8 @@ func getLabelsForStackImage(stackID string, buildImage string, stackYaml StackYa
 	if err != nil {
 		return labels, err
 	}
-	configLabels[appsodyKeyPrefix+"id"] = stackID
-	configLabels[appsodyKeyPrefix+"tag"] = buildImage
+	configLabels[appsodyStackKeyPrefix+"id"] = stackID
+	configLabels[appsodyStackKeyPrefix+"tag"] = buildImage
 
 	for key, value := range configLabels {
 		labelString := fmt.Sprintf("%s=%s", key, value)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -62,7 +62,9 @@ const workDirNotSet = ""
 
 const ociKeyPrefix = "org.opencontainers.image."
 
-const appsodyKeyPrefix = "dev.appsody.stack."
+const appsodyStackKeyPrefix = "dev.appsody.stack."
+
+const appsodyImageSourceKeyPrefix = "dev.appsody.image.source."
 
 // Checks whether an inode (it does not bother
 // about file or folder) exists or not.
@@ -577,7 +579,7 @@ func getConfigLabels(projectConfig ProjectConfig) (map[string]string, error) {
 
 	var maintainersString string
 	for index, maintainer := range projectConfig.Maintainers {
-		maintainersString += maintainer.Name + " (" + maintainer.Email + ")"
+		maintainersString += maintainer.Name + " <" + maintainer.Email + ">"
 		if index < len(projectConfig.Maintainers)-1 {
 			maintainersString += ", "
 		}
@@ -603,7 +605,7 @@ func getConfigLabels(projectConfig ProjectConfig) (map[string]string, error) {
 	}
 
 	if projectConfig.Stack != "" {
-		labels[appsodyKeyPrefix+"configured"] = projectConfig.Stack
+		labels[appsodyStackKeyPrefix+"configured"] = projectConfig.Stack
 	}
 
 	if projectConfig.ApplicationName != "" {
@@ -613,8 +615,8 @@ func getConfigLabels(projectConfig ProjectConfig) (map[string]string, error) {
 	return labels, nil
 }
 
-func getGitLabels(dryrun bool) (map[string]string, error) {
-	gitInfo, err := GetGitInfo(dryrun)
+func getGitLabels(config *RootCommandConfig) (map[string]string, error) {
+	gitInfo, err := GetGitInfo(config)
 	if err != nil {
 		return nil, err
 	}
@@ -634,6 +636,26 @@ func getGitLabels(dryrun bool) (map[string]string, error) {
 		if gitInfo.ChangesMade {
 			labels[revisionKey] += "-modified"
 		}
+	}
+
+	if commitInfo.Author != "" && commitInfo.AuthorEmail != "" {
+		labels[appsodyImageSourceKeyPrefix+"author"] = commitInfo.Author + " <" + commitInfo.AuthorEmail + ">"
+	}
+
+	if commitInfo.Committer != "" && commitInfo.CommitterEmail != "" {
+		labels[appsodyImageSourceKeyPrefix+"committer"] = commitInfo.Committer + " <" + commitInfo.CommitterEmail + ">"
+	}
+
+	if commitInfo.Date != "" {
+		labels[appsodyImageSourceKeyPrefix+"date"] = commitInfo.Date
+	}
+
+	if commitInfo.Message != "" {
+		labels[appsodyImageSourceKeyPrefix+"message"] = commitInfo.Message
+	}
+
+	if commitInfo.ContextDir != "" {
+		labels[appsodyImageSourceKeyPrefix+"contextDir"] = commitInfo.ContextDir
 	}
 
 	return labels, nil


### PR DESCRIPTION
#502 

FYI @kylegc I had to revert the cleaning of the functions (removing the config) because I need to use it to get the `projectDir`. I was thinking of passing only the `projectDir` and `dryrun`, but I think in the future we might use the `config` again.

Tested locally using a `nodejs-express` stack.