### PR TITLE
Transfer stack commit labels properly

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -150,7 +150,8 @@ func getLabels(config *buildCommandConfig) ([]string, error) {
 
 	for key, value := range stackLabels {
 
-		key = strings.Replace(key, "org.opencontainers.image", "dev.appsody.stack", -1)
+		key = strings.Replace(key, ociKeyPrefix, appsodyStackKeyPrefix, 1)
+		key = strings.Replace(key, appsodyImageCommitKeyPrefix, appsodyStackKeyPrefix+"commit.", 1)
 
 		// This is temporarily until we update the labels in stack dockerfile
 		if key == "appsody.stack" {


### PR DESCRIPTION
`dev.appsody.image.commit` labels will be added to the stack, and we need to make sure to transfer them to the appsody project as a different label, such as `dev.appsody.stack.commit`