### PR TITLE
Enforce stack dir name (stack id) with the project name rules

### DIFF
--- a/cmd/stack_lint.go
+++ b/cmd/stack_lint.go
@@ -16,7 +16,6 @@ package cmd
 
 import (
 	"io/ioutil"
-	"path"
 	"path/filepath"
 
 	"github.com/pkg/errors"
@@ -47,7 +46,7 @@ This command can be run from the base directory of your stack or you can supply 
 			configPath := filepath.Join(imagePath, "/config")
 			projectPath := filepath.Join(imagePath, "/project")
 
-			stackID := path.Base(stackPath)
+			stackID := filepath.Base(stackPath)
 			Info.log("LINTING ", stackID)
 
 			validStackID, err := IsValidProjectName(stackID)

--- a/cmd/stack_lint.go
+++ b/cmd/stack_lint.go
@@ -47,7 +47,14 @@ This command can be run from the base directory of your stack or you can supply 
 			configPath := filepath.Join(imagePath, "/config")
 			projectPath := filepath.Join(imagePath, "/project")
 
-			Info.log("LINTING ", path.Base(stackPath))
+			stackID := path.Base(stackPath)
+			Info.log("LINTING ", stackID)
+
+			validStackID, err := IsValidProjectName(stackID)
+			if !validStackID {
+				Error.log("Stack directory name is invalid. ", err)
+				stackLintErrorCount++
+			}
 
 			fileCheck, err := Exists(filepath.Join(stackPath, "/README.md"))
 			if err != nil {


### PR DESCRIPTION
The stack name should be restricted, especially now that it is going into k8s labels