### PR TITLE
Improve test output to only show detail on failures

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /package
 .vscode/
 cover.out
+test.out

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,7 @@ CONTROLLER_DIR := $(shell dirname $(APPSODY_MOUNT_CONTROLLER))
 export STACKSLIST ?= incubator/nodejs
 # use -count=1 to disable cache and -p=1 to stream output live
 GO_TEST_COMMAND := go test -v -count=1 -p=1 -covermode=count -coverprofile=cover.out -coverpkg ./cmd
+GO_TEST_LOGGING := | tee test.out | grep -E "^\s*(---|===)" ; tail -3 test.out ; awk '/--- FAIL/,/===/' test.out ; ! grep -E "(--- FAIL)" test.out
 GO_TEST_COVER_VIEWER := go tool cover -func=cover.out && go tool cover -html=cover.out
 # Set a default VERSION only if it is not already set
 VERSION ?= 0.0.0
@@ -51,15 +52,15 @@ install-controller: $(APPSODY_MOUNT_CONTROLLER) ## Downloads the controller and 
 
 .PHONY: test
 test: install-controller ## Run the all the automated tests
-	$(GO_TEST_COMMAND) ./...
+	$(GO_TEST_COMMAND) ./... $(GO_TEST_LOGGING)
 
 .PHONY: unittest
 unittest: ## Run the automated unit tests
-	$(GO_TEST_COMMAND) ./cmd
+	$(GO_TEST_COMMAND) ./cmd $(GO_TEST_LOGGING)
 
 .PHONY: functest
 functest: install-controller  ## Run the automated functional tests
-	$(GO_TEST_COMMAND) ./functest
+	$(GO_TEST_COMMAND) ./functest $(GO_TEST_LOGGING)
 
 .PHONY: cover
 cover: test ## Run all tests and open test coverage report


### PR DESCRIPTION
Fixes #493 

This isn't pretty, but it was something I had created previously and used locally for myself.
It prints live updates of the current test being run and its PASS/FAIL status, then at the end prints the detailed output only for the failed tests.