### PR TITLE
Set better image name for stack validate build test

### DIFF
--- a/cmd/stack_validate.go
+++ b/cmd/stack_validate.go
@@ -286,7 +286,7 @@ func TestTest(projectDir string) error {
 // Simple test for appsody build command. A future enhancement would be to verify the image that gets built.
 func TestBuild(stack string, projectDir string) error {
 
-	imageName := "dev.local/" + stack
+	imageName := "dev.local/" + filepath.Base(projectDir)
 
 	Info.Log("******************************************")
 	Info.Log("Running appsody build")


### PR DESCRIPTION
The stack validate build command should be using a temporary project name, not the stack name for the image tag.