### PR TITLE
Output version update message to Warning

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1805,14 +1805,9 @@ func getLatestVersion() string {
 func doVersionCheck(config *RootCommandConfig) {
 	var latest = getLatestVersion()
 	var currentTime = time.Now().Format("2006-01-02 15:04:05 -0700 MST")
-
-	if latest != "" && VERSION != "vlatest" && VERSION != latest {
-		switch os := runtime.GOOS; os {
-		case "darwin":
-			Info.logf("\n*\n*\n*\n\nA new CLI update is available.\nPlease run `brew upgrade appsody` to upgrade from %s --> %s.\n\n*\n*\n*", VERSION, latest)
-		default:
-			Info.logf("\n*\n*\n*\n\nA new CLI update is available.\nPlease go to https://appsody.dev/docs/getting-started/installation#upgrading-appsody and upgrade from %s --> %s.\n\n*\n*\n*", VERSION, latest)
-		}
+	if true || latest != "" && VERSION != "vlatest" && VERSION != latest {
+		updateString := GetUpdateString(runtime.GOOS, VERSION, latest)
+		Warning.logf(updateString)
 	}
 
 	config.CliConfig.Set("lastversioncheck", currentTime)
@@ -1820,6 +1815,18 @@ func doVersionCheck(config *RootCommandConfig) {
 		Error.logf("Writing default config file %s", err)
 
 	}
+}
+
+// GetUpdateString Returns a format string to advise the user how to upgrade
+func GetUpdateString(osName string, version string, latest string) string {
+	var updateString = ""
+	switch osName {
+	case "darwin":
+		updateString = "Please run `brew upgrade appsody` to upgrade"
+	default:
+		updateString = "Please go to https://appsody.dev/docs/getting-started/installation#upgrading-appsody and upgrade"
+	}
+	return fmt.Sprintf("\n*\n*\n*\n\nA new CLI update is available.\n%s from %s --> %s.\n\n*\n*\n*\n", updateString, version, latest)
 }
 
 func getLastCheckTime(config *RootCommandConfig) string {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1819,7 +1819,7 @@ func doVersionCheck(config *RootCommandConfig) {
 
 // GetUpdateString Returns a format string to advise the user how to upgrade
 func GetUpdateString(osName string, version string, latest string) string {
-	var updateString = ""
+	var updateString string
 	switch osName {
 	case "darwin":
 		updateString = "Please run `brew upgrade appsody` to upgrade"

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1805,7 +1805,7 @@ func getLatestVersion() string {
 func doVersionCheck(config *RootCommandConfig) {
 	var latest = getLatestVersion()
 	var currentTime = time.Now().Format("2006-01-02 15:04:05 -0700 MST")
-	if true || latest != "" && VERSION != "vlatest" && VERSION != latest {
+	if latest != "" && VERSION != "vlatest" && VERSION != latest {
 		updateString := GetUpdateString(runtime.GOOS, VERSION, latest)
 		Warning.logf(updateString)
 	}

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -276,3 +276,27 @@ func TestInvalidConvertLabelToKubeFormat(t *testing.T) {
 		})
 	}
 }
+
+var getUpdateStringTests = []struct {
+	input        string
+	version      string
+	latest       string
+	updateString string
+}{
+	{"darwin", "1", "2", "Please run `brew upgrade appsody` to upgrade"},
+	{"anythingelse", "1", "2", "Please go to https://appsody.dev/docs/getting-started/installation#upgrading-appsody and upgrade"},
+	{"", "1", "2", "Please go to https://appsody.dev/docs/getting-started/installation#upgrading-appsody and upgrade"},
+}
+
+func TestGetUpdateString(t *testing.T) {
+	for _, test := range getUpdateStringTests {
+		t.Run(test.input, func(t *testing.T) {
+			output := cmd.GetUpdateString(test.input, test.version, test.latest)
+			expectedOutput := fmt.Sprintf("\n*\n*\n*\n\nA new CLI update is available.\n%s from %s --> %s.\n\n*\n*\n*\n", test.updateString, test.version, test.latest)
+			if output != expectedOutput {
+				t.Errorf("Expected %s to convert to %s but got %s", test.input, expectedOutput, output)
+			}
+		})
+
+	}
+}


### PR DESCRIPTION
### Summary 
* Print the version update message to Stderr (this means that scripts can read only from stdout when parsing JSON from the `-o json` flag)
* Reformat the `doVersionCheck` function so that minimal upkeep is needed if the message is changed in common parts and added `GetUpdateString` function.

### Testing
Manually tested.
Written unit tests for `GetUpdateString` function to test different output depending on OS.

### Note
The only catch with using `Warning.logf` instead of `Info.logf` is the `[Warning]` that is printed before the version message so the output for MacOS is now:
```
[Warning] 
*
*
*

A new CLI update is available.
Please run `brew upgrade appsody` to upgrade from vlatest --> 0.4.10.

*
*
*
```
@kylegc FYI.

Signed-off-by: James Wallis <james.wallis1@ibm.com>