### PR TITLE
appsody debug: reformat help text

### DIFF
--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -26,7 +26,7 @@ func newDebugCmd(rootConfig *RootCommandConfig) *cobra.Command {
   Starts the debugging environment, passing the "--privileged" option to the "docker run" command as a flag.
   
   appsody debug --name my-project-dev2 -p 3001:3000
-  Starts the debugging environment, names the development container "my-project-dev2", binds the container port 3000 to the host port 3001.`,
+  Starts the debugging environment, names the development container "my-project-dev2", and binds the container port 3000 to the host port 3001.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			Info.log("Running debug environment")

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -20,8 +20,13 @@ func newDebugCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	// debug Cmd represents the debug command
 	var debugCmd = &cobra.Command{
 		Use:   "debug",
-		Short: "Run the local Appsody environment in debug mode",
-		Long:  `This starts a docker based continuous build environment for your project with debugging enabled.`,
+		Short: "Debug your Appsody project",
+		Long:  `Start a container-based continuous build environment for your Appsody project, with debugging enabled.`,
+		Example: `  appsody debug --docker-options "--privileged"
+  Starts debugging environment and passes the "--privileged" option to the docker run as a flag.
+  
+  appsody debug --name my-project-dev2 -p 3001:3000
+  Starts debugging environment, names development container "my-project-dev2" and binds container port 3000 to host port 3001.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			Info.log("Running debug environment")

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -20,13 +20,13 @@ func newDebugCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	// debug Cmd represents the debug command
 	var debugCmd = &cobra.Command{
 		Use:   "debug",
-		Short: "Debug your Appsody project",
+		Short: "Debug your Appsody project.",
 		Long:  `Start a container-based continuous build environment for your Appsody project, with debugging enabled.`,
 		Example: `  appsody debug --docker-options "--privileged"
-  Starts debugging environment and passes the "--privileged" option to the docker run as a flag.
+  Starts the debugging environment and passes the "--privileged" option to the "docker run" command as a flag.
   
   appsody debug --name my-project-dev2 -p 3001:3000
-  Starts debugging environment, names development container "my-project-dev2" and binds container port 3000 to host port 3001.`,
+  Starts the debugging environment, names the development container "my-project-dev2" and, binds the container port 3000 to the host port 3001.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			Info.log("Running debug environment")

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -23,10 +23,10 @@ func newDebugCmd(rootConfig *RootCommandConfig) *cobra.Command {
 		Short: "Debug your Appsody project.",
 		Long:  `Start a container-based continuous build environment for your Appsody project, with debugging enabled.`,
 		Example: `  appsody debug --docker-options "--privileged"
-  Starts the debugging environment and passes the "--privileged" option to the "docker run" command as a flag.
+  Starts the debugging environment, passing the "--privileged" option to the "docker run" command as a flag.
   
   appsody debug --name my-project-dev2 -p 3001:3000
-  Starts the debugging environment, names the development container "my-project-dev2" and, binds the container port 3000 to the host port 3001.`,
+  Starts the debugging environment, names the development container "my-project-dev2", binds the container port 3000 to the host port 3001.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			Info.log("Running debug environment")


### PR DESCRIPTION
Changed help text formatting for `appsody debug` command

Fixes: #576 