### PR TITLE
appsody list: reformat help text

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -35,7 +35,7 @@ func newListCmd(rootConfig *RootCommandConfig) *cobra.Command {
 		Short: "List the available Appsody stacks.",
 		Long: `List all the Appsody stacks available in your repositories. 
 
-An asterisk in the repository column denotes the default repository. An asterisk in the template column denotes the default template used, when you initialise an Appsody project.`,
+An asterisk in the repository column denotes the default repository. An asterisk in the template column denotes the default template that is used when you initialise an Appsody project.`,
 		Example: `  appsody list
   Lists all available stacks for each of your repositories.
   

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -32,10 +32,10 @@ func newListCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	// listCmd represents the list command
 	var listCmd = &cobra.Command{
 		Use:   "list [repository]",
-		Short: "Lists the available Appsody stacks.",
-		Long: `Lists all the Appsody stacks available in your repositories. 
+		Short: "List the available Appsody stacks.",
+		Long: `List all the Appsody stacks available in your repositories. 
 
-An asterisk under the repository column denotes the default repository. An asterisk under the template column denotes the default stack template you will get when you initialise an Appsody project.`,
+An asterisk in the repository column denotes the default repository. An asterisk in the template column denotes the default template used, when you initialise an Appsody project.`,
 		Example: `  appsody list
   Lists all available stacks for each of your repositories.
   

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -33,7 +33,9 @@ func newListCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	var listCmd = &cobra.Command{
 		Use:   "list [repository]",
 		Short: "Lists the available Appsody stacks.",
-		Long:  `Lists all the Appsody stacks available in your repositories.`,
+		Long: `Lists all the Appsody stacks available in your repositories. 
+
+An asterisk under the repository column denotes the default repository. An asterisk under the template column denotes the default stack template you will get when you initialise an Appsody project.`,
 		Example: `  appsody list
   Lists all available stacks for each of your repositories.
   

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -32,8 +32,13 @@ func newListCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	// listCmd represents the list command
 	var listCmd = &cobra.Command{
 		Use:   "list [repository]",
-		Short: "List the Appsody stacks available to init",
-		Long:  `This command lists all the stacks available in your repositories. If you omit the  optional [repository] parameter, the stacks for all the repositories are listed. If you specify the repository name [repository], only the stacks in that repository will be listed.`,
+		Short: "Lists the available Appsody stacks.",
+		Long:  `Lists all the Appsody stacks available in your repositories.`,
+		Example: `  appsody list
+  Lists all available stacks for each of your repositories.
+  
+  appsody list my-repo
+  Lists available stacks only in your "my-repo" repository.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var repos RepositoryFile
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1107,12 +1107,14 @@ func GenDeploymentYaml(appName string, imageName string, ports []string, pdir st
 		*volumeMounts = append(*volumeMounts, newVolumeMount)
 	}
 	// Dependencies mount
-
-	if depsMount != "" {
-		// Now the volume mount
-		depVolumeMount := VolumeMount{Name: "dependencies", MountPath: depsMount}
-		*volumeMounts = append(*volumeMounts, depVolumeMount)
-	}
+	// Issue #597: we remove this mount, since it doesn't seem to work with Python etc.
+	// And provides no benefit
+	/*
+		if depsMount != "" {
+			// Now the volume mount
+			depVolumeMount := VolumeMount{Name: "dependencies", MountPath: depsMount}
+			*volumeMounts = append(*volumeMounts, depVolumeMount)
+		}*/
 
 	//subPath := filepath.Base(pdir)
 	//workspaceMount := VolumeMount{"appsody-workspace", "/project/user-app", subPath}


### PR DESCRIPTION
Changed help text formatting for `appsody list` command

Fixes: #580 