### PR TITLE
appsody repo: reformat help text

### DIFF
--- a/cmd/repo_add.go
+++ b/cmd/repo_add.go
@@ -27,8 +27,10 @@ func newRepoAddCmd(config *RootCommandConfig) *cobra.Command {
 	// initCmd represents the init command
 	var addCmd = &cobra.Command{
 		Use:   "add <name> <url>",
-		Short: "Add an Appsody repository",
-		Long:  ``,
+		Short: "Adds an Appsody repository.",
+		Long:  `Adds an Appsody repository to your list of configured Appsody repositories.`,
+		Example: `  appsody repo add my-local-repo file://path/to/my-local-repo.yaml
+  Adds the "my-local-repo" repository, specified by the "file://path/to/my-local-repo.yaml" file to your list of repositories.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
 

--- a/cmd/repo_add.go
+++ b/cmd/repo_add.go
@@ -27,8 +27,8 @@ func newRepoAddCmd(config *RootCommandConfig) *cobra.Command {
 	// initCmd represents the init command
 	var addCmd = &cobra.Command{
 		Use:   "add <name> <url>",
-		Short: "Adds an Appsody repository.",
-		Long:  `Adds an Appsody repository to your list of configured Appsody repositories.`,
+		Short: "Add an Appsody repository.",
+		Long:  `Add an Appsody repository to your list of configured Appsody repositories.`,
 		Example: `  appsody repo add my-local-repo file://path/to/my-local-repo.yaml
   Adds the "my-local-repo" repository, specified by the "file://path/to/my-local-repo.yaml" file to your list of repositories.`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/repo_list.go
+++ b/cmd/repo_list.go
@@ -31,8 +31,8 @@ func newRepoListCmd(config *RootCommandConfig) *cobra.Command {
 	// repo list represent repo list cmd
 	var repoListCmd = &cobra.Command{
 		Use:   "list",
-		Short: "Lists your Appsody repositories.",
-		Long:  `Lists all your configured Appsody repositories. An asterisk denotes the default repository.`,
+		Short: "List your Appsody repositories.",
+		Long:  `List all your configured Appsody repositories. The "incubator" repository is the initial default repository for Appsody.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var repos RepositoryFile
 

--- a/cmd/repo_list.go
+++ b/cmd/repo_list.go
@@ -31,8 +31,8 @@ func newRepoListCmd(config *RootCommandConfig) *cobra.Command {
 	// repo list represent repo list cmd
 	var repoListCmd = &cobra.Command{
 		Use:   "list",
-		Short: "List configured Appsody repositories",
-		Long:  `List configured Appsody repositories. An asterisk denotes the default repository.`,
+		Short: "Lists your Appsody repositories.",
+		Long:  `Lists all your configured Appsody repositories. An asterisk denotes the default repository.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			var repos RepositoryFile
 

--- a/cmd/repo_remove.go
+++ b/cmd/repo_remove.go
@@ -26,7 +26,7 @@ func newRepoRemoveCmd(config *RootCommandConfig) *cobra.Command {
 	var removeCmd = &cobra.Command{
 		Use:   "remove <name>",
 		Short: "Remove an Appsody repository.",
-		Long:  `Remove an Appsody repository from your list of configured Appsody repositories.
+		Long: `Remove an Appsody repository from your list of configured Appsody repositories.
 		
 You cannot remove the default repository, but you can make a different repository the default (see appsody repo set-default).`,
 		Example: `  appsody repo remove my-local-repo

--- a/cmd/repo_remove.go
+++ b/cmd/repo_remove.go
@@ -25,8 +25,10 @@ func newRepoRemoveCmd(config *RootCommandConfig) *cobra.Command {
 	// initCmd represents the init command
 	var removeCmd = &cobra.Command{
 		Use:   "remove <name>",
-		Short: "Remove a configured Appsody repository",
-		Long:  ``,
+		Short: "Removes an Appsody repository.",
+		Long:  `Removes an Appsody repository from your list of configured Appsody repositories.`,
+		Example: `  appsody repo remove my-local-repo
+  Removes the "my-local-repo" repository from your list of configured repositories.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Error, you must specify repository name")

--- a/cmd/repo_remove.go
+++ b/cmd/repo_remove.go
@@ -25,8 +25,10 @@ func newRepoRemoveCmd(config *RootCommandConfig) *cobra.Command {
 	// initCmd represents the init command
 	var removeCmd = &cobra.Command{
 		Use:   "remove <name>",
-		Short: "Removes an Appsody repository.",
-		Long:  `Removes an Appsody repository from your list of configured Appsody repositories.`,
+		Short: "Remove an Appsody repository.",
+		Long:  `Remove an Appsody repository from your list of configured Appsody repositories.
+		
+You cannot remove the default repository, but you can make a different repository the default (see appsody repo set-default).`,
 		Example: `  appsody repo remove my-local-repo
   Removes the "my-local-repo" repository from your list of configured repositories.`,
 		RunE: func(cmd *cobra.Command, args []string) error {

--- a/cmd/repo_set_default.go
+++ b/cmd/repo_set_default.go
@@ -25,8 +25,12 @@ func newRepoDefaultCmd(config *RootCommandConfig) *cobra.Command {
 	// initCmd represents the init command
 	var setDefaultCmd = &cobra.Command{
 		Use:   "set-default <name>",
-		Short: "Set desired default repository",
-		Long:  ``,
+		Short: "Sets a default repository.",
+		Long: `Sets your specified repository to be the default repository. The "incubator" repository is the initial default repository you will get upon installing Appsody. The default repository cannot be removed from you list of configured Appsody repositories. To remove a default repository, you would first have to set a different default repository.
+
+The default repository is denoted by an asterisk when you run "appsody repo list" or "appsody list". As a result of setting this default repository, you will not have to specify the repository, when initialising a new project using a stack in that repository.`,
+		Example: `  appsody repo set-default my-local-repo
+  Sets your default repository to "my-local-repo".`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
 				return errors.New("Error, you must specify desired default repository")

--- a/cmd/repo_set_default.go
+++ b/cmd/repo_set_default.go
@@ -25,10 +25,10 @@ func newRepoDefaultCmd(config *RootCommandConfig) *cobra.Command {
 	// initCmd represents the init command
 	var setDefaultCmd = &cobra.Command{
 		Use:   "set-default <name>",
-		Short: "Sets a default repository.",
-		Long: `Sets your specified repository to be the default repository. The "incubator" repository is the initial default repository you will get upon installing Appsody. The default repository cannot be removed from you list of configured Appsody repositories. To remove a default repository, you would first have to set a different default repository.
+		Short: "Set a default repository.",
+		Long: `Set your specified repository to be the default repository.
 
-The default repository is denoted by an asterisk when you run "appsody repo list" or "appsody list". As a result of setting this default repository, you will not have to specify the repository, when initialising a new project using a stack in that repository.`,
+The default repository is used when you run the "appsody init" command without specifying a repository name. Use "appsody repo list" or "appsody list" to see which repository is currently the default (denoted by an asterisk).`,
 		Example: `  appsody repo set-default my-local-repo
   Sets your default repository to "my-local-repo".`,
 		RunE: func(cmd *cobra.Command, args []string) error {


### PR DESCRIPTION
Changed help text formatting for following `appsody stack` commands:
- `appsody repo add`
- `appsody repo list`
- `appsody repo remove`
- `appsody repo set-default`

Fixes: #583 