### PR TITLE
Fix version issue because only one -ldflags is allowed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,12 +116,12 @@ build-linux: ## Build the linux binary
 build-windows: ## Build the windows binary
 
 build-linux build-windows: ## Build the binary of the respective operating system
-	GOOS=$(os) CGO_ENABLED=0 GOARCH=amd64 go build -o $(BUILD_PATH)/$(build_binary) -ldflags "-X main.VERSION=$(VERSION)" -ldflags "-X main.CONTROLLERVERSION=$(APPSODY_CONTROLLER_VERSION)"
+	GOOS=$(os) CGO_ENABLED=0 GOARCH=amd64 go build -o $(BUILD_PATH)/$(build_binary) -ldflags "-X main.VERSION=$(VERSION) -X main.CONTROLLERVERSION=$(APPSODY_CONTROLLER_VERSION)"
 
 .PHONY: build-darwin
 
 build-darwin: ## Build the OSX binary
-	GOOS=$(os) GOARCH=amd64 go build -o $(BUILD_PATH)/$(build_binary) -ldflags "-X main.VERSION=$(VERSION)" -ldflags "-X main.CONTROLLERVERSION=$(APPSODY_CONTROLLER_VERSION)"
+	GOOS=$(os) GOARCH=amd64 go build -o $(BUILD_PATH)/$(build_binary) -ldflags "-X main.VERSION=$(VERSION) -X main.CONTROLLERVERSION=$(APPSODY_CONTROLLER_VERSION)"
 
 .PHONY: package
 package: build-docs tar-linux deb-linux rpm-linux tar-darwin brew-darwin tar-windows ## Creates packages for all operating systems and store them in package/ dir


### PR DESCRIPTION
The second `-ldflags` arg overwrote the first so the VERSION wasn't getting set. Fixed it by setting both flags in the same `-ldflags` option.