### PR TITLE
Do not override existing non-appsody labels and annotations in app-deploy

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -508,8 +508,14 @@ func updateDeploymentConfig(config *buildCommandConfig) error {
 		}
 	}
 
-	appsodyApplication.Labels = selectedLabels
-	appsodyApplication.Annotations = labels
+	for key, value := range selectedLabels {
+		appsodyApplication.Labels[key] = value
+	}
+
+	for key, value := range labels {
+		appsodyApplication.Annotations[key] = value
+	}
+
 	appsodyApplication.Spec.CreateKnativeService = &config.knative
 
 	imageName := appsodyApplication.Spec.ApplicationImage


### PR DESCRIPTION
In other words - only override exisiting appsody labels and annotations in app-deploy
For `kNative` and `ApplicaitionImage` the behaviour can be specified through command line flags to the deploy command.