### PR TITLE
cmd: Fix stack package so that the correct value for language is put in the index

### DIFF
--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -393,7 +393,7 @@ func initialiseStackData(stackID string, stackYaml StackYaml) IndexYamlStack {
 	newStackStruct.Version = stackYaml.Version
 	newStackStruct.Description = stackYaml.Description
 	newStackStruct.License = stackYaml.License
-	newStackStruct.Language = stackYaml.License
+	newStackStruct.Language = stackYaml.Language
 	newStackStruct.Maintainers = append(newStackStruct.Maintainers, stackYaml.Maintainers...)
 	newStackStruct.DefaultTemplate = stackYaml.DefaultTemplate
 


### PR DESCRIPTION
Currently, when running `appsody stack package`, the `language` field in the generated index puts the value for the `license` field. This PR fixes this.

Fixes: https://github.com/appsody/appsody/issues/663