### PR TITLE
Refactor InitConfig and EnsureConfig so they are testable

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -136,7 +136,7 @@ func build(config *buildCommandConfig) error {
 		return perr
 	}
 
-	extractDir := filepath.Join(getHome(config.RootCommandConfig), "extract", projectName)
+	extractDir := filepath.Join(getHome(config.CliConfig), "extract", projectName)
 	dockerfile := filepath.Join(extractDir, "Dockerfile")
 	buildImage := projectName //Lowercased
 

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -91,7 +91,7 @@ func extract(config *extractCommandConfig) error {
 		}
 	}
 
-	extractDir := filepath.Join(getHome(config.RootCommandConfig), "extract")
+	extractDir := filepath.Join(getHome(config.CliConfig), "extract")
 	extractDirExists, err := Exists(extractDir)
 	if err != nil {
 		return errors.Errorf("Error checking directory: %v", err)

--- a/cmd/operator.go
+++ b/cmd/operator.go
@@ -141,7 +141,7 @@ func downloadCRDYaml(log *LoggingConfig, url string, target string) (string, err
 }
 
 func getDeployConfigDir(rootConfig *RootCommandConfig) (string, error) {
-	deployConfigDir := filepath.Join(getHome(rootConfig), "deploy")
+	deployConfigDir := filepath.Join(getHome(rootConfig.CliConfig), "deploy")
 	deployConfigDirExists, err := Exists(deployConfigDir)
 	if err != nil {
 		return "", errors.Errorf("Error checking directory: %v", err)

--- a/cmd/repo_add.go
+++ b/cmd/repo_add.go
@@ -82,7 +82,7 @@ func newRepoAddCmd(config *RootCommandConfig) *cobra.Command {
 				}
 
 				repoFile.Add(&newEntry)
-				err = repoFile.WriteFile(getRepoFileLocation(config))
+				err = repoFile.WriteFile(getRepoFileLocation(config.CliConfig))
 				if err != nil {
 					return errors.Errorf("Failed to write file to repository location: %v", err)
 				}

--- a/cmd/repo_remove.go
+++ b/cmd/repo_remove.go
@@ -59,7 +59,7 @@ You cannot remove the default repository, but you can make a different repositor
 				} else {
 					config.Error.log("Repository is not in configured list of repositories")
 				}
-				err := repoFile.WriteFile(getRepoFileLocation(config))
+				err := repoFile.WriteFile(getRepoFileLocation(config.CliConfig))
 				if err != nil {
 					log.Fatalf("Failed to write file repository location: %v", err)
 				}

--- a/cmd/repo_set_default.go
+++ b/cmd/repo_set_default.go
@@ -62,7 +62,7 @@ The default repository is used when you run the "appsody init" command without s
 				} else {
 					config.Error.log("Repository is not in configured list of repositories")
 				}
-				err := repoFile.WriteFile(getRepoFileLocation(config))
+				err := repoFile.WriteFile(getRepoFileLocation(config.CliConfig))
 				if err != nil {
 					log.Fatalf("Failed to write file repository location: %v", err)
 				}

--- a/cmd/stack_addtorepo.go
+++ b/cmd/stack_addtorepo.go
@@ -83,7 +83,7 @@ The updated repository index file is created in  ~/.appsody/stacks/dev.local dir
 				return errors.New("Unable to reach templates directory. Current directory must be the root of the stack")
 			}
 
-			appsodyHome := getHome(rootConfig)
+			appsodyHome := getHome(rootConfig.CliConfig)
 			log.Debug.Log("appsodyHome is:", appsodyHome)
 
 			devLocal := filepath.Join(appsodyHome, "stacks", "dev.local")

--- a/cmd/stack_create.go
+++ b/cmd/stack_create.go
@@ -71,19 +71,19 @@ The stack name must start with a lowercase letter, and can contain only lowercas
 				return errors.New("A stack named " + stack + " already exists in your directory. Specify a unique stack name")
 			}
 
-			extractFolderExists, err := Exists(filepath.Join(getHome(rootConfig), "extract"))
+			extractFolderExists, err := Exists(filepath.Join(getHome(rootConfig.CliConfig), "extract"))
 			if err != nil {
 				return err
 			}
 
 			if !extractFolderExists {
-				err = os.MkdirAll(filepath.Join(getHome(rootConfig), "extract"), os.ModePerm)
+				err = os.MkdirAll(filepath.Join(getHome(rootConfig.CliConfig), "extract"), os.ModePerm)
 				if err != nil {
 					return err
 				}
 			}
 
-			err = downloadFileToDisk(rootConfig.LoggingConfig, "https://github.com/appsody/stacks/archive/master.zip", filepath.Join(getHome(rootConfig), "extract", "repo.zip"), config.Dryrun)
+			err = downloadFileToDisk(rootConfig.LoggingConfig, "https://github.com/appsody/stacks/archive/master.zip", filepath.Join(getHome(rootConfig.CliConfig), "extract", "repo.zip"), config.Dryrun)
 			if err != nil {
 				return err
 			}
@@ -92,7 +92,7 @@ The stack name must start with a lowercase letter, and can contain only lowercas
 				return err
 			}
 
-			valid, unzipErr := unzip(rootConfig.LoggingConfig, filepath.Join(getHome(rootConfig), "extract", "repo.zip"), stack, config.copy, config.Dryrun)
+			valid, unzipErr := unzip(rootConfig.LoggingConfig, filepath.Join(getHome(rootConfig.CliConfig), "extract", "repo.zip"), stack, config.copy, config.Dryrun)
 			if unzipErr != nil {
 				return unzipErr
 			}
@@ -102,7 +102,7 @@ The stack name must start with a lowercase letter, and can contain only lowercas
 			}
 
 			//deleting the stacks repo zip
-			os.Remove(filepath.Join(getHome(rootConfig), "extract", "repo.zip"))
+			os.Remove(filepath.Join(getHome(rootConfig.CliConfig), "extract", "repo.zip"))
 
 			//moving out the stack which we need
 			if config.Dryrun {

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -104,7 +104,7 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 			log.Debug.Log("stackID is: ", stackID)
 
 			// sets stack path to be the copied folder
-			stackPath := filepath.Join(getHome(rootConfig), "stacks", "packaging-"+stackID)
+			stackPath := filepath.Join(getHome(rootConfig.CliConfig), "stacks", "packaging-"+stackID)
 			log.Debug.Log("stackPath is: ", stackPath)
 
 			// creates stackPath dir if it doesn't exist
@@ -148,7 +148,7 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 				return errors.New("Unable to reach templates directory. Current directory must be the root of the stack")
 			}
 
-			appsodyHome := getHome(rootConfig)
+			appsodyHome := getHome(rootConfig.CliConfig)
 			log.Debug.Log("appsodyHome is:", appsodyHome)
 
 			devLocal := filepath.Join(appsodyHome, "stacks", "dev.local")
@@ -364,9 +364,9 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 					log.Info.logf("Appsody repo %s is configured with %s's URL. Deleting it to setup %s.", repoNameToDelete, repoName, repoName)
 					repos.Remove(repoNameToDelete)
 				}
-				err = repos.WriteFile(getRepoFileLocation(rootConfig))
+				err = repos.WriteFile(getRepoFileLocation(rootConfig.CliConfig))
 				if err != nil {
-					return errors.Errorf("Error writing to repo file %s. %v", getRepoFileLocation(rootConfig), err)
+					return errors.Errorf("Error writing to repo file %s. %v", getRepoFileLocation(rootConfig.CliConfig), err)
 				}
 				log.Info.Logf("Creating %s repository", repoName)
 				_, err = AddLocalFileRepo(repoName, indexFileLocal)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1700,7 +1700,7 @@ func checkTime(config *RootCommandConfig) {
 // this code should be removed when we think everyone is using the latest index.
 func setNewIndexURL(config *RootCommandConfig) {
 
-	var repoFile = getRepoFileLocation(config)
+	var repoFile = getRepoFileLocation(config.CliConfig)
 	var oldIndexURL = "https://raw.githubusercontent.com/appsody/stacks/master/index.yaml"
 	var newIndexURL = "https://github.com/appsody/stacks/releases/latest/download/incubator-index.yaml"
 
@@ -1728,7 +1728,7 @@ func setNewRepoName(config *RootCommandConfig) {
 	if appsodyhubRepo != nil && appsodyhubRepo.URL == incubatorRepositoryURL {
 		config.Info.log("Migrating your repo name from 'appsodyhub' to 'incubator'")
 		appsodyhubRepo.Name = "incubator"
-		err := repoFile.WriteFile(getRepoFileLocation(config))
+		err := repoFile.WriteFile(getRepoFileLocation(config.CliConfig))
 		if err != nil {
 			config.Warning.logf("Failed to write file to repository location: %v", err)
 		}

--- a/functest/extract_test.go
+++ b/functest/extract_test.go
@@ -102,10 +102,11 @@ func TestExtract(t *testing.T) {
 		loggingConfig := &cmd.LoggingConfig{}
 		loggingConfig.InitLogging(&outBuffer, &outBuffer)
 		config := &cmd.RootCommandConfig{LoggingConfig: loggingConfig}
-		err = cmd.InitConfig(config)
+		defaults, err := cmd.ConfigDefaults()
 		if err != nil {
-			t.Fatal("Could not init appsody config", err)
+			t.Fatal("Could not determine default home directory", err)
 		}
+		config.CliConfig = cmd.InitConfig("", defaults)
 		mounts, _ := cmd.GetEnvVar("APPSODY_MOUNTS", config)
 		pDir, _ := cmd.GetEnvVar("APPSODY_PROJECT_DIR", config)
 		t.Log(outBuffer.String())


### PR DESCRIPTION
This PR:
1. Exports `InitConfig` and `EnsureConfig` so that they are testable, and refactors the assignment of the default appsody config values into a separate `ConfigDefaults()` function that produces a `ConfigValues` type.  This would allow direct testing of these functions, for example, to create an Appsody directory in a location other than the default.
2. Replaces `cmd.RootCommandConfig` with `viper.Viper` in various config related functions that did not need the full root config, so that `InitConfig` and `EnsureConfig` can be driven without requiring a full root config.

Motivation: while developing #640, I initially used these functions to generate the appsody configuration file. Later I changed to generating a minimal file manually, but these functions could now be unit tested.  (though I didn't actually add any tests here)