### PR TITLE
Ensure consistent labels in image and app-deploy

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -487,7 +487,6 @@ func generateDeploymentConfig(config *buildCommandConfig, imageName string, labe
 	return nil
 }
 
-
 func updateDeploymentConfig(config *buildCommandConfig, imageName string, labels map[string]string) error {
 	configFile := config.appDeployFile
 

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -202,7 +202,7 @@ func build(config *buildCommandConfig) error {
 	}
 
 	// Generate app-deploy
-	err = generateDeploymentConfig(config)
+	err = generateDeploymentConfig(config, labels)
 	if err != nil {
 		return err
 	}
@@ -328,7 +328,7 @@ func CreateLabelPairs(labels map[string]string) []string {
 	return labelsArr
 }
 
-func generateDeploymentConfig(config *buildCommandConfig) error {
+func generateDeploymentConfig(config *buildCommandConfig, labels map[string]string) error {
 	containerConfigDir := "/config/app-deploy.yaml"
 	configFile := config.appDeployFile
 
@@ -353,7 +353,7 @@ func generateDeploymentConfig(config *buildCommandConfig) error {
 
 	if exists {
 		config.Info.log("Found existing deployment manifest ", configFile)
-		err := updateDeploymentConfig(config)
+		err := updateDeploymentConfig(config, labels)
 		if err != nil {
 			return err
 		}
@@ -475,7 +475,7 @@ func generateDeploymentConfig(config *buildCommandConfig) error {
 			return errors.Errorf("Failed to write local application configuration file: %s", err)
 		}
 
-		err = updateDeploymentConfig(config)
+		err = updateDeploymentConfig(config, labels)
 		if err != nil {
 			return errors.Errorf("Failed to update deployment config file: %s", err)
 		}
@@ -486,17 +486,12 @@ func generateDeploymentConfig(config *buildCommandConfig) error {
 	return nil
 }
 
-func updateDeploymentConfig(config *buildCommandConfig) error {
+func updateDeploymentConfig(config *buildCommandConfig, labels map[string]string) error {
 	configFile := config.appDeployFile
 
 	appsodyApplication, err := getAppsodyApplication(configFile)
 	if err != nil {
 		return err
-	}
-
-	labels, err := getLabels(config.RootCommandConfig)
-	if err != nil {
-		return errors.Errorf("Could not get labels: %s", err)
 	}
 
 	labels = convertLabelsToKubeFormat(config.LoggingConfig, labels)

--- a/cmd/cmdtest/testutils.go
+++ b/cmd/cmdtest/testutils.go
@@ -326,6 +326,32 @@ func AddLocalRepo(t *TestSandbox, repoName string, repoFilePath string) (string,
 	return repoURL, nil
 }
 
+// AddLocalFileRepo calls the repo add command with the repo index located
+// at the local file path. The path may be relative to the current working
+// directory.
+// Returns the URL of the repo added.
+// Returns a function which should be deferred by the caller to cleanup
+// the repo list when finished.
+func AddLocalRepo(t *TestSandbox, repoName string, repoFilePath string) (string, error) {
+	absPath, err := filepath.Abs(repoFilePath)
+	if err != nil {
+		return "", err
+	}
+	var repoURL string
+	if runtime.GOOS == "windows" {
+		// for windows, add a leading slash and convert to unix style slashes
+		absPath = "/" + filepath.ToSlash(absPath)
+	}
+	repoURL = "file://" + absPath
+	// add a new repo
+	_, err = RunAppsody(t, "repo", "add", repoName, repoURL)
+	if err != nil {
+		return "", err
+	}
+
+	return repoURL, nil
+}
+
 // RunDockerCmdExec runs the docker command with the given args in a new process
 // The stdout and stderr are captured, printed, and returned
 // args will be passed to the docker command

--- a/cmd/cmdtest/testutils.go
+++ b/cmd/cmdtest/testutils.go
@@ -326,32 +326,6 @@ func AddLocalRepo(t *TestSandbox, repoName string, repoFilePath string) (string,
 	return repoURL, nil
 }
 
-// AddLocalFileRepo calls the repo add command with the repo index located
-// at the local file path. The path may be relative to the current working
-// directory.
-// Returns the URL of the repo added.
-// Returns a function which should be deferred by the caller to cleanup
-// the repo list when finished.
-func AddLocalRepo(t *TestSandbox, repoName string, repoFilePath string) (string, error) {
-	absPath, err := filepath.Abs(repoFilePath)
-	if err != nil {
-		return "", err
-	}
-	var repoURL string
-	if runtime.GOOS == "windows" {
-		// for windows, add a leading slash and convert to unix style slashes
-		absPath = "/" + filepath.ToSlash(absPath)
-	}
-	repoURL = "file://" + absPath
-	// add a new repo
-	_, err = RunAppsody(t, "repo", "add", repoName, repoURL)
-	if err != nil {
-		return "", err
-	}
-
-	return repoURL, nil
-}
-
 // RunDockerCmdExec runs the docker command with the given args in a new process
 // The stdout and stderr are captured, printed, and returned
 // args will be passed to the docker command

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,12 +65,9 @@ type RootCommandConfig struct {
 	StackRegistry    string
 
 	// package scoped, these are mostly for caching
-	setupConfigRun     bool
-	imagePulled        map[string]bool
-	cachedEnvVars      map[string]string
-	cachedStackLabels  map[string]string
-	cachedConfigLabels map[string]string
-	cachedGitLabels    map[string]string
+	setupConfigRun bool
+	imagePulled    map[string]bool
+	cachedEnvVars  map[string]string
 }
 
 // Regular expression to match ANSI terminal commands so that we can remove them from the log

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,10 +65,12 @@ type RootCommandConfig struct {
 	StackRegistry    string
 
 	// package scoped, these are mostly for caching
-	setupConfigRun    bool
-	imagePulled       map[string]bool
-	cachedEnvVars     map[string]string
-	cachedStackLabels map[string]string
+	setupConfigRun     bool
+	imagePulled        map[string]bool
+	cachedEnvVars      map[string]string
+	cachedStackLabels  map[string]string
+	cachedConfigLabels map[string]string
+	cachedGitLabels    map[string]string
 }
 
 // Regular expression to match ANSI terminal commands so that we can remove them from the log

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -679,10 +679,15 @@ func getConfigLabels(projectConfig ProjectConfig, filename string) (map[string]s
 		labels["dev.appsody.app.name"] = projectConfig.ApplicationName
 	}
 
+	config.cachedConfigLabels = labels
 	return labels, nil
 }
 
 func getGitLabels(config *RootCommandConfig) (map[string]string, error) {
+	if config.cachedGitLabels != nil {
+		return config.cachedGitLabels, nil
+	}
+
 	gitInfo, err := GetGitInfo(config)
 	if err != nil {
 		return nil, err
@@ -738,6 +743,7 @@ func getGitLabels(config *RootCommandConfig) (map[string]string, error) {
 		labels[appsodyImageCommitKeyPrefix+"contextDir"] = commitInfo.contextDir
 	}
 
+	config.cachedGitLabels = labels
 	return labels, nil
 }
 

--- a/functest/build_test.go
+++ b/functest/build_test.go
@@ -96,6 +96,7 @@ var appsodyStackLabels = []string{
 }
 
 func TestBuildLabels(t *testing.T) {
+	stacksList = "incubator/nodejs"
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
 
@@ -257,6 +258,9 @@ func verifyImageAndConfigLabelsMatch(t *testing.T, appsodyApplication v1beta1.Ap
 		t.Errorf("Error inspecting docker image: %s", err)
 	}
 
+	output = strings.ReplaceAll(output, "\n", "")
+	output = strings.ReplaceAll(output, "'", "")
+
 	var imageLabels map[string]string
 	err = json.Unmarshal([]byte(output), &imageLabels)
 	if err != nil {
@@ -269,11 +273,17 @@ func verifyImageAndConfigLabelsMatch(t *testing.T, appsodyApplication v1beta1.Ap
 			t.Errorf("Could not convert label to Kubernetes format: %s", err)
 		}
 
-		if appsodyApplication.Labels[key] == "" {
+		label := appsodyApplication.Labels[key]
+		annotation := appsodyApplication.Annotations[key]
+		if label == "" && annotation == "" {
 			t.Errorf("Could not find label %s in deployment config", key)
 		}
 
-		if appsodyApplication.Labels[key] != value {
+		if label != "" && label != value {
+			t.Errorf("Mismatch of %s label between built image and deployment config", key)
+		}
+
+		if annotation != "" && annotation != value {
 			t.Errorf("Mismatch of %s label between built image and deployment config", key)
 		}
 	}


### PR DESCRIPTION
Currently the `created` label from the image build and the `app-deploy.yaml` are not matching because we compute the labels twice. In this PR, I cache the labels inside the `RootCommandConfig`. I thought of packaging up the labels into a struct, but it could be the case that a function will be used independently - would like to hear thoughts on this! 