### PR TITLE
templating: add built-in template variables for bumped versions

### DIFF
--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -18,10 +18,10 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"text/template"
 	"unicode"
-	"strconv"
 
 	"github.com/gabriel-vasile/mimetype"
 	"github.com/pkg/errors"


### PR DESCRIPTION
This PR adds the bumped versions of major/minor/patch versions to the existing built-in template variables. As seen in the PR to use go-templating in the `java-sprint-boot2` stack (https://github.com/appsody/stacks/pull/517), the stack makes use of the bumped minor version. We could include these bumped versions as built-in variables to help stack creators (currently, this would be the java stacks that require a version range).
