### PR TITLE
Remove some os.Exit()s

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -245,8 +245,7 @@ func initAppsody(stack string, template string, config *initCommandConfig) error
 		if !mapEmpty {
 			checkErr := CheckStackRequirements(config.LoggingConfig, reqsMap, config.Buildah)
 			if checkErr != nil {
-				config.Error.log(checkErr)
-				os.Exit(1)
+				return checkErr
 			}
 		} else {
 			config.Info.log("No stack requirements set. Skipping...")
@@ -335,7 +334,6 @@ func install(config *initCommandConfig) error {
 		config.Warning.log("The stack init script failed: ", err)
 		config.Warning.log("Your local IDE may not build properly, but the Appsody container should still work.")
 		config.Warning.log("To try again, resolve the issue then run `appsody init` with no arguments.")
-		os.Exit(0)
 	}
 	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -361,4 +361,5 @@ func (config *RootCommandConfig) initLogging() error {
 		klogInitialized = true
 		config.Debug.log("Logging to file ", pathString)
 	}
+	return nil
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -107,7 +107,10 @@ Complete documentation is available at https://appsody.dev`,
 	if setupErr != nil {
 		return rootCmd, rootConfig, setupErr
 	}
-	rootConfig.initLogging()
+	err := rootConfig.initLogging()
+	if err != nil {
+		return rootCmd, rootConfig, err
+	}
 
 	rootCmd.AddCommand(
 		newInitCmd(rootConfig),
@@ -321,7 +324,7 @@ func (config *LoggingConfig) InitLogging(outWriter, errWriter io.Writer) {
 	}
 }
 
-func (config *RootCommandConfig) initLogging() {
+func (config *RootCommandConfig) initLogging() error {
 	var allLoggers = []*appsodylogger{&config.Info, &config.Warning, &config.Error, &config.Debug, &config.Container, &config.InitScript, &config.DockerLog}
 	if config.Verbose {
 		for _, l := range allLoggers {
@@ -330,7 +333,7 @@ func (config *RootCommandConfig) initLogging() {
 
 		homeDirectory, dirErr := homedir.Dir()
 		if dirErr != nil {
-			os.Exit(1)
+			return errors.Errorf("Error getting home directory: %v", dirErr)
 		}
 
 		logDir := filepath.Join(homeDirectory, ".appsody", "logs")


### PR DESCRIPTION
@upLukeWeston @Kamran64 We should avoid using os.Exit() wherever possible and return errors instead.