### PR TITLE
Fix error message to print string of outbuffer instead of the buffer.

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1991,7 +1991,8 @@ func CheckStackRequirements(log *LoggingConfig, requirementArray map[string]stri
 				if parseErr != nil || cutCmdOutput == "0.0.0" {
 					log.Error.log(parseErr)
 					log.Warning.log("Unable to parse user version - This stack may not work in your current development environment.")
-					return nil
+					// Continue when the version can not be determined or the appsody version is 0.0.0
+					continue
 				}
 				compareVersion := setConstraint.Check(parseUserVersion)
 

--- a/cmd/utils_test.go
+++ b/cmd/utils_test.go
@@ -120,8 +120,8 @@ func TestInvalidVersionAgainstStack(t *testing.T) {
 	err := cmd.CheckStackRequirements(log, reqsMap, false)
 
 	if err == nil {
-		t.Log(outBuffer)
-		t.Fatal(err)
+		t.Log(outBuffer.String())
+		t.Fatal("Expected Error NOT thrown", reqsMap)
 	}
 }
 


### PR DESCRIPTION
Continue when we don't get the version instead of exiting routine.