### PR TITLE
package/validate: image registry flag

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -139,7 +139,7 @@ func build(config *buildCommandConfig) error {
 
 	extractDir := filepath.Join(getHome(config.RootCommandConfig), "extract", projectName)
 	dockerfile := filepath.Join(extractDir, "Dockerfile")
-	buildImage := "dev.local/" + projectName //Lowercased
+	buildImage := "dev.local/appsody/" + projectName //Lowercased
 
 	// Regardless of pass or fail, remove the local extracted folder
 	defer os.RemoveAll(extractDir)

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -139,7 +139,7 @@ func build(config *buildCommandConfig) error {
 
 	extractDir := filepath.Join(getHome(config.RootCommandConfig), "extract", projectName)
 	dockerfile := filepath.Join(extractDir, "Dockerfile")
-	buildImage := "dev.local/appsody/" + projectName //Lowercased
+	buildImage := "dev.local/" + projectName //Lowercased
 
 	// Regardless of pass or fail, remove the local extracted folder
 	defer os.RemoveAll(extractDir)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -304,6 +304,16 @@ func initAppsody(stack string, template string, config *initCommandConfig) error
 //Runs the .appsody-init.sh/bat files if necessary
 func install(config *initCommandConfig) error {
 	config.Info.log("Setting up the development environment")
+
+	// reset config.StackRegistry and get it again from the newly untarred .appsody-config.yaml
+	// this will need to be updated when we support --stack-registry on the init command
+	config.StackRegistry = ""
+	var stackErr error
+	config.StackRegistry, stackErr = getStackRegistry(config.RootCommandConfig)
+	if stackErr != nil {
+		return stackErr
+	}
+
 	projectDir, perr := getProjectDir(config.RootCommandConfig)
 	if perr != nil {
 		return perr

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -79,7 +79,7 @@ func newStackPackageCmd(rootConfig *RootCommandConfig) *cobra.Command {
 
 	var imageNamespace string
 	var imageRegistry string
-	var namespaceAndRepo string 
+	var namespaceAndRepo string
 
 	log := rootConfig.LoggingConfig
 
@@ -198,8 +198,8 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 			// docker build
 			// create the image name to be used for the docker image
 			if imageNamespace == "dev.local" && imageRegistry != "docker.io" {
-				return errors.Errorf("Error creating the image name. When specifying the image registry: %v, you must also specify the image namespace.", imageRegistry)
-			} else if imageNamespace == "dev.local"{
+				return errors.Errorf("Error creating the image name. When specifying the image registry: %v: you must also specify the image namespace.", imageRegistry)
+			} else if imageNamespace == "dev.local" {
 				namespaceAndRepo = imageNamespace + "/" + stackID
 			} else {
 				namespaceAndRepo = imageRegistry + "/" + imageNamespace + "/" + stackID

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -197,12 +197,16 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 
 			// docker build
 			// create the image name to be used for the docker image
+			imageRepo := rootConfig.CliConfig.GetString("images")
+
 			if imageNamespace == "dev.local" && imageRegistry != "docker.io" {
 				return errors.Errorf("Error creating the image name. When specifying the image registry: %v: you must also specify the image namespace.", imageRegistry)
 			} else if imageNamespace == "dev.local" {
 				namespaceAndRepo = imageNamespace + "/" + stackID
-			} else {
+			} else if imageRegistry != "docker.io" {
 				namespaceAndRepo = imageRegistry + "/" + imageNamespace + "/" + stackID
+			} else {
+				namespaceAndRepo = imageRepo + "/" + imageNamespace + "/" + stackID
 			}
 
 			buildImage := namespaceAndRepo + ":" + stackYaml.Version

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -219,7 +219,7 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 			}
 
 			// create the template metadata
-			templateMetadata, err := CreateTemplateMap(labels, stackYaml, imageNamespace)
+			templateMetadata, err := CreateTemplateMap(labels, stackYaml, imageNamespace, imageRegistry)
 			if err != nil {
 				return errors.Errorf("Error creating templating mal: %v", err)
 			}
@@ -498,7 +498,7 @@ func GetLabelsForStackImage(stackID string, buildImage string, stackYaml StackYa
 
 // CreateTemplateMap - uses the git labels, stack.yaml, stackID and imageNamespace to create a map
 // with all the necessary data needed for the template
-func CreateTemplateMap(labels map[string]string, stackYaml StackYaml, imageNamespace string) (map[string]interface{}, error) {
+func CreateTemplateMap(labels map[string]string, stackYaml StackYaml, imageNamespace string, imageRegistry string) (map[string]interface{}, error) {
 
 	// create stack variables and add to templateMetadata map
 	var templateMetadata = make(map[string]interface{})
@@ -535,6 +535,7 @@ func CreateTemplateMap(labels map[string]string, stackYaml StackYaml, imageNames
 	// create image map add to templateMetadata map
 	var image = make(map[string]string)
 	image["namespace"] = imageNamespace
+	image["registry"] = imageRegistry
 	stack["image"] = image
 
 	// loop through user variables and add them to map, must begin with alphanumeric character

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -392,8 +392,8 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 		},
 	}
 
-	stackPackageCmd.PersistentFlags().StringVar(&imageNamespace, "image-namespace", "dev.local", "Namespace that the images will be created using.")
-	stackPackageCmd.PersistentFlags().StringVar(&imageRegistry, "image-registry", "docker.io", "Registry that the images will be created using.")
+	stackPackageCmd.PersistentFlags().StringVar(&imageNamespace, "image-namespace", "dev.local", "Namespace used for creating the images.")
+	stackPackageCmd.PersistentFlags().StringVar(&imageRegistry, "image-registry", "docker.io", "Registry used for creating the images.")
 
 	return stackPackageCmd
 }

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -78,6 +78,8 @@ func newStackPackageCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	// 4. create/update an appsody repo for the stack
 
 	var imageNamespace string
+	var imageRegistry string
+	var namespaceAndRepo string 
 
 	log := rootConfig.LoggingConfig
 
@@ -195,7 +197,14 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 
 			// docker build
 			// create the image name to be used for the docker image
-			namespaceAndRepo := imageNamespace + "/" + stackID
+			if imageNamespace == "dev.local" && imageRegistry != "docker.io" {
+				return errors.Errorf("Error creating the image name. When specifying the image registry: %v, you must also specify the image namespace.", imageRegistry)
+			} else if imageNamespace == "dev.local"{
+				namespaceAndRepo = imageNamespace + "/" + stackID
+			} else {
+				namespaceAndRepo = imageRegistry + "/" + imageNamespace + "/" + stackID
+			}
+
 			buildImage := namespaceAndRepo + ":" + stackYaml.Version
 
 			imageDir := filepath.Join(stackPath, "image")
@@ -383,7 +392,8 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 		},
 	}
 
-	stackPackageCmd.PersistentFlags().StringVar(&imageNamespace, "image-namespace", "dev.local", "Namespace that the images will be created using (default is dev.local)")
+	stackPackageCmd.PersistentFlags().StringVar(&imageNamespace, "image-namespace", "dev.local", "Namespace that the images will be created using.")
+	stackPackageCmd.PersistentFlags().StringVar(&imageRegistry, "image-registry", "docker.io", "Registry that the images will be created using.")
 
 	return stackPackageCmd
 }

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -90,10 +90,10 @@ func newStackPackageCmd(rootConfig *RootCommandConfig) *cobra.Command {
 
 The packaging process builds the stack image, generates the "tar.gz" archive files for each template, and adds your stack to the "dev.local" repository in your Appsody configuration. You can see the list of your packaged stacks by running 'appsody list dev.local'.`,
 		Example: `  appsody stack package
-  Packages the stack in the current directory, tags the built image with the "dev.local" namespace, and adds the stack to the "dev.local" repository.
+  Packages the stack in the current directory, tags the built image with the default registry and namespace, and adds the stack to the "dev.local" repository.
   
   appsody stack package --image-namespace my-namespace
-  Packages the stack in the current directory, tags the built image with the "my-namespace" namespace, and adds the stack to the "dev.local" repository.`,
+  Packages the stack in the current directory, tags the built image with the default registry and "my-namespace" namespace, and adds the stack to the "dev.local" repository.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			log.Info.Log("******************************************")
@@ -199,11 +199,9 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 			// create the image name to be used for the docker image
 			imageRepo := rootConfig.CliConfig.GetString("images")
 
-			if imageNamespace == "dev.local" && imageRegistry != "docker.io" {
+			if imageRegistry != "dev.local" && imageNamespace == "appsody" {
 				return errors.Errorf("Error creating the image name. When specifying the image registry: %v: you must also specify the image namespace.", imageRegistry)
-			} else if imageNamespace == "dev.local" {
-				namespaceAndRepo = imageNamespace + "/" + stackID
-			} else if imageRegistry != "docker.io" {
+			} else if imageRegistry == "dev.local" && imageNamespace == "appsody" || imageRegistry != "dev.local" && imageNamespace != "appsody" {
 				namespaceAndRepo = imageRegistry + "/" + imageNamespace + "/" + stackID
 			} else {
 				namespaceAndRepo = imageRepo + "/" + imageNamespace + "/" + stackID
@@ -396,8 +394,8 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 		},
 	}
 
-	stackPackageCmd.PersistentFlags().StringVar(&imageNamespace, "image-namespace", "dev.local", "Namespace used for creating the images.")
-	stackPackageCmd.PersistentFlags().StringVar(&imageRegistry, "image-registry", "docker.io", "Registry used for creating the images.")
+	stackPackageCmd.PersistentFlags().StringVar(&imageNamespace, "image-namespace", "appsody", "Namespace used for creating the images.")
+	stackPackageCmd.PersistentFlags().StringVar(&imageRegistry, "image-registry", "dev.local", "Registry used for creating the images.")
 
 	return stackPackageCmd
 }

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -197,15 +197,7 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 
 			// docker build
 			// create the image name to be used for the docker image
-			imageRepo := rootConfig.CliConfig.GetString("images")
-
-			if imageRegistry != "dev.local" && imageNamespace == "appsody" {
-				return errors.Errorf("Error creating the image name. When specifying the image registry: %v: you must also specify the image namespace.", imageRegistry)
-			} else if imageRegistry == "dev.local" && imageNamespace == "appsody" || imageRegistry != "dev.local" && imageNamespace != "appsody" {
-				namespaceAndRepo = imageRegistry + "/" + imageNamespace + "/" + stackID
-			} else {
-				namespaceAndRepo = imageRepo + "/" + imageNamespace + "/" + stackID
-			}
+			namespaceAndRepo = imageRegistry + "/" + imageNamespace + "/" + stackID
 
 			buildImage := namespaceAndRepo + ":" + stackYaml.Version
 

--- a/cmd/stack_package_test.go
+++ b/cmd/stack_package_test.go
@@ -31,7 +31,7 @@ import (
 func TestTemplatingAllVariables(t *testing.T) {
 
 	// gets all the necessary data from a setup function
-	imageNamespace, stackYaml, labels, err := setupStackPackageTests()
+	imageNamespace, imageRegistry, stackYaml, labels, err := setupStackPackageTests()
 	if err != nil {
 		t.Fatalf("Error during setup: %v", err)
 	}
@@ -62,7 +62,7 @@ func TestTemplatingAllVariables(t *testing.T) {
 	}
 
 	// create the template metadata
-	templateMetadata, err := cmd.CreateTemplateMap(labels, stackYaml, imageNamespace)
+	templateMetadata, err := cmd.CreateTemplateMap(labels, stackYaml, imageNamespace, imageRegistry)
 	if err != nil {
 		t.Fatalf("Error creating template map: %v", err)
 	}
@@ -90,7 +90,7 @@ func TestTemplatingAllVariables(t *testing.T) {
 func TestTemplatingWrongVariables(t *testing.T) {
 
 	// gets all the necessary data from a setup function
-	imageNamespace, stackYaml, labels, err := setupStackPackageTests()
+	imageNamespace, imageRegistry, stackYaml, labels, err := setupStackPackageTests()
 	if err != nil {
 		t.Fatalf("Error during setup: %v", err)
 	}
@@ -121,7 +121,7 @@ func TestTemplatingWrongVariables(t *testing.T) {
 	}
 
 	// create the template metadata
-	templateMetadata, err := cmd.CreateTemplateMap(labels, stackYaml, imageNamespace)
+	templateMetadata, err := cmd.CreateTemplateMap(labels, stackYaml, imageNamespace, imageRegistry)
 	if err != nil {
 		t.Fatalf("Error creating template map: %v", err)
 	}
@@ -154,7 +154,7 @@ func TestTemplatingFilePermissions(t *testing.T) {
 	}
 
 	// gets all the necessary data from a setup function
-	imageNamespace, stackYaml, labels, err := setupStackPackageTests()
+	imageNamespace, imageRegistry, stackYaml, labels, err := setupStackPackageTests()
 	if err != nil {
 		t.Fatalf("Error during setup: %v", err)
 	}
@@ -190,7 +190,7 @@ func TestTemplatingFilePermissions(t *testing.T) {
 	}
 
 	// create the template metadata
-	templateMetadata, err := cmd.CreateTemplateMap(labels, stackYaml, imageNamespace)
+	templateMetadata, err := cmd.CreateTemplateMap(labels, stackYaml, imageNamespace, imageRegistry)
 	if err != nil {
 		t.Fatalf("Error creating template map: %v", err)
 	}
@@ -233,7 +233,7 @@ func canWrite(filepath string) (bool, error) {
 
 }
 
-func setupStackPackageTests() (string, cmd.StackYaml, map[string]string, error) {
+func setupStackPackageTests() (string, string, cmd.StackYaml, map[string]string, error) {
 	var loggingConfig = &cmd.LoggingConfig{}
 	loggingConfig.InitLogging(os.Stdout, os.Stderr)
 	var rootConfig = &cmd.RootCommandConfig{LoggingConfig: loggingConfig}
@@ -241,6 +241,7 @@ func setupStackPackageTests() (string, cmd.StackYaml, map[string]string, error) 
 	var stackYaml cmd.StackYaml
 	stackID := "starter"
 	imageNamespace := "dev.local"
+	imageRegistry := "docker.io"
 	buildImage := imageNamespace + "/" + stackID + ":SNAPSHOT"
 	projectPath := filepath.Join(".", "testdata", "starter")
 
@@ -249,24 +250,24 @@ func setupStackPackageTests() (string, cmd.StackYaml, map[string]string, error) 
 
 	err := cmd.InitConfig(rootConfig)
 	if err != nil {
-		return imageNamespace, stackYaml, labels, errors.Errorf("Error getting config: %v", err)
+		return imageNamespace, imageRegistry, stackYaml, labels, errors.Errorf("Error getting config: %v", err)
 	}
 
 	source, err := ioutil.ReadFile(filepath.Join(projectPath, "stack.yaml"))
 	if err != nil {
-		return imageNamespace, stackYaml, labels, errors.Errorf("Error reading stackyaml: %v", err)
+		return imageNamespace, imageRegistry, stackYaml, labels, errors.Errorf("Error reading stackyaml: %v", err)
 	}
 
 	err = yaml.Unmarshal(source, &stackYaml)
 	if err != nil {
-		return imageNamespace, stackYaml, labels, errors.Errorf("Error parsing stackyaml: %v", err)
+		return imageNamespace, imageRegistry, stackYaml, labels, errors.Errorf("Error parsing stackyaml: %v", err)
 	}
 
 	labels, err = cmd.GetLabelsForStackImage(stackID, buildImage, stackYaml, rootConfig)
 	if err != nil {
-		return imageNamespace, stackYaml, labels, errors.Errorf("Error getting labels: %v", err)
+		return imageNamespace, imageRegistry, stackYaml, labels, errors.Errorf("Error getting labels: %v", err)
 	}
 
-	return imageNamespace, stackYaml, labels, err
+	return imageNamespace, imageRegistry, stackYaml, labels, err
 
 }

--- a/cmd/stack_package_test.go
+++ b/cmd/stack_package_test.go
@@ -80,7 +80,7 @@ func TestTemplatingAllVariables(t *testing.T) {
 	}
 	s := string(b)
 	t.Log(s)
-	if !strings.Contains(s, "id: starter, name: Starter Sample, version: 0.1.1, description: Runnable starter stack, copy to create a new stack, tag: dev.local/starter:SNAPSHOT, maintainers: Henry Nash <henry.nash@uk.ibm.com>, semver.major: 0, semver.minor: 1, semver.patch: 1, semver.majorminor: 0.1, image.namespace: dev.local, customvariable1: value1, customvariable2: value2") {
+	if !strings.Contains(s, "id: starter, name: Starter Sample, version: 0.1.1, description: Runnable starter stack, copy to create a new stack, tag: appsody/starter:SNAPSHOT, maintainers: Henry Nash <henry.nash@uk.ibm.com>, semver.major: 0, semver.minor: 1, semver.patch: 1, semver.majorminor: 0.1, image.namespace: appsody, customvariable1: value1, customvariable2: value2") {
 		t.Fatal("Templating text did not match expected values")
 	}
 
@@ -240,8 +240,8 @@ func setupStackPackageTests() (string, string, cmd.StackYaml, map[string]string,
 	var labels = map[string]string{}
 	var stackYaml cmd.StackYaml
 	stackID := "starter"
-	imageNamespace := "dev.local"
-	imageRegistry := "docker.io"
+	imageNamespace := "appsody"
+	imageRegistry := "dev.local"
 	buildImage := imageNamespace + "/" + stackID + ":SNAPSHOT"
 	projectPath := filepath.Join(".", "testdata", "starter")
 

--- a/cmd/stack_validate.go
+++ b/cmd/stack_validate.go
@@ -79,7 +79,7 @@ Runs the following validation tests against the stack and its templates:
 			stackName := filepath.Base(stackPath)
 			rootConfig.Info.Log("stackName is: ", stackName)
 
-			if imageNamespace == "dev.local" && imageRegistry != "docker.io" {
+			if imageRegistry != "dev.local" && imageNamespace == "appsody" {
 				return errors.Errorf("Error creating the image name. When specifying the image registry: %v: you must also specify the image namespace.", imageRegistry)
 			}
 
@@ -153,7 +153,7 @@ Runs the following validation tests against the stack and its templates:
 				rootConfig.Info.Log("Created project dir: " + projectDir)
 
 				// init
-				err = TestInit(rootConfig.LoggingConfig, "dev.local/"+stackName, templates[i], projectDir)
+				err = TestInit(rootConfig.LoggingConfig, imageRegistry+imageNamespace+stackName, templates[i], projectDir)
 				if err != nil {
 					rootConfig.Error.Log(err)
 					testResults = append(testResults, ("FAILED: Init for stack:" + stackName + " template:" + templates[i]))
@@ -167,7 +167,7 @@ Runs the following validation tests against the stack and its templates:
 
 				// run
 				if !initFail {
-					err = TestRun(rootConfig.LoggingConfig, "dev.local/"+stackName, templates[i], projectDir)
+					err = TestRun(rootConfig.LoggingConfig, imageRegistry+imageNamespace+stackName, templates[i], projectDir)
 					if err != nil {
 						//logs error but keeps going
 						rootConfig.Error.Log(err)
@@ -181,7 +181,7 @@ Runs the following validation tests against the stack and its templates:
 
 				// test
 				if !initFail {
-					err = TestTest(rootConfig.LoggingConfig, "dev.local/"+stackName, templates[i], projectDir)
+					err = TestTest(rootConfig.LoggingConfig, imageRegistry+imageNamespace+stackName, templates[i], projectDir)
 					if err != nil {
 						//logs error but keeps going
 						rootConfig.Error.Log(err)
@@ -195,7 +195,7 @@ Runs the following validation tests against the stack and its templates:
 
 				// build
 				if !initFail {
-					err = TestBuild(rootConfig.LoggingConfig, "dev.local/"+stackName, templates[i], projectDir)
+					err = TestBuild(rootConfig.LoggingConfig, imageRegistry+imageNamespace+stackName, templates[i], projectDir)
 					if err != nil {
 						//logs error but keeps going
 						rootConfig.Error.Log(err)
@@ -233,8 +233,8 @@ Runs the following validation tests against the stack and its templates:
 
 	stackValidateCmd.PersistentFlags().BoolVar(&noPackage, "no-package", false, "Skips running appsody stack package")
 	stackValidateCmd.PersistentFlags().BoolVar(&noLint, "no-lint", false, "Skips running appsody stack lint")
-	stackValidateCmd.PersistentFlags().StringVar(&imageNamespace, "image-namespace", "dev.local", "Namespace used for creating the images.")
-	stackValidateCmd.PersistentFlags().StringVar(&imageRegistry, "image-registry", "docker.io", "Registry used for creating the images.")
+	stackValidateCmd.PersistentFlags().StringVar(&imageNamespace, "image-namespace", "appsody", "Namespace used for creating the images.")
+	stackValidateCmd.PersistentFlags().StringVar(&imageRegistry, "image-registry", "dev.local", "Registry used for creating the images.")
 
 	return stackValidateCmd
 }
@@ -328,7 +328,7 @@ func TestTest(log *LoggingConfig, stack string, template string, projectDir stri
 // Simple test for appsody build command. A future enhancement would be to verify the image that gets built.
 func TestBuild(log *LoggingConfig, stack string, template string, projectDir string) error {
 
-	imageName := "dev.local/" + filepath.Base(projectDir)
+	imageName := "dev.local/appsody" + filepath.Base(projectDir)
 
 	log.Info.Log("**************************************************************************")
 	log.Info.Log("Running appsody build against stack:" + stack + " template:" + template)

--- a/cmd/stack_validate.go
+++ b/cmd/stack_validate.go
@@ -78,11 +78,6 @@ Runs the following validation tests against the stack and its templates:
 			// get the stack name from the stack path
 			stackName := filepath.Base(stackPath)
 			rootConfig.Info.Log("stackName is: ", stackName)
-
-			if imageRegistry != "dev.local" && imageNamespace == "appsody" {
-				return errors.Errorf("Error creating the image name. When specifying the image registry: %v: you must also specify the image namespace.", imageRegistry)
-			}
-
 			rootConfig.Info.Log("#################################################")
 			rootConfig.Info.Log("Validating stack:", stackName)
 			rootConfig.Info.Log("#################################################")
@@ -151,9 +146,10 @@ Runs the following validation tests against the stack and its templates:
 				}
 
 				rootConfig.Info.Log("Created project dir: " + projectDir)
+				stack := "dev.local/" + stackName
 
 				// init
-				err = TestInit(rootConfig.LoggingConfig, imageRegistry+imageNamespace+stackName, templates[i], projectDir)
+				err = TestInit(rootConfig.LoggingConfig, stack, templates[i], projectDir)
 				if err != nil {
 					rootConfig.Error.Log(err)
 					testResults = append(testResults, ("FAILED: Init for stack:" + stackName + " template:" + templates[i]))
@@ -167,7 +163,7 @@ Runs the following validation tests against the stack and its templates:
 
 				// run
 				if !initFail {
-					err = TestRun(rootConfig.LoggingConfig, imageRegistry+imageNamespace+stackName, templates[i], projectDir)
+					err = TestRun(rootConfig.LoggingConfig, stack, templates[i], projectDir)
 					if err != nil {
 						//logs error but keeps going
 						rootConfig.Error.Log(err)
@@ -181,7 +177,7 @@ Runs the following validation tests against the stack and its templates:
 
 				// test
 				if !initFail {
-					err = TestTest(rootConfig.LoggingConfig, imageRegistry+imageNamespace+stackName, templates[i], projectDir)
+					err = TestTest(rootConfig.LoggingConfig, stack, templates[i], projectDir)
 					if err != nil {
 						//logs error but keeps going
 						rootConfig.Error.Log(err)
@@ -195,7 +191,7 @@ Runs the following validation tests against the stack and its templates:
 
 				// build
 				if !initFail {
-					err = TestBuild(rootConfig.LoggingConfig, imageRegistry+imageNamespace+stackName, templates[i], projectDir)
+					err = TestBuild(rootConfig.LoggingConfig, stack, templates[i], projectDir)
 					if err != nil {
 						//logs error but keeps going
 						rootConfig.Error.Log(err)

--- a/cmd/stack_validate.go
+++ b/cmd/stack_validate.go
@@ -40,6 +40,7 @@ func newStackValidateCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	var noPackage bool
 	var noLint bool
 	var imageNamespace string
+	var imageRegistry string
 
 	var stackValidateCmd = &cobra.Command{
 		Use:   "validate",
@@ -78,6 +79,10 @@ Runs the following validation tests against the stack and its templates:
 			stackName := filepath.Base(stackPath)
 			rootConfig.Info.Log("stackName is: ", stackName)
 
+			if imageNamespace == "dev.local" && imageRegistry != "docker.io" {
+				return errors.Errorf("Error creating the image name. When specifying the image registry: %v: you must also specify the image namespace.", imageRegistry)
+			}
+
 			rootConfig.Info.Log("#################################################")
 			rootConfig.Info.Log("Validating stack:", stackName)
 			rootConfig.Info.Log("#################################################")
@@ -106,7 +111,7 @@ Runs the following validation tests against the stack and its templates:
 
 			// package
 			if !noPackage {
-				_, err = RunAppsodyCmdExec([]string{"stack", "package", "--image-namespace", imageNamespace}, stackPath)
+				_, err = RunAppsodyCmdExec([]string{"stack", "package", "--image-namespace", imageNamespace, "--image-registry", imageRegistry}, stackPath)
 				if err != nil {
 					//logs error but keeps going
 					rootConfig.Error.Log(err)
@@ -228,7 +233,8 @@ Runs the following validation tests against the stack and its templates:
 
 	stackValidateCmd.PersistentFlags().BoolVar(&noPackage, "no-package", false, "Skips running appsody stack package")
 	stackValidateCmd.PersistentFlags().BoolVar(&noLint, "no-lint", false, "Skips running appsody stack lint")
-	stackValidateCmd.PersistentFlags().StringVar(&imageNamespace, "image-namespace", "dev.local", "Namespace used for creating the images")
+	stackValidateCmd.PersistentFlags().StringVar(&imageNamespace, "image-namespace", "dev.local", "Namespace used for creating the images.")
+	stackValidateCmd.PersistentFlags().StringVar(&imageRegistry, "image-registry", "docker.io", "Registry used for creating the images.")
 
 	return stackValidateCmd
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -478,20 +478,7 @@ func getProjectConfig(config *RootCommandConfig) (*ProjectConfig, error) {
 			return &projectConfig, errors.Errorf("Error reading project config %v", err)
 
 		}
-
-		stack := v.GetString("stack")
 		config.Debug.log("Project stack from config file: ", projectConfig.Stack)
-		imageRepo := config.CliConfig.GetString("images")
-		projectConfig.Stack = stack
-		if !strings.Contains(stack, "dev.local") {
-			projectConfig.Stack = imageRepo + "/" + projectConfig.Stack
-			projectConfig.Stack, err = OverrideStackRegistry(config.StackRegistry, projectConfig.Stack)
-
-			if err != nil {
-				return &projectConfig, err
-			}
-			config.Debug.Logf("Project stack after override: %s is: %s", config.StackRegistry, projectConfig.Stack)
-		}
 		config.ProjectConfig = &projectConfig
 	}
 	return config.ProjectConfig, nil

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -483,8 +483,7 @@ func getProjectConfig(config *RootCommandConfig) (*ProjectConfig, error) {
 		config.Debug.log("Project stack from config file: ", projectConfig.Stack)
 		imageRepo := config.CliConfig.GetString("images")
 		projectConfig.Stack = stack
-		imageComponents := strings.Split(projectConfig.Stack, "/")
-		if len(imageComponents) < 3 && !strings.Contains(stack, "dev.local") {
+		if !strings.Contains(stack, "dev.local") {
 			projectConfig.Stack = imageRepo + "/" + projectConfig.Stack
 			projectConfig.Stack, err = OverrideStackRegistry(config.StackRegistry, projectConfig.Stack)
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -484,16 +484,15 @@ func getProjectConfig(config *RootCommandConfig) (*ProjectConfig, error) {
 		imageRepo := config.CliConfig.GetString("images")
 		config.Debug.log("Image repository set to: ", imageRepo)
 		projectConfig.Stack = stack
-		if imageRepo != "docker.io" {
-			projectConfig.Stack = imageRepo + "/" + projectConfig.Stack
-		}
-		//Override the stack registry URL
-		projectConfig.Stack, err = OverrideStackRegistry(config.StackRegistry, projectConfig.Stack)
 
-		if err != nil {
-			return &projectConfig, err
+		if !strings.Contains(stack, "dev.local") && len(strings.Split(stack, "/")) < 3 {
+			projectConfig.Stack, err = OverrideStackRegistry(config.StackRegistry, projectConfig.Stack)
+
+			if err != nil {
+				return &projectConfig, err
+			}
+			config.Debug.Logf("Project stack after override: %s is: %s", config.StackRegistry, projectConfig.Stack)
 		}
-		config.Debug.Logf("Project stack after override: %s is: %s", config.StackRegistry, projectConfig.Stack)
 		config.ProjectConfig = &projectConfig
 	}
 	return config.ProjectConfig, nil

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -479,6 +479,9 @@ func getProjectConfig(config *RootCommandConfig) (*ProjectConfig, error) {
 
 		}
 
+		// TODO We should consider refactoring the following code. There is a circular dependency between
+		// getProjectConfig(), getStackRegistry(), and setting config.StackRegistry which is especially
+		// concering with the `if config.ProjectConfig == nil` caching of this method.
 		stack := v.GetString("stack")
 		config.Debug.log("Project stack from config file: ", projectConfig.Stack)
 		imageRepo := config.CliConfig.GetString("images")

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -482,17 +482,22 @@ func getProjectConfig(config *RootCommandConfig) (*ProjectConfig, error) {
 		stack := v.GetString("stack")
 		config.Debug.log("Project stack from config file: ", projectConfig.Stack)
 		imageRepo := config.CliConfig.GetString("images")
-		config.Debug.log("Image repository set to: ", imageRepo)
 		projectConfig.Stack = stack
 
-		if !strings.Contains(stack, "dev.local") && len(strings.Split(stack, "/")) < 3 {
-			projectConfig.Stack, err = OverrideStackRegistry(config.StackRegistry, projectConfig.Stack)
+		stackElements := strings.Split(stack, "/")
 
-			if err != nil {
-				return &projectConfig, err
-			}
-			config.Debug.Logf("Project stack after override: %s is: %s", config.StackRegistry, projectConfig.Stack)
+		if imageRepo != "docker.io" && stackElements[0] != imageRepo && stackElements[0] == "docker.io" {
+			projectConfig.Stack = imageRepo + "/" + projectConfig.Stack
 		}
+
+		// if !strings.Contains(stack, "dev.local") && len(stackElements) < 3 {
+		// 	projectConfig.Stack, err = OverrideStackRegistry(config.StackRegistry, projectConfig.Stack)
+
+		// 	if err != nil {
+		// 		return &projectConfig, err
+		// 	}
+		// 	config.Debug.Logf("Project stack after override: %s is: %s", config.StackRegistry, projectConfig.Stack)
+		// }
 		config.ProjectConfig = &projectConfig
 	}
 	return config.ProjectConfig, nil

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -478,7 +478,23 @@ func getProjectConfig(config *RootCommandConfig) (*ProjectConfig, error) {
 			return &projectConfig, errors.Errorf("Error reading project config %v", err)
 
 		}
+
+		stack := v.GetString("stack")
 		config.Debug.log("Project stack from config file: ", projectConfig.Stack)
+		imageRepo := config.CliConfig.GetString("images")
+		config.Debug.log("Image repository set to: ", imageRepo)
+		projectConfig.Stack = stack
+		imageComponents := strings.Split(projectConfig.Stack, "/")
+		if len(imageComponents) < 3 {
+			projectConfig.Stack = imageRepo + "/" + projectConfig.Stack
+		}
+		//Override the stack registry URL
+		projectConfig.Stack, err = OverrideStackRegistry(config.StackRegistry, projectConfig.Stack)
+
+		if err != nil {
+			return &projectConfig, err
+		}
+		config.Debug.Logf("Project stack after override: %s is: %s", config.StackRegistry, projectConfig.Stack)
 		config.ProjectConfig = &projectConfig
 	}
 	return config.ProjectConfig, nil


### PR DESCRIPTION
The `stack package` and `validate` command now uses `registry/namespace/stack:0.0.0` format to fully qualify the stack location. This is embedded into the template `.appsody-config.yaml` files.

Added a flag so user can change the default registry.

Fixes: #669 
This PR should wait for https://github.com/appsody/appsody/pull/725 and https://github.com/appsody/appsody/pull/749