### PR TITLE
Only remove quotes and newlines from beginning and end of inspect output

### DIFF
--- a/functest/build_test.go
+++ b/functest/build_test.go
@@ -277,13 +277,12 @@ func verifyImageAndConfigLabelsMatch(t *testing.T, appsodyApplication v1beta1.Ap
 			t.Errorf("Could not find label %s in deployment config", key)
 		}
 
-		t.Logf("Comparing %s with %s%s", value, label, annotation)
 		if label != "" && label != value {
-			t.Errorf("Mismatch of %s label between built image and deployment config", key)
+			t.Errorf("Mismatch of %s label between built image and deployment config. Expected %s but found %s", key, value, label)
 		}
 
 		if annotation != "" && annotation != value {
-			t.Errorf("Mismatch of %s label between built image and deployment config", key)
+			t.Errorf("Mismatch of %s annotation between built image and deployment config. Expected %s but found %s", key, value, annotation)
 		}
 	}
 

--- a/functest/build_test.go
+++ b/functest/build_test.go
@@ -257,9 +257,7 @@ func verifyImageAndConfigLabelsMatch(t *testing.T, appsodyApplication v1beta1.Ap
 	if err != nil {
 		t.Errorf("Error inspecting docker image: %s", err)
 	}
-
-	output = strings.ReplaceAll(output, "\n", "")
-	output = strings.ReplaceAll(output, "'", "")
+	output = strings.Trim(output, "\n'")
 
 	var imageLabels map[string]string
 	err = json.Unmarshal([]byte(output), &imageLabels)
@@ -279,6 +277,7 @@ func verifyImageAndConfigLabelsMatch(t *testing.T, appsodyApplication v1beta1.Ap
 			t.Errorf("Could not find label %s in deployment config", key)
 		}
 
+		t.Logf("Comparing %s with %s%s", value, label, annotation)
 		if label != "" && label != value {
 			t.Errorf("Mismatch of %s label between built image and deployment config", key)
 		}


### PR DESCRIPTION
We hit a weird situation where the local commit had a single quote in it, and this test was failing because it removed all the quotes. It should only remove the leading and trailing quotes.