### PR TITLE
Fix tests from panicing locally from log after test completed

### DIFF
--- a/functest/run_test.go
+++ b/functest/run_test.go
@@ -48,6 +48,7 @@ func TestRun(t *testing.T) {
 	go func() {
 		_, err = cmdtest.RunAppsody(sandbox, "run")
 		runChannel <- err
+		close(runChannel)
 	}()
 
 	// defer the appsody stop to close the docker container
@@ -55,6 +56,11 @@ func TestRun(t *testing.T) {
 		_, err = cmdtest.RunAppsody(sandbox, "stop")
 		if err != nil {
 			t.Logf("Ignoring error running appsody stop: %s", err)
+		}
+		// wait for the appsody command/goroutine to finish
+		runErr := <-runChannel
+		if runErr != nil {
+			t.Logf("Ignoring error from the appsody command: %s", runErr)
 		}
 	}()
 
@@ -132,6 +138,20 @@ func TestRunSimple(t *testing.T) {
 		go func() {
 			_, err = cmdtest.RunAppsody(sandbox, "run", "--name", containerName)
 			runChannel <- err
+			close(runChannel)
+		}()
+
+		// defer the appsody stop to close the docker container
+		defer func() {
+			_, err = cmdtest.RunAppsody(sandbox, "stop", "--name", containerName)
+			if err != nil {
+				t.Logf("Ignoring error running appsody stop: %s", err)
+			}
+			// wait for the appsody command/goroutine to finish
+			runErr := <-runChannel
+			if runErr != nil {
+				t.Logf("Ignoring error from the appsody command: %s", runErr)
+			}
 		}()
 
 		// It will take a while for the container to spin up, so let's use docker ps to wait for it
@@ -159,10 +179,5 @@ func TestRunSimple(t *testing.T) {
 			t.Fatal("container never appeared to start")
 		}
 
-		// stop and clean up after the run
-		_, err = cmdtest.RunAppsody(sandbox, "stop", "--name", containerName)
-		if err != nil {
-			t.Logf("Ignoring error running appsody stop: %s", err)
-		}
 	}
 }

--- a/functest/stop_test.go
+++ b/functest/stop_test.go
@@ -45,6 +45,7 @@ func TestStopWithoutName(t *testing.T) {
 	go func() {
 		_, err = cmdtest.RunAppsody(sandbox, "run")
 		runChannel <- err
+		close(runChannel)
 	}()
 
 	// defer the appsody stop to close the docker container
@@ -72,6 +73,12 @@ func TestStopWithoutName(t *testing.T) {
 		if dockerOutput != "" {
 			t.Fatal("docker container " + containerName + " was found and should have been stopped")
 
+		}
+
+		// wait for the appsody command/goroutine to finish
+		runErr := <-runChannel
+		if runErr != nil {
+			t.Logf("Ignoring error from the appsody command: %s", runErr)
 		}
 
 	}()
@@ -127,6 +134,7 @@ func TestStopWithName(t *testing.T) {
 	go func() {
 		_, err = cmdtest.RunAppsodyCmd([]string{"run", "--name", "testStopContainer"}, projectDir, t)
 		runChannel <- err
+		close(runChannel)
 	}()
 
 	// defer the appsody stop to close the docker container
@@ -150,6 +158,12 @@ func TestStopWithName(t *testing.T) {
 		if dockerOutput != "" {
 			t.Fatal("docker container testStopContainer was found and should have been stopped")
 
+		}
+
+		// wait for the appsody command/goroutine to finish
+		runErr := <-runChannel
+		if runErr != nil {
+			t.Logf("Ignoring error from the appsody command: %s", runErr)
 		}
 
 	}()

--- a/functest/test_test.go
+++ b/functest/test_test.go
@@ -65,6 +65,20 @@ func TestTestSimple(t *testing.T) {
 			log.Println("Running appsody test...")
 			_, err = cmdtest.RunAppsody(sandbox, "test")
 			runChannel <- err
+			close(runChannel)
+		}()
+
+		// defer the appsody stop to close the docker container
+		defer func() {
+			_, err = cmdtest.RunAppsody(sandbox, "stop")
+			if err != nil {
+				t.Logf("Ignoring error running appsody stop: %s", err)
+			}
+			// wait for the appsody command/goroutine to finish
+			runErr := <-runChannel
+			if runErr != nil {
+				t.Logf("Ignoring error from the appsody command: %s", runErr)
+			}
 		}()
 
 		waitForError := 20 // in seconds


### PR DESCRIPTION
Another strange error we were hitting running the tests locally:
`panic: Log in goroutine after TestRun has completed`
It turns out that the goroutine calling appsody wasn't finished and continued to log messages with t.Log() after the tests had been completed. The go test framework panics when this happens.

This seems to only happen when running the tests individually, not as the whole test bucket, but I'm guessing that was just lucky timing. I've fixed the problem by waiting for data on the goroutine channel before finishing the test.