### PR TITLE
fix buildah missing options

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -194,7 +194,7 @@ func build(config *buildCommandConfig) error {
 		return execError
 	}
 	if config.pushURL != "" || config.push {
-		err := ImagePush(config.LoggingConfig, buildImage, config.Buildah, config.Dryrun)
+		err := ImagePush(config.LoggingConfig, buildImage, config.Buildah, config.buildahBuildOptions, config.Dryrun)
 		if err != nil {
 			return errors.Errorf("Could not push the docker image - exiting. Error: %v", err)
 		}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1300,14 +1300,15 @@ func DockerTag(log *LoggingConfig, imageToTag string, tag string, dryrun bool) e
 }
 
 //ImagePush pushes a docker image to a docker registry (assumes that the user has done docker login)
-func ImagePush(log *LoggingConfig, imageToPush string, buildah bool, dryrun bool) error {
+func ImagePush(log *LoggingConfig, imageToPush string, buildah bool, pushArgs string, dryrun bool) error {
 	log.Info.log("Pushing image ", imageToPush)
 	cmdName := "docker"
 	if buildah {
 		cmdName = "buildah"
 	}
 
-	cmdArgs := []string{"push", imageToPush}
+	//the order matters especially with buildah
+	cmdArgs := []string{"push", pushArgs, imageToPush}
 	if dryrun {
 		log.Info.log("Dry run - skipping execution of: ", cmdName, " ", strings.Join(cmdArgs, " "))
 		return nil


### PR DESCRIPTION
This is a fix for #729.

In `appsody build` command like:

```sh
$ appsody build -v --buildah -t "spring-boot-demo:docker" --buildah-options "--tls-verify=false" --push-url docker://registry:5000
```

The `buildah` options `"--tls-verify=false"` would be missing because of the bug.
