### PR TITLE
Change templating delimiters to use {{.stack}}

### DIFF
--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -223,7 +223,7 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 
 			// tag with the full version then mojorminor, major, and latest
 			cmdArgs := []string{"-t", buildImage}
-			var semver = make(map[string]string)
+			semver := templateMetadata["semver"].(map[string]string)
 			cmdArgs = append(cmdArgs, "-t", namespaceAndRepo+":"+semver["majorminor"])
 			cmdArgs = append(cmdArgs, "-t", namespaceAndRepo+":"+semver["major"])
 			cmdArgs = append(cmdArgs, "-t", namespaceAndRepo)

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -223,7 +223,7 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 
 			// tag with the full version then mojorminor, major, and latest
 			cmdArgs := []string{"-t", buildImage}
-			semver := make(map[string]interface{})["semver"].(map[string]string)
+			var semver = make(map[string]string)
 			cmdArgs = append(cmdArgs, "-t", namespaceAndRepo+":"+semver["majorminor"])
 			cmdArgs = append(cmdArgs, "-t", namespaceAndRepo+":"+semver["major"])
 			cmdArgs = append(cmdArgs, "-t", namespaceAndRepo)

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -223,7 +223,7 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 
 			// tag with the full version then mojorminor, major, and latest
 			cmdArgs := []string{"-t", buildImage}
-			semver := templateMetadata["stack"].(map[string]interface{})["semver"].(map[string]string)
+			semver := make(map[string]interface{})["semver"].(map[string]string)
 			cmdArgs = append(cmdArgs, "-t", namespaceAndRepo+":"+semver["majorminor"])
 			cmdArgs = append(cmdArgs, "-t", namespaceAndRepo+":"+semver["major"])
 			cmdArgs = append(cmdArgs, "-t", namespaceAndRepo)

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -506,14 +506,13 @@ func CreateTemplateMap(labels map[string]string, stackYaml StackYaml, imageNames
 	}
 
 	// create map that holds stack variables
-	var stack = make(map[string]interface{})
-	stack["id"] = labels[appsodyStackKeyPrefix+"id"]
-	stack["name"] = labels[ociKeyPrefix+"title"]
-	stack["version"] = versionLabel
-	stack["description"] = labels[ociKeyPrefix+"description"]
-	stack["created"] = labels[ociKeyPrefix+"created"]
-	stack["tag"] = labels[appsodyStackKeyPrefix+"tag"]
-	stack["maintainers"] = labels[ociKeyPrefix+"authors"]
+	templateMetadata["id"] = labels[appsodyStackKeyPrefix+"id"]
+	templateMetadata["name"] = labels[ociKeyPrefix+"title"]
+	templateMetadata["version"] = versionLabel
+	templateMetadata["description"] = labels[ociKeyPrefix+"description"]
+	templateMetadata["created"] = labels[ociKeyPrefix+"created"]
+	templateMetadata["tag"] = labels[appsodyStackKeyPrefix+"tag"]
+	templateMetadata["maintainers"] = labels[ociKeyPrefix+"authors"]
 
 	// create version map and add to templateMetadata map
 	var semver = make(map[string]string)
@@ -521,12 +520,12 @@ func CreateTemplateMap(labels map[string]string, stackYaml StackYaml, imageNames
 	semver["minor"] = versionFull[1]
 	semver["patch"] = versionFull[2]
 	semver["majorminor"] = strings.Join(versionFull[0:2], ".")
-	stack["semver"] = semver
+	templateMetadata["semver"] = semver
 
 	// create image map add to templateMetadata map
 	var image = make(map[string]string)
 	image["namespace"] = imageNamespace
-	stack["image"] = image
+	templateMetadata["image"] = image
 
 	// loop through user variables and add them to map, must begin with alphanumeric character
 	for key, value := range stackYaml.TemplatingData {
@@ -535,12 +534,11 @@ func CreateTemplateMap(labels map[string]string, stackYaml StackYaml, imageNames
 		runes := []rune(key)
 		firstRune := runes[0]
 		if unicode.IsLetter(firstRune) || unicode.IsNumber(firstRune) {
-			stack[key] = value
+			templateMetadata[key] = value
 		} else {
 			return templateMetadata, errors.Errorf("Variable name didn't start with alphanumeric character")
 		}
 	}
-	templateMetadata["stack"] = stack
 	return templateMetadata, err
 
 }

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -577,7 +577,7 @@ func ApplyTemplating(stackPath string, templateMetadata interface{}) error {
 			}
 
 			// create new template from parsing file
-			tmpl, err := template.New(file).ParseFiles(path)
+			tmpl, err := template.New(file).Delims("{{.stack", "}}").ParseFiles(path)
 			if err != nil {
 				return errors.Errorf("Error creating new template from file: %v", err)
 			}

--- a/cmd/stack_package_test.go
+++ b/cmd/stack_package_test.go
@@ -50,7 +50,7 @@ func TestTemplatingAllVariables(t *testing.T) {
 	defer os.RemoveAll(templatingPath)
 
 	// write some text to file
-	_, err = file.WriteString("id: {{.stack.id}}, name: {{.stack.name}}, version: {{.stack.version}}, description: {{.stack.description}}, tag: {{.stack.tag}}, maintainers: {{.stack.maintainers}}, semver.major: {{.stack.semver.major}}, semver.minor: {{.stack.semver.minor}}, semver.patch: {{.stack.semver.patch}}, semver.majorminor: {{.stack.semver.majorminor}}, image.namespace: {{.stack.image.namespace}}, customvariable1: {{.stack.variable1}}, customvariable2: {{.stack.variable2}}")
+	_, err = file.WriteString("id: {{.stack.id}}, name: {{.stack.name}}, version: {{.stack.version}}, description: {{.stack.description}}, tag: {{.stack.tag}}, maintainers: {{.stack.maintainers}}, semver.major: {{.stack.semver.major}}, semver.minor: {{.stack.semver.minor}}, semver.patch: {{.stack.semver.patch}}, semver.majorminor: {{.stack.semver.majorminor}}, image.namespace: {{.stack.image.namespace}}, image.registry: {{.stack.image.registry}}, customvariable1: {{.stack.variable1}}, customvariable2: {{.stack.variable2}}")
 	if err != nil {
 		t.Fatalf("Error writing to file: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestTemplatingAllVariables(t *testing.T) {
 	}
 	s := string(b)
 	t.Log(s)
-	if !strings.Contains(s, "id: starter, name: Starter Sample, version: 0.1.1, description: Runnable starter stack, copy to create a new stack, tag: appsody/starter:SNAPSHOT, maintainers: Henry Nash <henry.nash@uk.ibm.com>, semver.major: 0, semver.minor: 1, semver.patch: 1, semver.majorminor: 0.1, image.namespace: appsody, customvariable1: value1, customvariable2: value2") {
+	if !strings.Contains(s, "id: starter, name: Starter Sample, version: 0.1.1, description: Runnable starter stack, copy to create a new stack, tag: appsody/starter:SNAPSHOT, maintainers: Henry Nash <henry.nash@uk.ibm.com>, semver.major: 0, semver.minor: 1, semver.patch: 1, semver.majorminor: 0.1, image.namespace: appsody, image.registry: dev.local, customvariable1: value1, customvariable2: value2") {
 		t.Fatal("Templating text did not match expected values")
 	}
 

--- a/cmd/stack_package_test.go
+++ b/cmd/stack_package_test.go
@@ -50,7 +50,7 @@ func TestTemplatingAllVariables(t *testing.T) {
 	defer os.RemoveAll(templatingPath)
 
 	// write some text to file
-	_, err = file.WriteString("id: {{.stack.id}}, name: {{.stack.name}}, version: {{.stack.version}}, description: {{.stack.description}}, tag: {{.stack.tag}}, maintainers: {{.stack.maintainers}}, semver.major: {{.stack.semver.major}}, semver.minor: {{.stack.semver.minor}}, semver.patch: {{.stack.semver.patch}}, semver.majorminor: {{.stack.semver.majorminor}}, image.namespace: {{.stack.image.namespace}}, image.registry: {{.stack.image.registry}}, customvariable1: {{.stack.variable1}}, customvariable2: {{.stack.variable2}}")
+	_, err = file.WriteString("{{test}}, id: {{.stack.id}}, name: {{.stack.name}}, version: {{.stack.version}}, description: {{.stack.description}}, tag: {{.stack.tag}}, maintainers: {{.stack.maintainers}}, semver.major: {{.stack.semver.major}}, semver.minor: {{.stack.semver.minor}}, semver.patch: {{.stack.semver.patch}}, semver.majorminor: {{.stack.semver.majorminor}}, image.namespace: {{.stack.image.namespace}}, image.registry: {{.stack.image.registry}}, customvariable1: {{.stack.variable1}}, customvariable2: {{.stack.variable2}}")
 	if err != nil {
 		t.Fatalf("Error writing to file: %v", err)
 	}
@@ -80,7 +80,7 @@ func TestTemplatingAllVariables(t *testing.T) {
 	}
 	s := string(b)
 	t.Log(s)
-	if !strings.Contains(s, "id: starter, name: Starter Sample, version: 0.1.1, description: Runnable starter stack, copy to create a new stack, tag: appsody/starter:SNAPSHOT, maintainers: Henry Nash <henry.nash@uk.ibm.com>, semver.major: 0, semver.minor: 1, semver.patch: 1, semver.majorminor: 0.1, image.namespace: appsody, image.registry: dev.local, customvariable1: value1, customvariable2: value2") {
+	if !strings.Contains(s, "{{test}}, id: starter, name: Starter Sample, version: 0.1.1, description: Runnable starter stack, copy to create a new stack, tag: appsody/starter:SNAPSHOT, maintainers: Henry Nash <henry.nash@uk.ibm.com>, semver.major: 0, semver.minor: 1, semver.patch: 1, semver.majorminor: 0.1, image.namespace: appsody, image.registry: dev.local, customvariable1: value1, customvariable2: value2") {
 		t.Fatal("Templating text did not match expected values")
 	}
 


### PR DESCRIPTION
This is not a breaking change to existing stacks using templating.  This is a temporary solution due to many errors happening with the new templating feature.  This means that it will avoid code collisions from other templating libraries that use `{{` `}}` as delimiters, as the new delimiters are `{{.stack` `}}`.