### PR TITLE
Propagate stack package verbose option

### DIFF
--- a/cmd/stack_validate.go
+++ b/cmd/stack_validate.go
@@ -92,7 +92,7 @@ Runs the following validation tests against the stack and its templates:
 
 			// lint
 			if !noLint {
-				_, err = RunAppsodyCmdExec([]string{"stack", "lint"}, stackPath)
+				_, err = RunAppsodyCmdExec([]string{"stack", "lint"}, stackPath, rootConfig)
 				if err != nil {
 					//logs error but keeps going
 					rootConfig.Error.Log(err)
@@ -106,7 +106,8 @@ Runs the following validation tests against the stack and its templates:
 
 			// package
 			if !noPackage {
-				_, err = RunAppsodyCmdExec([]string{"stack", "package", "--image-namespace", imageNamespace, "--image-registry", imageRegistry}, stackPath)
+				_, err = RunAppsodyCmdExec([]string{"stack", "package", "--image-namespace", imageNamespace, "--image-registry", imageRegistry},
+					stackPath, rootConfig)
 				if err != nil {
 					//logs error but keeps going
 					rootConfig.Error.Log(err)
@@ -155,7 +156,7 @@ Runs the following validation tests against the stack and its templates:
 				stack := "dev.local/" + stackName
 
 				// init
-				err = TestInit(rootConfig.LoggingConfig, stack, templates[i], projectDir)
+				err = TestInit(rootConfig.LoggingConfig, stack, templates[i], projectDir, rootConfig)
 				if err != nil {
 					rootConfig.Error.Log(err)
 					testResults = append(testResults, ("FAILED: Init for stack:" + stackName + " template:" + templates[i]))
@@ -169,7 +170,7 @@ Runs the following validation tests against the stack and its templates:
 
 				// run
 				if !initFail {
-					err = TestRun(rootConfig.LoggingConfig, stack, templates[i], projectDir)
+					err = TestRun(rootConfig.LoggingConfig, stack, templates[i], projectDir, rootConfig)
 					if err != nil {
 						//logs error but keeps going
 						rootConfig.Error.Log(err)
@@ -183,7 +184,7 @@ Runs the following validation tests against the stack and its templates:
 
 				// test
 				if !initFail {
-					err = TestTest(rootConfig.LoggingConfig, stack, templates[i], projectDir)
+					err = TestTest(rootConfig.LoggingConfig, stack, templates[i], projectDir, rootConfig)
 					if err != nil {
 						//logs error but keeps going
 						rootConfig.Error.Log(err)
@@ -197,7 +198,7 @@ Runs the following validation tests against the stack and its templates:
 
 				// build
 				if !initFail {
-					err = TestBuild(rootConfig.LoggingConfig, stack, templates[i], projectDir)
+					err = TestBuild(rootConfig.LoggingConfig, stack, templates[i], projectDir, rootConfig)
 					if err != nil {
 						//logs error but keeps going
 						rootConfig.Error.Log(err)
@@ -242,17 +243,17 @@ Runs the following validation tests against the stack and its templates:
 }
 
 // Simple test for appsody init command
-func TestInit(log *LoggingConfig, stack string, template string, projectDir string) error {
+func TestInit(log *LoggingConfig, stack string, template string, projectDir string, rootConfig *RootCommandConfig) error {
 
 	log.Info.Log("**************************************************************************")
 	log.Info.Log("Running appsody init against stack:" + stack + " template:" + template)
 	log.Info.Log("**************************************************************************")
-	_, err := RunAppsodyCmdExec([]string{"init", stack, template}, projectDir)
+	_, err := RunAppsodyCmdExec([]string{"init", stack, template}, projectDir, rootConfig)
 	return err
 }
 
 // Simple test for appsody run command. A future enhancement would be to verify the image that gets built.
-func TestRun(log *LoggingConfig, stack string, template string, projectDir string) error {
+func TestRun(log *LoggingConfig, stack string, template string, projectDir string, rootConfig *RootCommandConfig) error {
 
 	runChannel := make(chan error)
 	containerName := "testRunContainer"
@@ -260,7 +261,7 @@ func TestRun(log *LoggingConfig, stack string, template string, projectDir strin
 		log.Info.Log("**************************************************************************")
 		log.Info.Log("Running appsody run against stack:" + stack + "template: " + template)
 		log.Info.Log("**************************************************************************")
-		_, err := RunAppsodyCmdExec([]string{"run", "--name", containerName}, projectDir)
+		_, err := RunAppsodyCmdExec([]string{"run", "--name", containerName}, projectDir, rootConfig)
 		runChannel <- err
 	}()
 
@@ -284,7 +285,7 @@ func TestRun(log *LoggingConfig, stack string, template string, projectDir strin
 			healthCheckWait += healthCheckFrequency
 
 			log.Info.Log("about to run appsody ps")
-			stopOutput, errStop := RunAppsodyCmdExec([]string{"ps"}, projectDir)
+			stopOutput, errStop := RunAppsodyCmdExec([]string{"ps"}, projectDir, rootConfig)
 			if !strings.Contains(stopOutput, "CONTAINER") {
 				log.Info.Log("appsody ps output doesn't contain header line")
 			}
@@ -309,7 +310,7 @@ func TestRun(log *LoggingConfig, stack string, template string, projectDir strin
 	log.Info.Log("Appsody run did not fail")
 
 	// stop and clean up after the run
-	_, err := RunAppsodyCmdExec([]string{"stop", "--name", "testRunContainer"}, projectDir)
+	_, err := RunAppsodyCmdExec([]string{"stop", "--name", "testRunContainer"}, projectDir, rootConfig)
 	if err != nil {
 		log.Error.Log("appsody stop failed")
 	}
@@ -318,24 +319,24 @@ func TestRun(log *LoggingConfig, stack string, template string, projectDir strin
 }
 
 // Simple test for appsody build command. A future enhancement would be to verify the image that gets built.
-func TestTest(log *LoggingConfig, stack string, template string, projectDir string) error {
+func TestTest(log *LoggingConfig, stack string, template string, projectDir string, rootConfig *RootCommandConfig) error {
 
 	log.Info.Log("**************************************************************************")
 	log.Info.Log("Running appsody test against stack:" + stack + " template:" + template)
 	log.Info.Log("**************************************************************************")
-	_, err := RunAppsodyCmdExec([]string{"test", "--no-watcher"}, projectDir)
+	_, err := RunAppsodyCmdExec([]string{"test", "--no-watcher"}, projectDir, rootConfig)
 	return err
 }
 
 // Simple test for appsody build command. A future enhancement would be to verify the image that gets built.
-func TestBuild(log *LoggingConfig, stack string, template string, projectDir string) error {
+func TestBuild(log *LoggingConfig, stack string, template string, projectDir string, rootConfig *RootCommandConfig) error {
 
 	imageName := "dev.local/appsody" + filepath.Base(projectDir)
 
 	log.Info.Log("**************************************************************************")
 	log.Info.Log("Running appsody build against stack:" + stack + " template:" + template)
 	log.Info.Log("**************************************************************************")
-	_, err := RunAppsodyCmdExec([]string{"build", "--tag", imageName}, projectDir)
+	_, err := RunAppsodyCmdExec([]string{"build", "--tag", imageName}, projectDir, rootConfig)
 	if err != nil {
 		log.Error.Log(err)
 		return err

--- a/cmd/stack_validate_utils.go
+++ b/cmd/stack_validate_utils.go
@@ -28,7 +28,7 @@ import (
 // The stdout and stderr are captured, printed, and returned
 // args will be passed to the appsody command
 // workingDir will be the directory the command runs in
-func RunAppsodyCmdExec(args []string, workingDir string) (string, error) {
+func RunAppsodyCmdExec(args []string, workingDir string, rootConfig *RootCommandConfig) (string, error) {
 	execDir, err := os.Getwd()
 	if err != nil {
 		return "", err
@@ -48,7 +48,10 @@ func RunAppsodyCmdExec(args []string, workingDir string) (string, error) {
 
 	executable, _ := os.Executable()
 
-	cmdArgs := []string{executable, "-v"}
+	cmdArgs := []string{executable}
+	if rootConfig.Verbose {
+		cmdArgs = append(cmdArgs, "-v")
+	}
 	cmdArgs = append(cmdArgs, args...)
 	fmt.Println(cmdArgs)
 


### PR DESCRIPTION
Propagate the verbose option through to appsody command execution during stack validate.

Fixes #814 