### PR TITLE
Changed templating-data in stack.yaml to be stack-variables

### DIFF
--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -38,7 +38,7 @@ type StackYaml struct {
 	Language        string `yaml:"language"`
 	Maintainers     []Maintainer
 	DefaultTemplate string            `yaml:"default-template"`
-	TemplatingData  map[string]string `yaml:"templating-data"`
+	StackVariables  map[string]string `yaml:"stack-variables"`
 	Requirements    StackRequirement  `yaml:"requirements,omitempty"`
 }
 type Maintainer struct {
@@ -516,7 +516,7 @@ func CreateTemplateMap(labels map[string]string, stackYaml StackYaml, imageNames
 	templateMetadata["image"] = image
 
 	// loop through user variables and add them to map, must begin with alphanumeric character
-	for key, value := range stackYaml.TemplatingData {
+	for key, value := range stackYaml.StackVariables {
 
 		// validates that key starts with alphanumeric character
 		runes := []rune(key)

--- a/cmd/stack_yaml_lint.go
+++ b/cmd/stack_yaml_lint.go
@@ -112,13 +112,13 @@ func (stackDetails *StackYaml) checkTemplatingData(log *LoggingConfig) (int, int
 	stackLintWarningCount := 0
 	keyRegex := regexp.MustCompile("^[a-zA-Z0-9]*$")
 
-	if len(stackDetails.TemplatingData) == 0 {
+	if len(stackDetails.StackVariables) == 0 {
 		log.Warning.log("No custom templating variables defined - You will not be able to reuse variables across the stack")
 		stackLintWarningCount++
 		return stackLintErrorCount, stackLintWarningCount
 	}
 
-	for key := range stackDetails.TemplatingData {
+	for key := range stackDetails.StackVariables {
 		checkKey := keyRegex.FindString(string(key))
 
 		if checkKey == "" {

--- a/cmd/testdata/starter/stack.yaml
+++ b/cmd/testdata/starter/stack.yaml
@@ -8,6 +8,6 @@ maintainers:
   email: henry.nash@uk.ibm.com
   github-id: henrynash
 default-template: simple
-templating-data:
+stack-variables:
   variable1: value1
   variable2: value2


### PR DESCRIPTION
Further reduction in references to the word templating as to avoid confusion over conflicting pre-existing name templates.  In the `stack.yaml` where a user declares their custom variables, it is now declared using `stack-variables` instead.  The website and stacks already using templating need to be updated accordingly.