### PR TITLE
Add a no-check flag to to suppress all-namespaces kubectl command

### DIFF
--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -204,7 +204,7 @@ Run this command from the root directory of your Appsody project.`,
 	deployCmd.PersistentFlags().BoolVar(&config.knative, "knative", false, "Deploy as a Knative Service")
 	deployCmd.PersistentFlags().StringVar(&config.pushURL, "push-url", "", "Remote repository to push image to.  This will also trigger a push if the --push flag is not specified.")
 	deployCmd.PersistentFlags().StringVar(&config.pullURL, "pull-url", "", "Remote repository to pull image from.")
-	deployCmd.PersistentFlags().BoolVar(&config.noOperatorCheck, "no-operator-check", false, "Suppresses check for operator existing in namespace")
+	deployCmd.PersistentFlags().BoolVar(&config.noOperatorCheck, "no-operator-check", false, "Do not check whether existing operators are already watching the namespace")
 	deployCmd.PersistentFlags().BoolVar(&config.noOperatorInstall, "no-operator-install", false, "Deploy your application without installing the Appsody operator")
 	deployCmd.AddCommand(newDeleteDeploymentCmd(config))
 

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -25,10 +25,10 @@ import (
 
 type deployCommandConfig struct {
 	*RootCommandConfig
-	appDeployFile, namespace, tag, pushURL, pullURL string
-	knative, generate, force, push, nobuild         bool
-	dockerBuildOptions                              string
-	buildahBuildOptions                             string
+	appDeployFile, namespace, tag, pushURL, pullURL  string
+	knative, generate, force, push, nobuild, nocheck bool
+	dockerBuildOptions                               string
+	buildahBuildOptions                              string
 }
 
 func findNamespaceRepositoryAndTag(image string) string {
@@ -97,7 +97,7 @@ The command performs the following steps:
 			}
 
 			// Check for the Appsody Operator
-			operatorExists, existingNamespace, operatorExistsErr := operatorExistsWithWatchspace(config.LoggingConfig, namespace, config.Dryrun)
+			operatorExists, existingNamespace, operatorExistsErr := operatorExistsWithWatchspace(config.LoggingConfig, namespace, config.Dryrun, config.nocheck)
 			if operatorExistsErr != nil {
 				return operatorExistsErr
 			}
@@ -162,6 +162,7 @@ The command performs the following steps:
 	deployCmd.PersistentFlags().BoolVar(&config.knative, "knative", false, "Deploy as a Knative Service")
 	deployCmd.PersistentFlags().StringVar(&config.pushURL, "push-url", "", "Remote repository to push image to.  This will also trigger a push if the --push flag is not specified.")
 	deployCmd.PersistentFlags().StringVar(&config.pullURL, "pull-url", "", "Remote repository to pull image from.")
+	deployCmd.PersistentFlags().BoolVar(&config.nocheck, "no-check", false, "Suppresses check for operator existing in namespace")
 	deployCmd.AddCommand(newDeleteDeploymentCmd(config))
 
 	return deployCmd

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -25,10 +25,10 @@ import (
 
 type deployCommandConfig struct {
 	*RootCommandConfig
-	appDeployFile, namespace, tag, pushURL, pullURL  string
-	knative, generate, force, push, nobuild, nocheck bool
-	dockerBuildOptions                               string
-	buildahBuildOptions                              string
+	appDeployFile, namespace, tag, pushURL, pullURL                             string
+	knative, generate, force, push, nobuild, noOperatorCheck, noOperatorInstall bool
+	dockerBuildOptions                                                          string
+	buildahBuildOptions                                                         string
 }
 
 func findNamespaceRepositoryAndTag(image string) string {
@@ -96,27 +96,29 @@ The command performs the following steps:
 				return nil
 			}
 
-			// Check for the Appsody Operator
-			operatorExists, existingNamespace, operatorExistsErr := operatorExistsWithWatchspace(config.LoggingConfig, namespace, config.Dryrun, config.nocheck)
-			if operatorExistsErr != nil {
-				return operatorExistsErr
-			}
-
-			//kargs := []string{"service/appsody-operator"}
-			//_, err := KubeGet(kargs)
-			// Performing the kubectl apply
-			if !operatorExists {
-				config.Debug.logf("Failed to find Appsody operator that watches namespace %s. Attempting to install...", namespace)
-				operatorConfig := &operatorCommandConfig{config.RootCommandConfig, namespace}
-				operatorInstallConfig := &operatorInstallCommandConfig{operatorCommandConfig: operatorConfig}
-				//	operatorInstallConfig.RootCommandConfig = operatorConfig.RootCommandConfig
-				err := operatorInstall(operatorInstallConfig)
-				if err != nil {
-					return errors.Errorf("Failed to install an Appsody operator in namespace %s watching namespace %s. Error was: %v", namespace, namespace, err)
+			if !config.noOperatorInstall {
+				// Check for the Appsody Operator
+				operatorExists, existingNamespace, operatorExistsErr := operatorExistsWithWatchspace(config.LoggingConfig, namespace, config.Dryrun, config.noOperatorCheck)
+				if operatorExistsErr != nil {
+					return operatorExistsErr
 				}
-			} else {
-				config.Debug.logf("Operator exists in %s, watching %s ", existingNamespace, namespace)
 
+				//kargs := []string{"service/appsody-operator"}
+				//_, err := KubeGet(kargs)
+				// Performing the kubectl apply
+				if !operatorExists {
+					config.Debug.logf("Failed to find Appsody operator that watches namespace %s. Attempting to install...", namespace)
+					operatorConfig := &operatorCommandConfig{config.RootCommandConfig, namespace}
+					operatorInstallConfig := &operatorInstallCommandConfig{operatorCommandConfig: operatorConfig}
+					//	operatorInstallConfig.RootCommandConfig = operatorConfig.RootCommandConfig
+					err := operatorInstall(operatorInstallConfig)
+					if err != nil {
+						return errors.Errorf("Failed to install an Appsody operator in namespace %s watching namespace %s. Error was: %v", namespace, namespace, err)
+					}
+				} else {
+					config.Debug.logf("Operator exists in %s, watching %s ", existingNamespace, namespace)
+
+				}
 			}
 
 			// Performing the kubectl apply
@@ -162,7 +164,8 @@ The command performs the following steps:
 	deployCmd.PersistentFlags().BoolVar(&config.knative, "knative", false, "Deploy as a Knative Service")
 	deployCmd.PersistentFlags().StringVar(&config.pushURL, "push-url", "", "Remote repository to push image to.  This will also trigger a push if the --push flag is not specified.")
 	deployCmd.PersistentFlags().StringVar(&config.pullURL, "pull-url", "", "Remote repository to pull image from.")
-	deployCmd.PersistentFlags().BoolVar(&config.nocheck, "no-check", false, "Suppresses check for operator existing in namespace")
+	deployCmd.PersistentFlags().BoolVar(&config.noOperatorCheck, "no-operator-check", false, "Suppresses check for operator existing in namespace")
+	deployCmd.PersistentFlags().BoolVar(&config.noOperatorInstall, "no-operator-install", false, "Deploy your application without installing the Appsody operator")
 	deployCmd.AddCommand(newDeleteDeploymentCmd(config))
 
 	return deployCmd

--- a/cmd/operator_install.go
+++ b/cmd/operator_install.go
@@ -83,6 +83,9 @@ func operatorInstall(config *operatorInstallCommandConfig) error {
 		if existingOperatorWatchspace == "" {
 			existingOperatorWatchspace = "all namespaces"
 		}
+		if existingOperatorWatchspace != operatorNamespace {
+			return errors.Errorf("An Appsody operator already exists in namespace %s but is watching another namespace: %s. Contact your cluster administrator for more details.", operatorNamespace, existingOperatorWatchspace)
+		}
 		return errors.Errorf("An operator already exists in namespace %s and it is watching the %s namespace.", operatorNamespace, existingOperatorWatchspace)
 	}
 

--- a/cmd/operator_install.go
+++ b/cmd/operator_install.go
@@ -24,8 +24,8 @@ import (
 
 type operatorInstallCommandConfig struct {
 	*operatorCommandConfig
-	all        bool
-	watchspace string
+	all, nocheck bool
+	watchspace   string
 }
 
 func newOperatorInstallCmd(operatorConfig *operatorCommandConfig) *cobra.Command {
@@ -48,6 +48,7 @@ By default, the operator watches a single namespace. You can specify the ‘--wa
 
 	installCmd.PersistentFlags().StringVarP(&config.watchspace, "watchspace", "w", "", "The namespace that the operator watches.")
 	installCmd.PersistentFlags().BoolVar(&config.all, "watch-all", false, "Specifies that the operator watches all namespaces.")
+	installCmd.PersistentFlags().BoolVar(&config.nocheck, "no-check", false, "Suppresses check for operator existing in namespace")
 	return installCmd
 }
 
@@ -85,7 +86,7 @@ func operatorInstall(config *operatorInstallCommandConfig) error {
 		return errors.Errorf("An operator already exists in namespace %s and it is watching the %s namespace.", operatorNamespace, existingOperatorWatchspace)
 	}
 
-	watchExists, existingNamespace, watchExistsErr := operatorExistsWithWatchspace(config.LoggingConfig, watchNamespace, config.Dryrun)
+	watchExists, existingNamespace, watchExistsErr := operatorExistsWithWatchspace(config.LoggingConfig, watchNamespace, config.Dryrun, config.nocheck)
 	if watchExistsErr != nil {
 
 		return watchExistsErr

--- a/cmd/operator_install.go
+++ b/cmd/operator_install.go
@@ -94,7 +94,7 @@ func operatorInstall(config *operatorInstallCommandConfig) error {
 			}
 		}
 
-		if match == false {
+		if !match {
 			return errors.Errorf("An Appsody operator already exists in namespace %s but is watching another namespace: %s. Contact your cluster administrator for more details.", operatorNamespace, existingOperatorWatchspace)
 		}
 		return errors.Errorf("An operator already exists in namespace %s and it is watching the %s namespace.", operatorNamespace, existingOperatorWatchspace)

--- a/cmd/operator_install.go
+++ b/cmd/operator_install.go
@@ -83,11 +83,16 @@ func operatorInstall(config *operatorInstallCommandConfig) error {
 		if existingOperatorWatchspace == "" {
 			existingOperatorWatchspace = "all namespaces"
 		}
+		match := false
 		watchSpaces := getWatchSpaces(existingOperatorWatchspace, config.Dryrun)
 		for _, existingWatchspace := range watchSpaces {
-			if existingWatchspace != operatorNamespace {
-				return errors.Errorf("An Appsody operator already exists in namespace %s but is watching another namespace: %s. Contact your cluster administrator for more details.", operatorNamespace, existingOperatorWatchspace)
+			if existingWatchspace == operatorNamespace {
+				match = true
 			}
+		}
+
+		if match == false {
+			return errors.Errorf("An Appsody operator already exists in namespace %s but is watching another namespace: %s. Contact your cluster administrator for more details.", operatorNamespace, existingOperatorWatchspace)
 		}
 		return errors.Errorf("An operator already exists in namespace %s and it is watching the %s namespace.", operatorNamespace, existingOperatorWatchspace)
 	}

--- a/cmd/operator_install.go
+++ b/cmd/operator_install.go
@@ -83,8 +83,11 @@ func operatorInstall(config *operatorInstallCommandConfig) error {
 		if existingOperatorWatchspace == "" {
 			existingOperatorWatchspace = "all namespaces"
 		}
-		if existingOperatorWatchspace != operatorNamespace {
-			return errors.Errorf("An Appsody operator already exists in namespace %s but is watching another namespace: %s. Contact your cluster administrator for more details.", operatorNamespace, existingOperatorWatchspace)
+		watchSpaces := getWatchSpaces(existingOperatorWatchspace, config.Dryrun)
+		for _, existingWatchspace := range watchSpaces {
+			if existingWatchspace != operatorNamespace {
+				return errors.Errorf("An Appsody operator already exists in namespace %s but is watching another namespace: %s. Contact your cluster administrator for more details.", operatorNamespace, existingOperatorWatchspace)
+			}
 		}
 		return errors.Errorf("An operator already exists in namespace %s and it is watching the %s namespace.", operatorNamespace, existingOperatorWatchspace)
 	}

--- a/cmd/operator_install.go
+++ b/cmd/operator_install.go
@@ -24,8 +24,8 @@ import (
 
 type operatorInstallCommandConfig struct {
 	*operatorCommandConfig
-	all, nocheck bool
-	watchspace   string
+	all, noOperatorCheck bool
+	watchspace           string
 }
 
 func newOperatorInstallCmd(operatorConfig *operatorCommandConfig) *cobra.Command {
@@ -48,7 +48,7 @@ By default, the operator watches a single namespace. You can specify the ‘--wa
 
 	installCmd.PersistentFlags().StringVarP(&config.watchspace, "watchspace", "w", "", "The namespace that the operator watches.")
 	installCmd.PersistentFlags().BoolVar(&config.all, "watch-all", false, "Specifies that the operator watches all namespaces.")
-	installCmd.PersistentFlags().BoolVar(&config.nocheck, "no-check", false, "Suppresses check for operator existing in namespace")
+	installCmd.PersistentFlags().BoolVar(&config.noOperatorCheck, "no-operator-check", false, "Suppresses check for operator existing in namespace")
 	return installCmd
 }
 
@@ -86,7 +86,7 @@ func operatorInstall(config *operatorInstallCommandConfig) error {
 		return errors.Errorf("An operator already exists in namespace %s and it is watching the %s namespace.", operatorNamespace, existingOperatorWatchspace)
 	}
 
-	watchExists, existingNamespace, watchExistsErr := operatorExistsWithWatchspace(config.LoggingConfig, watchNamespace, config.Dryrun, config.nocheck)
+	watchExists, existingNamespace, watchExistsErr := operatorExistsWithWatchspace(config.LoggingConfig, watchNamespace, config.Dryrun, config.noOperatorCheck)
 	if watchExistsErr != nil {
 
 		return watchExistsErr

--- a/cmd/operator_utils.go
+++ b/cmd/operator_utils.go
@@ -148,9 +148,14 @@ func operatorExistsInNamespace(log *LoggingConfig, operatorNamespace string, dry
 }
 
 // Check to see if any other operator is watching the watchNameSpace
-func operatorExistsWithWatchspace(log *LoggingConfig, watchNamespace string, dryrun bool) (bool, string, error) {
+func operatorExistsWithWatchspace(log *LoggingConfig, watchNamespace string, dryrun bool, noCheck bool) (bool, string, error) {
 	log.Debug.log("Looking for an operator matching watchspace: ", watchNamespace)
-	var namespacesWithOperatorsGetArgs = []string{"pods", "-o=jsonpath='{.items[?(@.metadata.labels.name==\"appsody-operator\")].metadata.namespace}'", "--all-namespaces"}
+	var namespacesWithOperatorsGetArgs []string
+	if noCheck {
+		namespacesWithOperatorsGetArgs = []string{"pods", "-o=jsonpath='{.items[?(@.metadata.labels.name==\"appsody-operator\")].metadata.namespace}'", "-n", watchNamespace}
+	} else {
+		namespacesWithOperatorsGetArgs = []string{"pods", "-o=jsonpath='{.items[?(@.metadata.labels.name==\"appsody-operator\")].metadata.namespace}'", "--all-namespaces"}
+	}
 	getNamespacesOutput, getNamespacesErr := RunKubeGet(log, namespacesWithOperatorsGetArgs, dryrun)
 
 	if getNamespacesErr != nil {

--- a/cmd/operator_utils.go
+++ b/cmd/operator_utils.go
@@ -148,10 +148,10 @@ func operatorExistsInNamespace(log *LoggingConfig, operatorNamespace string, dry
 }
 
 // Check to see if any other operator is watching the watchNameSpace
-func operatorExistsWithWatchspace(log *LoggingConfig, watchNamespace string, dryrun bool, noCheck bool) (bool, string, error) {
+func operatorExistsWithWatchspace(log *LoggingConfig, watchNamespace string, dryrun bool, noOperatorCheck bool) (bool, string, error) {
 	log.Debug.log("Looking for an operator matching watchspace: ", watchNamespace)
 	var namespacesWithOperatorsGetArgs []string
-	if noCheck {
+	if noOperatorCheck {
 		namespacesWithOperatorsGetArgs = []string{"pods", "-o=jsonpath='{.items[?(@.metadata.labels.name==\"appsody-operator\")].metadata.namespace}'", "-n", watchNamespace}
 	} else {
 		namespacesWithOperatorsGetArgs = []string{"pods", "-o=jsonpath='{.items[?(@.metadata.labels.name==\"appsody-operator\")].metadata.namespace}'", "--all-namespaces"}
@@ -159,7 +159,7 @@ func operatorExistsWithWatchspace(log *LoggingConfig, watchNamespace string, dry
 	getNamespacesOutput, getNamespacesErr := RunKubeGet(log, namespacesWithOperatorsGetArgs, dryrun)
 
 	if getNamespacesErr != nil {
-		return false, "", getNamespacesErr
+		return false, "", errors.Errorf("Unable to query namespaces. Please check with your cluster administrator if an operator is already watching the target namespace. If so, please use the --no-operator-install flag. Otherwise, try the --no-operator-check flag. %v", getNamespacesErr)
 	}
 	getNamespacesOutput = strings.Trim(getNamespacesOutput, "'’\n")
 

--- a/functest/deploy_test.go
+++ b/functest/deploy_test.go
@@ -210,3 +210,33 @@ func TestDeployDeleteKubeFail(t *testing.T) {
 		t.Error("Deploy delete did not fail as expected")
 	}
 }
+
+func TestNoCheckFlag(t *testing.T) {
+	if !cmdtest.TravisTesting {
+		t.Skip()
+	}
+
+	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
+	defer cleanup()
+
+	_, err := cmdtest.AddLocalRepo(sandbox, "LocalTestRepo", filepath.Join(cmdtest.TestDirPath, "index.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Running appsody init...")
+	_, err = cmdtest.RunAppsody(sandbox, "init", "nodejs-express")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Log("Running appsody deploy...")
+	output, err := cmdtest.RunAppsody(sandbox, "deploy", "-t", "testdeploy/testimage", "--dryrun", "--no-check")
+	if err != nil {
+		t.Log("WARNING: deploy dryrun failed.")
+	}
+
+	if !strings.Contains(output, "kubectl get pods -o=jsonpath='{.items[?(@.metadata.labels.name==\"appsody-operator\")].metadata.namespace}' -n") {
+		t.Fatal(err, ": Expected kubectl get pods to run only against the targeted namespace rather than all namespaces.")
+	}
+}


### PR DESCRIPTION
Fixes: https://github.com/appsody/appsody/issues/813

Adds a new flag, `no-check` to `appsody deploy` and `appsody operator install` to suppress `kubectl get pods --all-namespaces` when checking if an operator already exists in the namespace.

Instead only the namespace specified will be queried (In case permission issues occur with `all-namespaces` mentioned in the issue above)

- Opening as draft so that I can write tests