### PR TITLE
cli commands will fail if extra arguments are given

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -79,13 +79,18 @@ func newBuildCmd(rootConfig *RootCommandConfig) *cobra.Command {
 
 By default, the built image is tagged with the project name that you specified when you initialised your Appsody project. If you did not specify a name, the image is tagged with the name of the root directory of your Appsody project.
 
-If you want to push the built image to an image repository using the [--push] options, you must specify the relevant image tag.`,
+If you want to push the built image to an image repository using the [--push] options, you must specify the relevant image tag.
+
+Run this command from the root directory of your Appsody project.`,
 		Example: `  appsody build -t my-repo/nodejs-express --push
   Builds the container image, tags it with my-repo/nodejs-express, and pushes it to the container registry the Docker CLI is currently logged into.
 
   appsody build -t my-repo/nodejs-express:0.1 --push-url my-registry-url
   Builds the container image, tags it with my-repo/nodejs-express, and pushes it to my-registry-url/my-repo/nodejs-express:0.1.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 
 			projectDir, err := getProjectDir(config.RootCommandConfig)
 			if err != nil {

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -89,7 +89,7 @@ Run this command from the root directory of your Appsody project.`,
   Builds the container image, tags it with my-repo/nodejs-express, and pushes it to my-registry-url/my-repo/nodejs-express:0.1.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 
 			projectDir, err := getProjectDir(config.RootCommandConfig)

--- a/cmd/build_delete.go
+++ b/cmd/build_delete.go
@@ -34,7 +34,7 @@ func newBuildDeleteCmd(config *buildCommandConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			projectName, perr := getProjectName(config.RootCommandConfig)
 			if perr != nil {

--- a/cmd/build_delete.go
+++ b/cmd/build_delete.go
@@ -33,6 +33,9 @@ func newBuildDeleteCmd(config *buildCommandConfig) *cobra.Command {
 		Long:   `This allows you to delete a Githook for your Appsody project.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			projectName, perr := getProjectName(config.RootCommandConfig)
 			if perr != nil {
 				return errors.Errorf("%v", perr)

--- a/cmd/build_setup.go
+++ b/cmd/build_setup.go
@@ -27,7 +27,7 @@ import (
 func newSetupCmd(config *buildCommandConfig) *cobra.Command {
 	// setupCmd allows you to setup a GitHook to drive a Tekton build pipeline for the Appsodys project in Git
 	var setupCmd = &cobra.Command{
-		Use: "setup",
+		Use: "setup <url",
 		// disable this command until we have a better plan on how to support ci pipelines
 		Hidden: true,
 		Short:  "Setup a Githook and build pipeline for your Appsody project",
@@ -38,7 +38,9 @@ func newSetupCmd(config *buildCommandConfig) *cobra.Command {
 			// TODO: add validation of the supplied Git URL
 			if len(args) < 1 {
 				return errors.New("error, you must specify a Git project URL")
-
+			}
+			if len(args) > 1 {
+				return errors.New("Expected only one argument: <Git project URL>.")
 			}
 			gitProject := args[0]
 

--- a/cmd/build_setup.go
+++ b/cmd/build_setup.go
@@ -40,7 +40,7 @@ func newSetupCmd(config *buildCommandConfig) *cobra.Command {
 				return errors.New("error, you must specify a Git project URL")
 			}
 			if len(args) > 1 {
-				return errors.New("Expected only one argument: <Git project URL>.")
+				return errors.New("expected only one argument: <Git project URL>")
 			}
 			gitProject := args[0]
 

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -43,7 +43,7 @@ func newCompletionCmd(log *LoggingConfig, rootCmd *cobra.Command) *cobra.Command
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			buf := new(bytes.Buffer)
 

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -15,6 +15,7 @@ package cmd
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -39,7 +40,11 @@ func newCompletionCmd(log *LoggingConfig, rootCmd *cobra.Command) *cobra.Command
 	3. Make sure to copy the appsody completion file generated above into the appropriate directory for your Linux distribution e.g.
 	appsody completion >  /etc/bash_completion.d/appsody`,
 
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			buf := new(bytes.Buffer)
 
 			log.Debug.log("Running bash completion script")
@@ -65,7 +70,7 @@ func newCompletionCmd(log *LoggingConfig, rootCmd *cobra.Command) *cobra.Command
 				spaceTab + spaceTab + "j=i+1\n" + "thecmd=${arr[i]}/${arr[j]}\n" + "commands+=(\"${thecmd}\")\n" + spaceTab + "done\n"
 
 			fmt.Println(header + afterAppsodyDevInit[0] + "_appsody_init()\n" + strings.Replace(afterAppsodyDevInit[1], "flags=()", extra, 1))
-
+			return nil
 		},
 	}
 

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -13,7 +13,10 @@
 // limitations under the License.
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"errors"
+	"github.com/spf13/cobra"
+)
 
 func newDebugCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	config := &devCommonConfig{RootCommandConfig: rootConfig}
@@ -21,7 +24,9 @@ func newDebugCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	var debugCmd = &cobra.Command{
 		Use:   "debug",
 		Short: "Debug your Appsody project.",
-		Long:  `Start a container-based continuous build environment for your Appsody project, with debugging enabled.`,
+		Long: `Start a container-based continuous build environment for your Appsody project, with debugging enabled.
+		
+Run this command from the root directory of your Appsody project.`,
 		Example: `  appsody debug --docker-options "--privileged"
   Starts the debugging environment, passing the "--privileged" option to the "docker run" command as a flag.
   
@@ -29,6 +34,9 @@ func newDebugCmd(rootConfig *RootCommandConfig) *cobra.Command {
   Starts the debugging environment, names the development container "my-project-dev2", and binds the container port 3000 to the host port 3001.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			config.Info.log("Running debug environment")
 			return commonCmd(config, "debug")
 		},

--- a/cmd/debug.go
+++ b/cmd/debug.go
@@ -35,7 +35,7 @@ Run this command from the root directory of your Appsody project.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			config.Info.log("Running debug environment")
 			return commonCmd(config, "debug")

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -67,7 +67,7 @@ Run this command from the root directory of your Appsody project.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			projectDir, err := getProjectDir(config.RootCommandConfig)
 			if err != nil {

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -56,7 +56,9 @@ The command performs the following steps:
 
 1. Runs the appsody build command to build the container image for deployment.
 2. Generates a deployment manifest file, "app-deploy.yaml", if one is not present, then applies it to your Kubernetes cluster.
-3. Deploys your image to your Kubernetes cluster via the Appsody operator, or as a Knative service if you specify the "--knative" flag. If an Appsody operator cannot be found, one will be installed on your cluster.`,
+3. Deploys your image to your Kubernetes cluster via the Appsody operator, or as a Knative service if you specify the "--knative" flag. If an Appsody operator cannot be found, one will be installed on your cluster.
+
+Run this command from the root directory of your Appsody project.`,
 		Example: `  appsody deploy --namespace my-namespace
   Builds and deploys your project to the "my-namespace" namespace in your local Kubernetes cluster.
   
@@ -64,6 +66,9 @@ The command performs the following steps:
   Builds and tags the image as "my-repo/nodejs-express", pushes the image to "external-registry-url/my-repo/nodejs-express", and creates a deployment manifest that tells the Kubernetes cluster to pull the image from "internal-registry-url/my-repo/nodejs-express".`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			projectDir, err := getProjectDir(config.RootCommandConfig)
 			if err != nil {
 				return err

--- a/cmd/deploy_delete.go
+++ b/cmd/deploy_delete.go
@@ -37,7 +37,7 @@ Run this command from the root directory of your Appsody project.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			exists, err := Exists(deployConfigFile)
 			if err != nil {

--- a/cmd/deploy_delete.go
+++ b/cmd/deploy_delete.go
@@ -36,6 +36,9 @@ Run this command from the root directory of your Appsody project.`,
   Deletes the AppsodyApplication from the "my-namespace" namespace, using the name and type specified in the "app-deploy.yaml" deployment manifest.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			exists, err := Exists(deployConfigFile)
 			if err != nil {
 				return errors.Errorf("Error checking status of %s", deployConfigFile)

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -47,7 +47,7 @@ Run this command from the root directory of your Appsody project.`,
   Extracts your project from the container to the local '$HOME/my-extract/directory' on your system.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			return extract(config)
 		},

--- a/cmd/extract.go
+++ b/cmd/extract.go
@@ -40,10 +40,15 @@ func newExtractCmd(rootConfig *RootCommandConfig) *cobra.Command {
 		Short: "Extract your Appsody project to a local directory.",
 		Long: `Extract the full application (the stack and your Appsody project) into a local directory.
 		
-Your project is extracted into your local '$HOME/.appsody/extract' directory, unless you use the --target-dir flag to specify a different location`,
+Your project is extracted into your local '$HOME/.appsody/extract' directory, unless you use the --target-dir flag to specify a different location.
+
+Run this command from the root directory of your Appsody project.`,
 		Example: `  appsody extract --target-dir $HOME/my-extract/directory
   Extracts your project from the container to the local '$HOME/my-extract/directory' on your system.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			return extract(config)
 		},
 	}

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -75,8 +75,11 @@ Use 'appsody list' to see the available stacks and templates.`,
 			if len(args) >= 1 {
 				stack = args[0]
 			}
-			if len(args) >= 2 {
+			if len(args) == 2 {
 				template = args[1]
+			}
+			if len(args) > 2 {
+				return errors.New("Expected at most two arguments: [stack] or [repository]/[stack] [template].")
 			}
 			return initAppsody(stack, template, config)
 		},

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -79,7 +79,7 @@ Use 'appsody list' to see the available stacks and templates.`,
 				template = args[1]
 			}
 			if len(args) > 2 {
-				return errors.New("Expected at most two arguments: [stack] or [repository]/[stack] [template].")
+				return errors.New("expected at most two arguments: [stack] or [repository]/[stack] [template]")
 			}
 			return initAppsody(stack, template, config)
 		},

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -48,7 +48,7 @@ An asterisk in the repository column denotes the default repository. An asterisk
 				return err
 			}
 			if len(args) > 1 {
-				return errors.New("Expected at most one argument: [repository].")
+				return errors.New("expected at most one argument: [repository]")
 			}
 			//var index RepoIndex
 			if len(args) < 1 {

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -47,6 +47,9 @@ An asterisk in the repository column denotes the default repository. An asterisk
 			if _, err := repos.getRepos(rootConfig); err != nil {
 				return err
 			}
+			if len(args) > 1 {
+				return errors.New("Expected at most one argument: [repository].")
+			}
 			//var index RepoIndex
 			if len(args) < 1 {
 				projects, err := repos.listProjects(rootConfig)
@@ -82,7 +85,6 @@ An asterisk in the repository column denotes the default repository. An asterisk
 					result := string(bytes)
 					rootConfig.Info.log("\n", result)
 				}
-
 			} else {
 				repoName := args[0]
 				_, err := repos.getRepos(rootConfig)
@@ -123,7 +125,6 @@ An asterisk in the repository column denotes the default repository. An asterisk
 					rootConfig.Info.log("\n", result)
 				}
 			}
-
 			return nil
 		},
 	}

--- a/cmd/operator_install.go
+++ b/cmd/operator_install.go
@@ -43,7 +43,7 @@ By default, the operator watches a single namespace. You can specify the ‘--wa
   Installs the Appsody Operator into your Kubernetes cluster in the "my-namespace" namespace, and sets it to watch for AppsodyApplication resources in the "my-watchspace" namespace.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			return operatorInstall(config)
 		},

--- a/cmd/operator_install.go
+++ b/cmd/operator_install.go
@@ -42,6 +42,9 @@ By default, the operator watches a single namespace. You can specify the ‘--wa
 		Example: `  appsody operator install --namespace my-namespace --watchspace my-watchspace
   Installs the Appsody Operator into your Kubernetes cluster in the "my-namespace" namespace, and sets it to watch for AppsodyApplication resources in the "my-watchspace" namespace.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			return operatorInstall(config)
 		},
 	}

--- a/cmd/operator_uninstall.go
+++ b/cmd/operator_uninstall.go
@@ -41,6 +41,9 @@ func newOperatorUninstallCmd(operatorConfig *operatorCommandConfig) *cobra.Comma
   Uninstalls the Appsody Operator in the "my-namespace" namespace from your Kubernetes cluster.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			operatorNamespace := "default"
 			if config.namespace != "" {
 				operatorNamespace = config.namespace

--- a/cmd/operator_uninstall.go
+++ b/cmd/operator_uninstall.go
@@ -42,7 +42,7 @@ func newOperatorUninstallCmd(operatorConfig *operatorCommandConfig) *cobra.Comma
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			operatorNamespace := "default"
 			if config.namespace != "" {

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -44,7 +44,7 @@ Shows the following information about the Appsody containers that are currently 
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			containers, err := listContainers(log)
 			if err != nil {

--- a/cmd/ps.go
+++ b/cmd/ps.go
@@ -43,6 +43,9 @@ func newPsCmd(log *LoggingConfig) *cobra.Command {
 Shows the following information about the Appsody containers that are currently running: container ID, container name, image and status.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			containers, err := listContainers(log)
 			if err != nil {
 				return err

--- a/cmd/repo_add.go
+++ b/cmd/repo_add.go
@@ -33,10 +33,10 @@ func newRepoAddCmd(config *RootCommandConfig) *cobra.Command {
   Adds the "my-local-repo" repository, specified by the "file:///absolute/path/to/my-local-repo.yaml" file to your list of repositories.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
-				return errors.New("You must specify a repository name and URL.")
+				return errors.New("you must specify a repository name and URL")
 			}
 			if len(args) > 2 {
-				return errors.New("Expected exactly two arguments: <repository> <url>.")
+				return errors.New("expected exactly two arguments: <repository> <url>")
 			}
 			return repoAdd(args[0], args[1], config)
 		},

--- a/cmd/repo_add.go
+++ b/cmd/repo_add.go
@@ -26,15 +26,17 @@ import (
 func newRepoAddCmd(config *RootCommandConfig) *cobra.Command {
 	// initCmd represents the init command
 	var addCmd = &cobra.Command{
-		Use:   "add <name> <url>",
+		Use:   "add <repository> <url>",
 		Short: "Add an Appsody repository.",
 		Long:  `Add an Appsody repository to your list of configured Appsody repositories.`,
 		Example: `  appsody repo add my-local-repo file:///absolute/path/to/my-local-repo.yaml
   Adds the "my-local-repo" repository, specified by the "file:///absolute/path/to/my-local-repo.yaml" file to your list of repositories.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 2 {
-
-				return errors.New("Error, you must specify repository name and URL")
+				return errors.New("You must specify a repository name and URL.")
+			}
+			if len(args) > 2 {
+				return errors.New("Expected exactly two arguments: <repository> <url>.")
 			}
 			return repoAdd(args[0], args[1], config)
 		},

--- a/cmd/repo_add_test.go
+++ b/cmd/repo_add_test.go
@@ -81,8 +81,8 @@ var repoAddErrorTests = []struct {
 	args          []string // input
 	expectedError string   // expected to be in the error message
 }{
-	{"No args", nil, "You must specify a repository name and URL"},
-	{"One arg", []string{"reponame"}, "You must specify a repository name and URL"},
+	{"No args", nil, "you must specify a repository name and URL"},
+	{"One arg", []string{"reponame"}, "you must specify a repository name and URL"},
 	{"No url scheme", []string{"test", "localhost"}, "unsupported protocol scheme"},
 	{"Non-existing url", []string{"test", "http://localhost/doesnotexist"}, "refused"},
 	{"Repo name over 50 characters", []string{"reponametoolongtestreponametoolongtestreponametoolongtest", "http://localhost/doesnotexist"}, "must be less than 50 characters"},

--- a/cmd/repo_add_test.go
+++ b/cmd/repo_add_test.go
@@ -81,8 +81,8 @@ var repoAddErrorTests = []struct {
 	args          []string // input
 	expectedError string   // expected to be in the error message
 }{
-	{"No args", nil, "you must specify repository name and URL"},
-	{"One arg", []string{"reponame"}, "you must specify repository name and URL"},
+	{"No args", nil, "You must specify a repository name and URL"},
+	{"One arg", []string{"reponame"}, "You must specify a repository name and URL"},
 	{"No url scheme", []string{"test", "localhost"}, "unsupported protocol scheme"},
 	{"Non-existing url", []string{"test", "http://localhost/doesnotexist"}, "refused"},
 	{"Repo name over 50 characters", []string{"reponametoolongtestreponametoolongtestreponametoolongtest", "http://localhost/doesnotexist"}, "must be less than 50 characters"},

--- a/cmd/repo_list.go
+++ b/cmd/repo_list.go
@@ -37,7 +37,7 @@ func newRepoListCmd(config *RootCommandConfig) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			var repos RepositoryFile
 

--- a/cmd/repo_list.go
+++ b/cmd/repo_list.go
@@ -16,6 +16,7 @@ package cmd
 
 import (
 	"encoding/json"
+	"errors"
 
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v2"
@@ -34,6 +35,10 @@ func newRepoListCmd(config *RootCommandConfig) *cobra.Command {
 		Short: "List your Appsody repositories.",
 		Long:  `List all your configured Appsody repositories. The "incubator" repository is the initial default repository for Appsody.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			var repos RepositoryFile
 
 			list, repoErr := repos.getRepos(config)

--- a/cmd/repo_remove.go
+++ b/cmd/repo_remove.go
@@ -36,7 +36,7 @@ You cannot remove the default repository, but you can make a different repositor
 				return errors.New("Error, you must specify repository name")
 			}
 			if len(args) > 1 {
-				return errors.New("Expected exactly one argument: <repository>.")
+				return errors.New("expected exactly one argument: <repository>")
 			}
 			var repoName = args[0]
 

--- a/cmd/repo_remove.go
+++ b/cmd/repo_remove.go
@@ -24,7 +24,7 @@ import (
 func newRepoRemoveCmd(config *RootCommandConfig) *cobra.Command {
 	// initCmd represents the init command
 	var removeCmd = &cobra.Command{
-		Use:   "remove <name>",
+		Use:   "remove <repository>",
 		Short: "Remove an Appsody repository.",
 		Long: `Remove an Appsody repository from your list of configured Appsody repositories.
 		
@@ -35,7 +35,9 @@ You cannot remove the default repository, but you can make a different repositor
 			if len(args) < 1 {
 				return errors.New("Error, you must specify repository name")
 			}
-
+			if len(args) > 1 {
+				return errors.New("Expected exactly one argument: <repository>.")
+			}
 			var repoName = args[0]
 
 			var repoFile RepositoryFile

--- a/cmd/repo_set_default.go
+++ b/cmd/repo_set_default.go
@@ -22,7 +22,7 @@ import (
 func newRepoDefaultCmd(config *RootCommandConfig) *cobra.Command {
 	// initCmd represents the init command
 	var setDefaultCmd = &cobra.Command{
-		Use:   "set-default <name>",
+		Use:   "set-default <repository>",
 		Short: "Set a default repository.",
 		Long: `Set your specified repository to be the default repository.
 
@@ -31,7 +31,10 @@ The default repository is used when you run the "appsody init" command without s
   Sets your default repository to "my-local-repo".`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errors.New("You must specify desired default repository")
+				return errors.New("You must specify desired default repository.")
+			}
+			if len(args) > 1 {
+				return errors.New("Expected exactly one arguments: <repository>.")
 			}
 
 			var repoName = args[0]

--- a/cmd/repo_set_default.go
+++ b/cmd/repo_set_default.go
@@ -31,7 +31,7 @@ The default repository is used when you run the "appsody init" command without s
   Sets your default repository to "my-local-repo".`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) < 1 {
-				return errors.New("You must specify desired default repository.")
+				return errors.New("you must specify desired default repository")
 			}
 			if len(args) > 1 {
 				return errors.New("expected exactly one arguments: <repository>")

--- a/cmd/repo_set_default.go
+++ b/cmd/repo_set_default.go
@@ -34,7 +34,7 @@ The default repository is used when you run the "appsody init" command without s
 				return errors.New("You must specify desired default repository.")
 			}
 			if len(args) > 1 {
-				return errors.New("Expected exactly one arguments: <repository>.")
+				return errors.New("expected exactly one arguments: <repository>")
 			}
 
 			var repoName = args[0]

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"github.com/spf13/cobra"
 )
 
@@ -52,7 +53,7 @@ func newRunCmd(rootConfig *RootCommandConfig) *cobra.Command {
 		Short: "Run your Appsody project in a containerized development environment.",
 		Long: `Run the local Appsody environment, starting a container-based, continuous build environment for your project.
 		
-Run this command from the root directory of your Appsody project`,
+Run this command from the root directory of your Appsody project.`,
 		Example: `  appsody run
   Runs your project in a containerized development environment.
 
@@ -63,6 +64,9 @@ Run this command from the root directory of your Appsody project`,
   Runs your project in a containerized development environment, binds the container port 3000 to the host port 3001, and passes the "--privileged" option to the "docker run" command as a flag.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			rootConfig.Info.log("Running development environment...")
 			return commonCmd(config, "run")
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -65,7 +65,7 @@ Run this command from the root directory of your Appsody project.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			rootConfig.Info.log("Running development environment...")
 			return commonCmd(config, "run")

--- a/cmd/stack_addtorepo.go
+++ b/cmd/stack_addtorepo.go
@@ -34,14 +34,15 @@ func newStackAddToRepoCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	log := rootConfig.LoggingConfig
 
 	var stackAddToRepoCmd = &cobra.Command{
-		Use:   "add-to-repo <repo-name>",
+		Use:   "add-to-repo <repository>",
 		Short: "Add stack information into a production Appsody repository",
 		Long: `Adds stack information into an Appsody repository. 
 		
-Adds stack information to a new or existing Appsody repository, specified by the <repo-name> argument. This enables you to share your stack with others.
+Adds stack information to a new or existing Appsody repository, specified by the <repository> argument. This enables you to share your stack with others.
 
-The updated repository index file is created in  ~/.appsody/stacks/dev.local directory.`,
+The updated repository index file is created in  ~/.appsody/stacks/dev.local directory.
 
+Run this command from the root directory of your Appsody project.`,
 		Example: `  appsody stack add-to-repo incubator
   Creates a new repository index file for the incubator repository, setting the template URLs to begin with a default URL of https://github.com/appsody/stacks/releases/latest/download/
 
@@ -58,6 +59,9 @@ The updated repository index file is created in  ~/.appsody/stacks/dev.local dir
 
 			if len(args) < 1 {
 				return errors.New("Required parameter missing. You must specify a repository name")
+			}
+			if len(args) > 1 {
+				return errors.New("Expected exactly one argument: <repository>.")
 			}
 
 			repoName = args[0]

--- a/cmd/stack_addtorepo.go
+++ b/cmd/stack_addtorepo.go
@@ -61,7 +61,7 @@ Run this command from the root directory of your Appsody project.`,
 				return errors.New("Required parameter missing. You must specify a repository name")
 			}
 			if len(args) > 1 {
-				return errors.New("Expected exactly one argument: <repository>.")
+				return errors.New("expected exactly one argument: <repository>")
 			}
 
 			repoName = args[0]

--- a/cmd/stack_create.go
+++ b/cmd/stack_create.go
@@ -54,6 +54,9 @@ The stack name must start with a lowercase letter, and can contain only lowercas
 			if len(args) < 1 {
 				return errors.New("Required parameter missing. You must specify a stack name")
 			}
+			if len(args) > 1 {
+				return errors.New("Expected exactly one argument: <name>.")
+			}
 
 			stack := args[0]
 

--- a/cmd/stack_create.go
+++ b/cmd/stack_create.go
@@ -55,7 +55,7 @@ The stack name must start with a lowercase letter, and can contain only lowercas
 				return errors.New("Required parameter missing. You must specify a stack name")
 			}
 			if len(args) > 1 {
-				return errors.New("Expected exactly one argument: <name>.")
+				return errors.New("expected exactly one argument: <name>")
 			}
 
 			stack := args[0]

--- a/cmd/stack_lint.go
+++ b/cmd/stack_lint.go
@@ -24,7 +24,7 @@ import (
 
 func newStackLintCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	var lintCmd = &cobra.Command{
-		Use:   "lint",
+		Use:   "lint [path]",
 		Short: "Check your stack structure.",
 		Long: `Check that the structure of your stack is valid. Error messages indicate critical issues in your stack structure, such as missing files, directories, or stack variables. Warning messages suggest optional stack enhancements.
 
@@ -43,6 +43,9 @@ Run this command from the root directory of your stack, or specify the path to y
 
 			if len(args) > 0 {
 				stackPath = args[0]
+			}
+			if len(args) > 1 {
+				return errors.New("Expected at most one argument: [path].")
 			}
 
 			imagePath := filepath.Join(stackPath, "image")

--- a/cmd/stack_lint.go
+++ b/cmd/stack_lint.go
@@ -45,7 +45,7 @@ Run this command from the root directory of your stack, or specify the path to y
 				stackPath = args[0]
 			}
 			if len(args) > 1 {
-				return errors.New("Expected at most one argument: [path].")
+				return errors.New("expected at most one argument: [path]")
 			}
 
 			imagePath := filepath.Join(stackPath, "image")

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -95,6 +95,9 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
   appsody stack package --image-namespace my-namespace
   Packages the stack in the current directory, tags the built image with the default registry and "my-namespace" namespace, and adds the stack to the "dev.local" repository.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 
 			log.Info.Log("******************************************")
 			log.Info.Log("Running appsody stack package")

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -96,7 +96,7 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
   Packages the stack in the current directory, tags the built image with the default registry and "my-namespace" namespace, and adds the stack to the "dev.local" repository.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 
 			log.Info.Log("******************************************")

--- a/cmd/stack_removefromrepo.go
+++ b/cmd/stack_removefromrepo.go
@@ -34,11 +34,11 @@ func newStackRemoveFromRepoCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	log := rootConfig.LoggingConfig
 
 	var stackRemoveFromRepoCmd = &cobra.Command{
-		Use:   "remove-from-repo <repo-name> <stack-name>",
+		Use:   "remove-from-repo <repository> <stack>",
 		Short: "Remove stack information from an Appsody repository",
 		Long: `Removes stack information from an Appsody repository. 
 		
-Removes stack information, specified by <stack-name> from an Appsody repository, specified by the <repo-name> argument.
+Removes stack information, specified by <stack> from an Appsody repository, specified by the <repository> argument.
 
 The updated repository index file is created in  ~/.appsody/stacks/dev.local directory.`,
 
@@ -52,6 +52,9 @@ The updated repository index file is created in  ~/.appsody/stacks/dev.local dir
 
 			if len(args) < 2 {
 				return errors.New("Required parameter missing. You must specify a repository name and a stack name")
+			}
+			if len(args) > 2 {
+				return errors.New("Expected exactly 2 arguments: <repository> <stack>.")
 			}
 
 			repoName = args[0]

--- a/cmd/stack_removefromrepo.go
+++ b/cmd/stack_removefromrepo.go
@@ -54,7 +54,7 @@ The updated repository index file is created in  ~/.appsody/stacks/dev.local dir
 				return errors.New("Required parameter missing. You must specify a repository name and a stack name")
 			}
 			if len(args) > 2 {
-				return errors.New("Expected exactly 2 arguments: <repository> <stack>.")
+				return errors.New("expected exactly 2 arguments: <repository> <stack>")
 			}
 
 			repoName = args[0]

--- a/cmd/stack_validate.go
+++ b/cmd/stack_validate.go
@@ -52,9 +52,14 @@ Runs the following validation tests against the stack and its templates:
   * appsody init 
   * appsody run 
   * appsody test 
-  * appsody build`,
+  * appsody build
+  
+Run this command from the root directory of your Appsody project.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			// vars to store test results
 			var testResults []string
 			var initFail bool // if init fails we can skip the rest of the tests

--- a/cmd/stack_validate.go
+++ b/cmd/stack_validate.go
@@ -58,7 +58,7 @@ Run this command from the root directory of your Appsody project.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			// vars to store test results
 			var testResults []string

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -37,7 +37,7 @@ To see a list of all your running Appsody containers, run the command 'appsody p
 
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			if !rootConfig.Buildah {
 				rootConfig.Info.log("Stopping development environment")

--- a/cmd/stop.go
+++ b/cmd/stop.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"github.com/spf13/cobra"
 )
 
@@ -35,6 +36,9 @@ To see a list of all your running Appsody containers, run the command 'appsody p
   Stops the running Appsody container with the name "nodejs-express-dev".`,
 
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			if !rootConfig.Buildah {
 				rootConfig.Info.log("Stopping development environment")
 				err := dockerStop(rootConfig, containerName, rootConfig.Dryrun)

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -34,7 +34,7 @@ Run this command from the root directory of your Appsody project.`,
   Runs the tests for your Appsody project without monitoring your project files for changes. The command completes after the tests are run once.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 
 			rootConfig.Info.log("Running test environment")

--- a/cmd/test.go
+++ b/cmd/test.go
@@ -13,7 +13,10 @@
 // limitations under the License.
 package cmd
 
-import "github.com/spf13/cobra"
+import (
+	"errors"
+	"github.com/spf13/cobra"
+)
 
 func newTestCmd(rootConfig *RootCommandConfig) *cobra.Command {
 	config := &devCommonConfig{RootCommandConfig: rootConfig}
@@ -30,6 +33,9 @@ Run this command from the root directory of your Appsody project.`,
   appsody test --no-watcher
   Runs the tests for your Appsody project without monitoring your project files for changes. The command completes after the tests are run once.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 
 			rootConfig.Info.log("Running test environment")
 			return commonCmd(config, "test")

--- a/cmd/testdata/bad_format_repository_config/config.yaml
+++ b/cmd/testdata/bad_format_repository_config/config.yaml
@@ -1,5 +1,5 @@
 home: testdata/bad_format_repository_config
-images: index.docker.io
-lastversioncheck: 2019-12-03 11:41:54 +0000 GMT
+images: docker.io
+lastversioncheck: 2020-01-10 14:31:59 +0000 GMT
 operator: https://github.com/appsody/appsody-operator/releases/latest/download
 tektonserver: ""

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -15,6 +15,7 @@
 package cmd
 
 import (
+	"errors"
 	"github.com/spf13/cobra"
 )
 
@@ -24,8 +25,12 @@ func newVersionCmd(log *LoggingConfig, rootCmd *cobra.Command) *cobra.Command {
 		Use:   "version",
 		Short: "Show the version of the Appsody CLI.",
 		Long:  `Show the version of the Appsody CLI that is currently in use.`,
-		Run: func(cmd *cobra.Command, args []string) {
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if len(args) > 0 {
+				return errors.New("Expected no additional arguments.")
+			}
 			log.Info.log(rootCmd.Use, " ", VERSION)
+			return nil
 		},
 	}
 

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -27,7 +27,7 @@ func newVersionCmd(log *LoggingConfig, rootCmd *cobra.Command) *cobra.Command {
 		Long:  `Show the version of the Appsody CLI that is currently in use.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
 			if len(args) > 0 {
-				return errors.New("Expected no additional arguments.")
+				return errors.New("expected no additional arguments")
 			}
 			log.Info.log(rootCmd.Use, " ", VERSION)
 			return nil


### PR DESCRIPTION
Added checks to CLI so appsody commands will fail if extra propositional arguments are added (and some other minor help text changes)

Fixes: #802 