### PR TITLE
Set pull policy to always

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -481,6 +481,7 @@
     "github.com/spf13/cobra/doc",
     "github.com/spf13/viper",
     "gopkg.in/yaml.v2",
+    "k8s.io/api/core/v1",
     "k8s.io/klog",
     "sigs.k8s.io/yaml",
   ]

--- a/cmd/build.go
+++ b/cmd/build.go
@@ -25,6 +25,7 @@ import (
 	"github.com/appsody/appsody-operator/pkg/apis/appsody/v1beta1"
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/yaml"
 
 	"bytes"
@@ -544,6 +545,11 @@ func updateDeploymentConfig(config *buildCommandConfig, imageName string, labels
 	}
 
 	appsodyApplication.Spec.ApplicationImage = imageName
+
+	if appsodyApplication.Spec.PullPolicy == nil {
+		pullPolicy := corev1.PullAlways
+		appsodyApplication.Spec.PullPolicy = &pullPolicy
+	}
 
 	// This only applies to the deploy command flow:
 	// - if the namespace doesn't exist in the manifest, and a namespace flag is not set: we write a "default" namespace

--- a/functest/build_test.go
+++ b/functest/build_test.go
@@ -35,6 +35,7 @@ type expectedDeploymentConfig struct {
 	imageTag   string
 	namespace  string
 	knative    bool
+	pullPolicy string
 }
 
 // Simple test for appsody build command. A future enhancement would be to verify the image that gets built.
@@ -201,7 +202,7 @@ func TestBuildLabels(t *testing.T) {
 		t.Errorf("Expected commit message \"%s\" but found \"%s\"", commitMessage, labelsMap[appsodyCommitKey+"message"])
 	}
 
-	checkDeploymentConfig(t, expectedDeploymentConfig{filepath.Join(sandbox.ProjectDir, deployFile), "", imageName, "", false})
+	checkDeploymentConfig(t, expectedDeploymentConfig{filepath.Join(sandbox.ProjectDir, deployFile), "", imageName, "", false, "Always"})
 
 	//delete the image
 	deleteImage(imageName, t)
@@ -256,7 +257,7 @@ func TestDeploymentConfig(t *testing.T) {
 			t.Error("appsody build command returned err: ", err)
 		}
 
-		checkDeploymentConfig(t, expectedDeploymentConfig{filepath.Join(sandbox.ProjectDir, deployFile), pullURL, imageName, "", true})
+		checkDeploymentConfig(t, expectedDeploymentConfig{filepath.Join(sandbox.ProjectDir, deployFile), pullURL, imageName, "", true, "Always"})
 
 		//delete the image
 		deleteImage(imageName, t)
@@ -388,6 +389,10 @@ func checkDeploymentConfig(t *testing.T, expectedDeploymentConfig expectedDeploy
 
 	if appsodyApplication.Namespace != expectedDeploymentConfig.namespace {
 		t.Errorf("Incorrect Namespace in app-deploy.yaml. Expected %s but found %s", expectedDeploymentConfig.namespace, appsodyApplication.Namespace)
+	}
+
+	if string(*appsodyApplication.Spec.PullPolicy) != expectedDeploymentConfig.pullPolicy {
+		t.Errorf("Incorrect PullPolicy in app-deploy.yaml. Expected %s but found %s", expectedDeploymentConfig.pullPolicy, appsodyApplication.Namespace)
 	}
 
 	verifyImageAndConfigLabelsMatch(t, appsodyApplication, expectedDeploymentConfig.imageTag)

--- a/functest/build_test.go
+++ b/functest/build_test.go
@@ -202,7 +202,7 @@ func TestBuildLabels(t *testing.T) {
 		t.Errorf("Expected commit message \"%s\" but found \"%s\"", commitMessage, labelsMap[appsodyCommitKey+"message"])
 	}
 
-	checkDeploymentConfig(t, expectedDeploymentConfig{filepath.Join(sandbox.ProjectDir, deployFile), "", imageName, "", false, "Always"})
+	checkDeploymentConfig(t, expectedDeploymentConfig{filepath.Join(sandbox.ProjectDir, deployFile), "", imageName, "", false, ""})
 
 	//delete the image
 	deleteImage(imageName, t)
@@ -251,13 +251,14 @@ func TestDeploymentConfig(t *testing.T) {
 		// appsody build
 		imageName := sandbox.ProjectName
 		pullURL := "my-pull-url"
+		pullPolicy := "Always"
 
-		_, err = cmdtest.RunAppsody(sandbox, "build", "--tag", imageName, "--pull-url", pullURL, "--knative")
+		_, err = cmdtest.RunAppsody(sandbox, "build", "--tag", imageName, "--pull-url", pullURL, "--knative", "--pullPolicy", pullPolicy)
 		if err != nil {
 			t.Error("appsody build command returned err: ", err)
 		}
 
-		checkDeploymentConfig(t, expectedDeploymentConfig{filepath.Join(sandbox.ProjectDir, deployFile), pullURL, imageName, "", true, "Always"})
+		checkDeploymentConfig(t, expectedDeploymentConfig{filepath.Join(sandbox.ProjectDir, deployFile), pullURL, imageName, "", true, pullPolicy})
 
 		//delete the image
 		deleteImage(imageName, t)
@@ -391,7 +392,7 @@ func checkDeploymentConfig(t *testing.T, expectedDeploymentConfig expectedDeploy
 		t.Errorf("Incorrect Namespace in app-deploy.yaml. Expected %s but found %s", expectedDeploymentConfig.namespace, appsodyApplication.Namespace)
 	}
 
-	if string(*appsodyApplication.Spec.PullPolicy) != expectedDeploymentConfig.pullPolicy {
+	if appsodyApplication.Spec.PullPolicy != nil && string(*appsodyApplication.Spec.PullPolicy) != expectedDeploymentConfig.pullPolicy {
 		t.Errorf("Incorrect PullPolicy in app-deploy.yaml. Expected %s but found %s", expectedDeploymentConfig.pullPolicy, appsodyApplication.Namespace)
 	}
 

--- a/functest/deploy_test.go
+++ b/functest/deploy_test.go
@@ -128,6 +128,8 @@ func TestGenerationDeploymentConfig(t *testing.T) {
 		imageTag := "testdeploy/testimage"
 		pullURL := "my-pull-url"
 		namespace := "myNamespace"
+		pullPolicy := "Always"
+
 		// appsody deploy
 		t.Log("Running appsody deploy...")
 		_, err = cmdtest.RunAppsody(sandbox, "deploy", "-t", imageTag, "--pull-url", pullURL, "--generate-only", "--knative", "-n", namespace)
@@ -137,7 +139,7 @@ func TestGenerationDeploymentConfig(t *testing.T) {
 			// t.Fatal(err)
 		}
 
-		checkDeploymentConfig(t, expectedDeploymentConfig{filepath.Join(sandbox.ProjectDir, deployFile), pullURL, imageTag, namespace, true, "Always"})
+		checkDeploymentConfig(t, expectedDeploymentConfig{filepath.Join(sandbox.ProjectDir, deployFile), pullURL, imageTag, namespace, true, pullPolicy})
 	}
 }
 

--- a/functest/deploy_test.go
+++ b/functest/deploy_test.go
@@ -137,7 +137,7 @@ func TestGenerationDeploymentConfig(t *testing.T) {
 			// t.Fatal(err)
 		}
 
-		checkDeploymentConfig(t, expectedDeploymentConfig{filepath.Join(sandbox.ProjectDir, deployFile), pullURL, imageTag, namespace, true})
+		checkDeploymentConfig(t, expectedDeploymentConfig{filepath.Join(sandbox.ProjectDir, deployFile), pullURL, imageTag, namespace, true, "Always"})
 	}
 }
 


### PR DESCRIPTION
Fixes #864 - It does not fix the reload of the image at every `appsody deploy`, this will fix when doing `appsody deploy delete` and `appsody deploy` with the same image.

I'm not a big fan of importing the `corev1` package from Kubernetes API

TODO: Needs testing on Knative
