### PR TITLE
Don't override registry name unless stack-registry flag is used

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -311,7 +311,7 @@ func install(config *initCommandConfig) error {
 
 	// reset config.StackRegistry and get it again from the newly untarred .appsody-config.yaml
 
-	defaultStackRegistry := getDefaultStackRegistry(config.RootCommandConfig)
+	//defaultStackRegistry := getDefaultStackRegistry(config.RootCommandConfig)
 	configFileStackRegistry, err := getStackRegistryFromConfigFile(config.RootCommandConfig)
 	if err != nil {
 		return err
@@ -321,13 +321,12 @@ func install(config *initCommandConfig) error {
 	if config.StackRegistryInit != "" {
 		config.Debug.Log("The flag --stack-registry was set to: ", config.StackRegistryInit)
 		stackRegistry = config.StackRegistryInit
-	} else if configFileStackRegistry == "" {
-		stackRegistry = defaultStackRegistry
-	}
-	config.Debug.Log("The stack registry in .appsody-config.yaml will be set to: ", stackRegistry)
-	err = setStackRegistry(stackRegistry, config.RootCommandConfig)
-	if err != nil {
-		return err
+
+		config.Debug.Log("The stack registry in .appsody-config.yaml will be set to: ", stackRegistry)
+		err = setStackRegistry(stackRegistry, config.RootCommandConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	projectDir, perr := getProjectDir(config.RootCommandConfig)

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -311,7 +311,6 @@ func install(config *initCommandConfig) error {
 
 	// reset config.StackRegistry and get it again from the newly untarred .appsody-config.yaml
 
-	//defaultStackRegistry := getDefaultStackRegistry(config.RootCommandConfig)
 	configFileStackRegistry, err := getStackRegistryFromConfigFile(config.RootCommandConfig)
 	if err != nil {
 		return err


### PR DESCRIPTION
Appsody should not add default stack registry unless stack-registry flag is used.

Signed-off-by: Neeraj Laad <neeraj.laad@gmail.com>