### PR TITLE
Make sure to set the stack registry to the one in the config file on init's extract

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -310,17 +310,22 @@ func install(config *initCommandConfig) error {
 	config.Info.log("Setting up the development environment")
 
 	// reset config.StackRegistry and get it again from the newly untarred .appsody-config.yaml
-
+	var err error
 	if config.StackRegistryInit != "" {
 		config.Debug.Log("The flag --stack-registry was set to: ", config.StackRegistryInit)
 		config.Debug.Log("Updating the stack registry in .appsody-config.yaml to be: ", config.StackRegistryInit)
-		err := setStackRegistry(config.StackRegistryInit, config.RootCommandConfig)
+		err = setStackRegistry(config.StackRegistryInit, config.RootCommandConfig)
 		if err != nil {
 			return err
 		}
 		// We must set the config.StackRegistry here so that subsequent calls to getProjectConfig() and
 		// thus extractAndInitialize will pick up the registry specified by the user's flag
 		config.StackRegistry = config.StackRegistryInit
+	} else {
+		config.StackRegistry, err = getStackRegistryFromConfigFile(config.RootCommandConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	projectDir, perr := getProjectDir(config.RootCommandConfig)
@@ -345,7 +350,7 @@ func install(config *initCommandConfig) error {
 
 	config.Debug.logf("Setting up the development environment for projectDir: %s and platform: %s", projectDir, platformDefinition)
 
-	err := extractAndInitialize(config)
+	err = extractAndInitialize(config)
 	if err != nil {
 		// For some reason without this sleep, the [InitScript] output log would get cut off and
 		// intermixed with the following Warning logs when verbose logging. Adding this sleep as a workaround.

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -597,6 +597,7 @@ func getProjectConfig(config *RootCommandConfig) (*ProjectConfig, error) {
 	if err != nil {
 		return nil, err
 	}
+	config.Debug.logf("Project stack before override: %s", projectConfig.Stack)
 
 	imageComponents := strings.Split(projectConfig.Stack, "/")
 	if len(imageComponents) < 3 {


### PR DESCRIPTION
When running `appsody init dev.local/java-microprofile` or init on any stack with a non-docker.io stack image, the init process will incorrectly pull and extract the docker.io image.

This bug was introduced in appsody 0.5.5 when adding --stack-registry to init
As a workaround you can specify `--stack-registry dev.local` on the init command.