### PR TITLE
HOLD: Removed old create method.

### DIFF
--- a/cmd/stack_create.go
+++ b/cmd/stack_create.go
@@ -15,14 +15,9 @@
 package cmd
 
 import (
-	"archive/zip"
-	"io"
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"runtime"
-	"strings"
-	"time"
 
 	"github.com/pkg/errors"
 	"github.com/spf13/cobra"
@@ -51,8 +46,6 @@ The stack name must start with a lowercase letter, and can contain only lowercas
   appsody stack create my-stack --copy incubator/nodejs-express  
   Creates a stack called my-stack, based on the Node.js Express stack.`,
 		RunE: func(cmd *cobra.Command, args []string) error {
-
-			currentTime := time.Now().Format("20060102150405")
 
 			if len(args) < 1 {
 				return errors.New("Required parameter missing. You must specify a stack name")
@@ -152,8 +145,7 @@ The stack name must start with a lowercase letter, and can contain only lowercas
 
 				if stackEntryURL == "" {
 					//TODO: REMOVE OLD CREATE METHOD AFTER NEXT RELEASE AND UPDATE STACKS
-					//return errors.New("No source URL specified.  Use the add-to-repo command with the --release-url flag to your repo")
-					return oldCreateMethod(rootConfig.LoggingConfig, rootConfig, config, stack, currentTime)
+					return errors.New("No source URL specified.  Use the add-to-repo command with the --release-url flag to your repo")
 				}
 
 				// download source.tar.gz of selected stack source
@@ -193,141 +185,4 @@ func getStack(stackList *IndexYaml, name string) *IndexYamlStack {
 		}
 	}
 	return nil
-}
-
-// To be removed in next release
-func oldCreateMethod(log *LoggingConfig, rootConfig *RootCommandConfig, config *stackCreateCommandConfig, stack string, currentTime string) error {
-	err := downloadFileToDisk(rootConfig.LoggingConfig, "https://github.com/appsody/stacks/archive/master.zip", filepath.Join(getHome(rootConfig), "extract", "repo.zip"), config.Dryrun)
-	if err != nil {
-		return err
-	}
-	_, stackTempDir, err := parseProjectParm(config.copy, config.RootCommandConfig)
-	if err != nil {
-		return err
-	}
-
-	valid, unzipErr := unzip(rootConfig.LoggingConfig, filepath.Join(getHome(rootConfig), "extract", "repo.zip"), stack, config.copy, config.Dryrun)
-	if unzipErr != nil {
-		return unzipErr
-	}
-
-	if !valid {
-		return errors.Errorf("Invalid stack name: " + config.copy + ". Stack name must be in the format <repo>/<stack>")
-	}
-
-	//deleting the stacks repo zip
-	os.Remove(filepath.Join(getHome(rootConfig), "extract", "repo.zip"))
-
-	//moving out the stack which we need
-	if config.Dryrun {
-		config.Info.logf("Dry Run -Skipping moving out of stack: %s from %s", stackTempDir, filepath.Join(stack, "stacks-master", config.copy))
-
-	} else {
-		stackTempDir = ".temp-" + stackTempDir + "-" + currentTime
-
-		err = os.Rename(filepath.Join(stack, "stacks-master", config.copy), stackTempDir)
-		if err != nil {
-			return err
-		}
-	}
-
-	//deleting the folder from which stack is extracted
-	os.RemoveAll(stack)
-
-	// rename the stack to the name which user want
-	if config.Dryrun {
-		config.Info.logf("Dry Run -Skipping renaming of stack from: %s to %s", stackTempDir, stack)
-
-	} else {
-		err = os.Rename(stackTempDir, stack)
-		if err != nil {
-			return err
-		}
-	}
-
-	if !config.Dryrun {
-		rootConfig.Info.log("Stack created: ", stack)
-	} else {
-		rootConfig.Info.log("Dry run complete")
-	}
-
-	return nil
-}
-
-// Unzip will decompress a zip archive - TO BE REMOVED NEXT RELEASE
-// within the zip file (parameter 1) to an output directory (parameter 2).
-func unzip(log *LoggingConfig, src string, dest string, copy string, dryrun bool) (bool, error) {
-	if dryrun {
-		log.Info.logf("Dry Run -Skipping unzip of file: %s from %s", copy, src)
-
-	} else {
-		valid := false
-
-		r, err := zip.OpenReader(src)
-		if err != nil {
-			return valid, err
-		}
-		defer r.Close()
-
-		for _, f := range r.File {
-
-			// Store filename/path for returning and using later on
-			fpath := filepath.Join(dest, f.Name)
-
-			// Check for ZipSlip. More Info: http://bit.ly/2MsjAWE
-			if !strings.HasPrefix(fpath, filepath.Clean(dest)+string(os.PathSeparator)) {
-				return valid, errors.Errorf("%s: illegal file path", fpath)
-			}
-
-			if runtime.GOOS == "windows" {
-				if !strings.HasPrefix(f.Name, "stacks-master/"+copy+"/") {
-					continue
-				} else {
-					valid = true
-				}
-			} else {
-				if !strings.HasPrefix(f.Name, filepath.Join("stacks-master", string(os.PathSeparator), copy)+string(os.PathSeparator)) {
-					continue
-				} else {
-					valid = true
-				}
-			}
-
-			if f.FileInfo().IsDir() {
-				// Make Folder
-				err := os.MkdirAll(fpath, os.ModePerm)
-				if err != nil {
-					return valid, err
-				}
-				continue
-			}
-
-			// Make File
-			if err = os.MkdirAll(filepath.Dir(fpath), os.ModePerm); err != nil {
-				return valid, err
-			}
-
-			outFile, err := os.OpenFile(fpath, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, f.Mode())
-			if err != nil {
-				return valid, err
-			}
-
-			rc, err := f.Open()
-			if err != nil {
-				return valid, err
-			}
-
-			_, err = io.Copy(outFile, rc)
-
-			// Close the file without defer to close before next iteration of loop
-			outFile.Close()
-			rc.Close()
-
-			if err != nil {
-				return valid, err
-			}
-		}
-		return valid, nil
-	}
-	return true, nil
 }

--- a/functest/create_test.go
+++ b/functest/create_test.go
@@ -15,6 +15,7 @@ package functest
 
 import (
 	"bytes"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -141,9 +142,9 @@ func TestStackCreateInvalidRepoFail(t *testing.T) {
 	defer cleanup()
 
 	createArgs := []string{"stack", "create", "testing-stack", "--copy", "invalid/starter"}
-	_, err := cmdtest.RunAppsody(sandbox, createArgs...)
+	output, err := cmdtest.RunAppsody(sandbox, createArgs...)
 	if err != nil {
-		if !strings.Contains(err.Error(), "Repository: invalid not found in repository.yaml file") {
+		if !strings.Contains(output, "Repository: invalid not found in repository.yaml file") {
 			t.Errorf("String \"Repository: invalid not found in repository.yaml file\" not found in output")
 		}
 	} else {
@@ -182,9 +183,9 @@ func TestStackCreateInvalidStackFail(t *testing.T) {
 	}
 
 	createArgs := []string{"stack", "create", "testing-stack", "--copy", "dev.local/invalid"}
-	_, err = cmdtest.RunAppsody(sandbox, createArgs...)
+	output, err := cmdtest.RunAppsody(sandbox, createArgs...)
 	if err != nil {
-		if !strings.Contains(err.Error(), "Stack not found in index") {
+		if !strings.Contains(output, "Stack not found in index") {
 			t.Errorf("String \"Stack not found in index\" not found in output")
 		}
 	} else {
@@ -239,13 +240,75 @@ func TestStackCreateInvalidURLFail(t *testing.T) {
 	}
 
 	createArgs := []string{"stack", "create", "testing-stack", "--copy", "test-repo/starter"}
-	_, err = cmdtest.RunAppsody(sandbox, createArgs...)
+	output, err := cmdtest.RunAppsody(sandbox, createArgs...)
 	if err != nil {
-		if !strings.Contains(err.Error(), "Could not download file://invalidurl") {
+		if !strings.Contains(output, "Could not download file://invalidurl") {
 			t.Errorf("String \"Could not download file://invalidurl\" not found in output")
 		}
 	} else {
 		t.Error("Stack create command unexpectededly passed with an invalid repository name")
+	}
+
+}
+func TestStackCreateNoSrcFail(t *testing.T) {
+
+	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
+	defer cleanup()
+
+	var outBuffer bytes.Buffer
+	log := &cmd.LoggingConfig{}
+	log.InitLogging(&outBuffer, &outBuffer)
+
+	stackDir := filepath.Join(sandbox.TestDataPath, "starter")
+	targetDir := filepath.Join(sandbox.ProjectDir, "starter")
+	err := cmd.CopyDir(log, stackDir, targetDir)
+	if err != nil {
+		t.Errorf("Problem copying %s to %s: %v", stackDir, targetDir, err)
+	} else {
+		t.Logf("Copied %s to %s", stackDir, targetDir)
+	}
+
+	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
+	// folder within the temp directory that has been generated for sandboxing purposes, rather than
+	// the usual core temp directory
+	sandbox.ProjectDir = filepath.Join(sandbox.ProjectDir, "starter")
+
+	packageArgs := []string{"stack", "package"}
+	_, err = cmdtest.RunAppsody(sandbox, packageArgs...)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	devlocalFile := filepath.Join(sandbox.ConfigDir, "stacks", "dev.local", "dev.local-index.yaml")
+
+	file, err := ioutil.ReadFile(devlocalFile)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	lines := strings.Split(string(file), "\n")
+
+	for i, line := range lines {
+		if strings.Contains(line, "src:") {
+			lines[i] = ""
+		}
+	}
+	output := strings.Join(lines, "\n")
+	err = ioutil.WriteFile(devlocalFile, []byte(output), 0644)
+
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	createArgs := []string{"stack", "create", "testing-stack", "--copy", "dev.local/starter"}
+	output, err = cmdtest.RunAppsody(sandbox, createArgs...)
+
+	if err != nil {
+		if !strings.Contains(output, "No source URL specified") {
+			t.Errorf("String \"No source URL specified\" not found in output")
+		}
+	} else {
+		t.Error("Stack create command unexpectededly passed with no source url")
 	}
 
 }


### PR DESCRIPTION
In reference to PR: #856 and Issue: #618 .  This now removes the old method of unzipping the github stacks folder.  SHOULD NOT BE MERGED UNTIL ALL STACKS HAVE BEEN RELEASED WITH A SRC URL.

Also added a func test for when the src is missing.