### PR TITLE
git_utils.go: improve code coverage

### DIFF
--- a/cmd/git_utils.go
+++ b/cmd/git_utils.go
@@ -46,7 +46,7 @@ type GitInfo struct {
 
 const trimChars = "' \r\n"
 
-func stringBefore(value string, searchValue string) string {
+func StringBefore(value string, searchValue string) string {
 	// Get substring before a string.
 
 	gitURLElements := strings.Split(value, searchValue)
@@ -57,7 +57,7 @@ func stringBefore(value string, searchValue string) string {
 
 }
 
-func stringAfter(value string, searchValue string) string {
+func StringAfter(value string, searchValue string) string {
 	// Get substring after a string.
 	position := strings.LastIndex(value, searchValue)
 	if position == -1 {
@@ -69,7 +69,7 @@ func stringAfter(value string, searchValue string) string {
 	}
 	return value[adjustedPosition:]
 }
-func stringBetween(value string, pre string, post string) string {
+func StringBetween(value string, pre string, post string) string {
 	// Get substring between two strings.
 	positionBegin := strings.Index(value, pre)
 	if positionBegin == -1 {
@@ -121,16 +121,16 @@ func GetGitInfo(config *RootCommandConfig) (GitInfo, error) {
 
 	if strings.HasPrefix(value, branchPrefix) {
 		if strings.Contains(value, branchSeparatorString) {
-			gitInfo.Branch = strings.Trim(stringBetween(value, branchPrefix, branchSeparatorString), trimChars)
-			gitInfo.Upstream = strings.Trim(stringAfter(value, branchSeparatorString), trimChars)
+			gitInfo.Branch = strings.Trim(StringBetween(value, branchPrefix, branchSeparatorString), trimChars)
+			gitInfo.Upstream = strings.Trim(StringAfter(value, branchSeparatorString), trimChars)
 			gitInfo.Upstream = strings.Split(gitInfo.Upstream, " ")[0]
 		} else {
-			gitInfo.Branch = strings.Trim(stringAfter(value, branchPrefix), trimChars)
+			gitInfo.Branch = strings.Trim(StringAfter(value, branchPrefix), trimChars)
 		}
 
 	}
 	if strings.Contains(value, noCommits) {
-		gitInfo.Branch = stringAfter(value, noCommits)
+		gitInfo.Branch = StringAfter(value, noCommits)
 	}
 	changesMade := false
 	outputLength := len(outputLines)
@@ -198,7 +198,7 @@ func RunGitGetLastCommit(URL string, config *RootCommandConfig) (CommitInfo, err
 		return commitInfo, errors.Errorf("JSON Unmarshall error: %v", err)
 	}
 	if URL != "" {
-		commitInfo.URL = stringBefore(URL, ".git") + "/commit/" + commitInfo.SHA
+		commitInfo.URL = StringBefore(URL, ".git") + "/commit/" + commitInfo.SHA
 	}
 
 	gitLocation, gitErr := exec.Command("git", "rev-parse", "--show-toplevel").Output()

--- a/cmd/git_utils_test.go
+++ b/cmd/git_utils_test.go
@@ -1,0 +1,114 @@
+// Copyright © 2019 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cmd_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	cmd "github.com/appsody/appsody/cmd"
+	"github.com/appsody/appsody/cmd/cmdtest"
+)
+
+func TestStringBefore(t *testing.T) {
+	var StringBeforeTests = []struct {
+		testName       string
+		value          string
+		searchString   string
+		expectedOutput string
+	}{
+		{"Empty values", "", "", ""},
+		{"Non-empty values", "teststring", "string", "test"},
+	}
+	for _, testData := range StringBeforeTests {
+		// need to set testData to a new variable scoped under the for loop
+		// otherwise tests run in parallel may get the wrong testData
+		// because the for loop reassigns it before the func runs
+		tt := testData
+
+		// call t.Run so that we can name and report on individual tests
+		t.Run(tt.testName, func(t *testing.T) {
+			output := cmd.StringBefore(tt.value, tt.searchString)
+			if output != tt.expectedOutput {
+				t.Errorf("Did not get expected string output: %s", tt.expectedOutput)
+			}
+		})
+	}
+}
+
+func TestStringAfter(t *testing.T) {
+	var StringAfterTests = []struct {
+		testName       string
+		value          string
+		searchString   string
+		expectedOutput string
+	}{
+		{"Empty values", "", "", ""},
+		{"Non-empty values", "teststring", "test", "string"},
+		{"Search value is not present in string", "teststring", "stringtest", ""},
+	}
+	for _, testData := range StringAfterTests {
+		tt := testData
+
+		t.Run(tt.testName, func(t *testing.T) {
+			output := cmd.StringAfter(tt.value, tt.searchString)
+			if output != tt.expectedOutput {
+				t.Errorf("Did not get expected string output: %s", tt.expectedOutput)
+			}
+		})
+	}
+}
+
+func TestStringBetween(t *testing.T) {
+	var StringBetweenTests = []struct {
+		testName       string
+		value          string
+		preString      string
+		postString     string
+		expectedOutput string
+	}{
+		{"Empty values", "", "", "", ""},
+		{"Non-empty values", "teststring", "te", "ing", "ststr"},
+		{"Search value preString is not present in string", "teststring", "blah", "string", ""},
+		{"Search value postString is not present in string", "teststring", "test", "blah", ""},
+	}
+	for _, testData := range StringBetweenTests {
+		tt := testData
+
+		t.Run(tt.testName, func(t *testing.T) {
+			output := cmd.StringBetween(tt.value, tt.preString, tt.postString)
+			if output != tt.expectedOutput {
+				t.Errorf("Did not get expected string output: %s", tt.expectedOutput)
+			}
+		})
+	}
+}
+
+func TestGetGitInfoWithNoCommits(t *testing.T) {
+	_, cleanup := cmdtest.TestSetupWithSandbox(t, true)
+	defer cleanup()
+
+	var outBuffer bytes.Buffer
+	loggingConfig := &cmd.LoggingConfig{}
+	loggingConfig.InitLogging(&outBuffer, &outBuffer)
+	config := &cmd.RootCommandConfig{LoggingConfig: loggingConfig}
+
+	_, err := cmd.GetGitInfo(config)
+	expectedError := "does not have any commits yet"
+	if err == nil || !strings.Contains(err.Error(), expectedError) {
+		t.Errorf("Should had flagged current branch: %v", expectedError)
+	}
+}

--- a/cmd/git_utils_test.go
+++ b/cmd/git_utils_test.go
@@ -16,7 +16,6 @@ package cmd_test
 
 import (
 	"bytes"
-	"os"
 	"strings"
 	"testing"
 
@@ -106,22 +105,15 @@ func TestGetGitInfoWithNotAGitRepo(t *testing.T) {
 	loggingConfig := &cmd.LoggingConfig{}
 	loggingConfig.InitLogging(&outBuffer, &outBuffer)
 	config := &cmd.RootCommandConfig{LoggingConfig: loggingConfig}
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Error(nil)
-	}
-	err = os.Chdir(sandbox.ProjectDir)
-	if err != nil {
-		t.Error(nil)
-	}
-	_, err = cmd.GetGitInfo(config)
+
+	// Change the config ProjectDir to be in the sandboxing folder because that's where
+	// we want to execute the commands
+	config.ProjectDir = sandbox.ProjectDir
+
+	_, err := cmd.GetGitInfo(config)
 	expectedError := "not a git repository"
 	if err == nil || !strings.Contains(err.Error(), expectedError) {
 		t.Errorf("Should had flagged error: %v", expectedError)
-	}
-	err = os.Chdir(cwd)
-	if err != nil {
-		t.Error(nil)
 	}
 }
 
@@ -134,25 +126,18 @@ func TestGetGitInfoWithNoCommits(t *testing.T) {
 	loggingConfig.InitLogging(&outBuffer, &outBuffer)
 	config := &cmd.RootCommandConfig{LoggingConfig: loggingConfig}
 
-	cwd, err := os.Getwd()
-	if err != nil {
-		t.Error(nil)
-	}
-	err = os.Chdir(sandbox.ProjectDir)
-	if err != nil {
-		t.Error(nil)
-	}
+	// Change the config ProjectDir to be in the sandboxing folder because that's where
+	// we want to execute the commands
+	config.ProjectDir = sandbox.ProjectDir
+
 	_, gitErr := cmd.RunGit(loggingConfig, sandbox.ProjectDir, []string{"init"}, false)
 	if gitErr != nil {
 		t.Error(gitErr)
 	}
-	_, err = cmd.GetGitInfo(config)
+	_, err := cmd.GetGitInfo(config)
 	expectedError := "does not have any commits yet"
 	if err == nil || !strings.Contains(err.Error(), expectedError) {
 		t.Errorf("Should had flagged error: %v", expectedError)
 	}
-	err = os.Chdir(cwd)
-	if err != nil {
-		t.Error(nil)
-	}
+
 }


### PR DESCRIPTION
Bumps code coverage of `git_utils.go` from 80% to 91%
I had to capitalise some functions to export them for testing

Fixes: #717 