### PR TITLE
operator commands: Improve code coverage

### DIFF
--- a/functest/operator_install_test.go
+++ b/functest/operator_install_test.go
@@ -73,7 +73,12 @@ func TestInstallOperatorWithNamespaceAndWatchspace(t *testing.T) {
 	log := &cmd.LoggingConfig{}
 	log.InitLogging(&outBuffer, &outBuffer)
 
-	defer removeNamespace(log, "namespace-for-test-operator-install")
+	defer func() {
+		err := removeNamespace(log, "namespace-for-test-operator-install")
+		if err != nil {
+			t.Fatalf("%s", err)
+		}
+	}()
 	expectedLogs := "Appsody operator deployed to Kubernetes"
 
 	namespaceKargs := []string{"create", "namespace", "namespace-for-test-operator-install"}

--- a/functest/operator_install_test.go
+++ b/functest/operator_install_test.go
@@ -43,19 +43,12 @@ func TestOperatorInstallCases(t *testing.T) {
 			sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 			defer cleanup()
 
-			t.Log("Now running appsody init")
-			args := []string{"init", "starter"}
-			_, err := cmdtest.RunAppsody(sandbox, args...)
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			t.Log("Now running appsody operator install")
 			operatorInstallArgs := append([]string{"operator", "install"}, tt.args...)
 			output, operatorErr := cmdtest.RunAppsody(sandbox, operatorInstallArgs...)
 
 			if !strings.Contains(output, tt.expectedLogs) {
-				t.Fatalf("Expected failure to include: %s but instead receieved: %s. Full error: %s", tt.expectedLogs, output, operatorErr)
+				t.Fatalf("Expected failure to include: %s but instead received: %s. Full error: %s", tt.expectedLogs, output, operatorErr)
 			}
 		})
 	}
@@ -98,19 +91,12 @@ func TestOperatorInstallAndUninstall(t *testing.T) {
 				t.Fatal(namespaceErr)
 			}
 
-			t.Log("Now running appsody init")
-			args := []string{"init", "starter"}
-			_, err := cmdtest.RunAppsody(sandbox, args...)
-			if err != nil {
-				t.Fatal(err)
-			}
-
 			t.Log("Now running appsody operator command")
 			operatorArgs := append([]string{"operator"}, tt.args...)
 			output, operatorErr := cmdtest.RunAppsody(sandbox, operatorArgs...)
 
 			if !strings.Contains(output, tt.expectedLogs) {
-				t.Fatalf("Expected failure to include: %s but instead receieved: %s. Full error: %s", tt.expectedLogs, output, operatorErr)
+				t.Fatalf("Expected failure to include: %s but instead received: %s. Full error: %s", tt.expectedLogs, output, operatorErr)
 			}
 		})
 	}

--- a/functest/operator_install_test.go
+++ b/functest/operator_install_test.go
@@ -1,0 +1,77 @@
+// Copyright © 2020 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package functest
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	cmd "github.com/appsody/appsody/cmd"
+	cmdtest "github.com/appsody/appsody/cmd/cmdtest"
+)
+
+func TestOperatorInstallCases(t *testing.T) {
+	var operatorInstallTests = []struct {
+		testName     string
+		args         []string
+		expectedLogs string
+	}{
+		{"Install in dryrun mode", []string{"--dryrun"}, "Appsody operator deployed to Kubernetes"},
+		//{"Install with namespace and watchspace", []string{"--watchspace", "testWatchspace", "--namespace", "testNamespace"}, "Appsody operator deployed to Kubernetes"},
+		{"Install with non existing namespace", []string{"--namespace", "nonexistingnamespace"}, "namespaces \"nonexistingnamespace\" not found"},
+	}
+
+	for _, testData := range operatorInstallTests {
+		tt := testData
+
+		t.Run(tt.testName, func(t *testing.T) {
+			sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
+			defer cleanup()
+
+			var outBuffer bytes.Buffer
+			log := &cmd.LoggingConfig{}
+			log.InitLogging(&outBuffer, &outBuffer)
+
+			if tt.testName == "Install with namespace and watchspace" {
+				namespaceKargs := []string{"create", "namespace", "testNamespace"}
+				_, namespaceErr := cmd.RunKube(log, namespaceKargs, false)
+				if namespaceErr != nil {
+					t.Fatal(namespaceErr)
+				}
+
+				watchspaceKargs := []string{"create", "namespace", "testWatchspace"}
+				_, watchspaceErr := cmd.RunKube(log, watchspaceKargs, false)
+				if watchspaceErr != nil {
+					t.Fatal(watchspaceErr)
+				}
+			}
+
+			t.Log("Now running appsody init")
+			args := []string{"init", "starter"}
+			_, err := cmdtest.RunAppsody(sandbox, args...)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			t.Log("Now running appsody operator install")
+			operatorInstallArgs := append([]string{"operator", "install"}, tt.args...)
+			output, operatorErr := cmdtest.RunAppsody(sandbox, operatorInstallArgs...)
+
+			if !strings.Contains(output, tt.expectedLogs) {
+				t.Fatalf("Expected failure to include: %s but instead receieved: %s. Full error: %s", tt.expectedLogs, output, operatorErr)
+			}
+		})
+	}
+}

--- a/functest/operator_install_test.go
+++ b/functest/operator_install_test.go
@@ -29,7 +29,6 @@ func TestOperatorInstallCases(t *testing.T) {
 		args         []string
 		expectedLogs string
 	}{
-		{"Run in dryrun mode", []string{"--dryrun"}, "Appsody operator deployed to Kubernetes"},
 		{"Install with non existing namespace", []string{"--namespace", "nonexistingnamespace"}, "namespaces \"nonexistingnamespace\" not found"},
 	}
 


### PR DESCRIPTION
- These tests can only be run locally as travis currently does not support kube commands.

Fixes: #731 
Fixes: #732 
Fixes: #733 