### PR TITLE
Cleaned up some of the testing codebase

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .DEFAULT_GOAL := help
 
 #### Constant variables
-export STACKSLIST ?= incubator/nodejs
+
 # use -count=1 to disable cache and -p=1 to stream output live
 GO_TEST_COMMAND := go test -v -count=1 -p=10 -parallel 10 -covermode=count -coverprofile=cover.out -coverpkg ./cmd
 GO_TEST_LOGGING := | tee test.out | grep -E "^\s*(---|===)" ; tail -3 test.out ; awk '/--- FAIL/,/===/' test.out ; ! grep -E "(--- FAIL|^FAIL)" test.out

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #### Constant variables
 
 # use -count=1 to disable cache and -p=1 to stream output live
-GO_TEST_COMMAND := go test -v -count=1 -p=5 -parallel 5 -covermode=count -coverprofile=cover.out -coverpkg ./cmd -timeout 15m
+GO_TEST_COMMAND := go test -v -count=1 -p=2 -parallel 5 -covermode=count -coverprofile=cover.out -coverpkg ./cmd -timeout 15m
 GO_TEST_LOGGING := | tee test.out | grep -E "^\s*(---|===)" ; tail -3 test.out ; awk '/--- FAIL/,/===/' test.out ; ! grep -E "(--- FAIL|^FAIL)" test.out
 GO_TEST_COVER_VIEWER := go tool cover -func=cover.out && go tool cover -html=cover.out
 # Set a default VERSION only if it is not already set

--- a/cmd/cmdtest/testutils.go
+++ b/cmd/cmdtest/testutils.go
@@ -389,3 +389,11 @@ func Exists(path string) (bool, error) {
 	}
 	return true, err
 }
+
+func GetEnvStacksList() string {
+	stacksList := os.Getenv("STACKS_LIST")
+	if stacksList == "" {
+		stacksList = "incubator/nodejs"
+	}
+	return stacksList
+}

--- a/cmd/stack_create_test.go
+++ b/cmd/stack_create_test.go
@@ -14,7 +14,6 @@
 package cmd_test
 
 import (
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -92,17 +91,9 @@ func TestStackCreateInvalidCases(t *testing.T) {
 			if !strings.Contains(output, tt.expectedLogs) {
 				t.Errorf("Did not find expected error '%s' in output", tt.expectedLogs)
 			}
-			exists, err := cmdtest.Exists(tt.stackName)
+			_, err = cmdtest.Exists(tt.stackName)
 			if err != nil {
 				t.Fatal("Error attempting to check stack exists: ", err)
-			}
-			if exists {
-				// It SHOULDN'T exist, but it might
-				err = os.RemoveAll(tt.stackName)
-				if err != nil {
-					t.Fatal("Error attempting to remove stack: ", err)
-				}
-				t.Fatal("Stack was created despite command failing")
 			}
 		})
 	}

--- a/cmd/stack_package_test.go
+++ b/cmd/stack_package_test.go
@@ -224,343 +224,114 @@ func TestTemplatingFilePermissionsFail(t *testing.T) {
 
 }
 
-func TestPackageNoStackYamlFail(t *testing.T) {
+func TestPackageMissingFilesFail(t *testing.T) {
 
-	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
-	defer cleanup()
-
-	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
-	// folder within the temp directory that has been generated for sandboxing purposes, rather than
-	// the usual core temp directory
-	sandbox.ProjectDir = filepath.Join(sandbox.TestDataPath, "starter")
-
-	// rename stack.yaml to test
-	stackPath := sandbox.ProjectDir
-	stackYaml := filepath.Join(stackPath, "stack.yaml")
-	newStackYaml := filepath.Join(stackPath, "test")
-
-	err := os.Rename(stackYaml, newStackYaml)
-	if err != nil {
-		t.Fatal(err)
+	var targetFiles = []struct {
+		testName           string
+		target             string
+		expectedLogWindows string
+		expectedLogDefault string
+	}{
+		{"No stack.yaml", "stack.yaml", "stack.yaml: The system cannot find the file specified", "stack.yaml: no such file or directory"},
+		{"No Templates Folder", "templates", "Unable to reach templates directory. Current directory must be the root of the stack", "Unable to reach templates directory. Current directory must be the root of the stack"},
 	}
-	defer func() {
-		err = os.Rename(newStackYaml, stackYaml)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
 
-	// run stack package
-	args := []string{"stack", "package"}
-	_, err = cmdtest.RunAppsody(sandbox, args...)
+	for _, testData := range targetFiles {
 
-	if err != nil {
-		if runtime.GOOS == "windows" {
-			if !strings.Contains(err.Error(), "stack.yaml: The system cannot find the file specified") {
-				t.Errorf("String \"stack.yaml: The system cannot find the file specified\" not found in output: '%v'", err.Error())
+		tt := testData
+
+		t.Run(tt.testName, func(t *testing.T) {
+			sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
+			defer cleanup()
+
+			sandbox.ProjectDir = filepath.Join(sandbox.TestDataPath, "starter")
+
+			target := filepath.Join(sandbox.ProjectDir, tt.target)
+
+			err := os.RemoveAll(target)
+			if err != nil {
+				t.Fatal(err)
 			}
-		} else {
-			if !strings.Contains(err.Error(), "stack.yaml: no such file or directory") {
-				t.Errorf("String \"stack.yaml: no such file or directory\" not found in output: '%v'", err.Error())
+
+			// run stack package
+			args := []string{"stack", "package"}
+			_, err = cmdtest.RunAppsody(sandbox, args...)
+
+			if err != nil {
+				if runtime.GOOS == "windows" {
+					if !strings.Contains(err.Error(), tt.expectedLogWindows) {
+						t.Errorf("String \""+tt.expectedLogWindows+"\" not found in output: '%v'", err.Error())
+					}
+				} else {
+					if !strings.Contains(err.Error(), tt.expectedLogDefault) {
+						t.Errorf("String \""+tt.expectedLogDefault+"\" not found in output: '%v'", err.Error())
+					}
+				}
+			} else {
+				t.Fatal("Stack package command unexpectedly passed with no stack.yaml present")
 			}
-		}
-	} else {
-		t.Fatal("Stack package command unexpectedly passed with no stack.yaml present")
+		})
 	}
-
 }
 
-func TestPackageInvalidStackYamlFail(t *testing.T) {
-
-	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
-	defer cleanup()
-
-	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
-	// folder within the temp directory that has been generated for sandboxing purposes, rather than
-	// the usual core temp directory
-	sandbox.ProjectDir = filepath.Join(sandbox.TestDataPath, "starter")
-
-	stackPath := sandbox.ProjectDir
-	stackYaml := filepath.Join(stackPath, "stack.yaml")
-
-	// change line to be testing
-	restoreLine := ""
-	file, err := ioutil.ReadFile(stackYaml)
-	if err != nil {
-		t.Fatal(err)
+func TestInvalidStackYaml(t *testing.T) {
+	var targetLines = []struct {
+		testName        string
+		targetLine      string
+		replacementLine string
+		expectedLog     string
+	}{
+		{"Invalid default-template", "default-template", "Enrique Was Here", "Error parsing the stack.yaml file"},
+		{"Invalid custom variable", "variable1", "  ^variable1: value1", "Error creating templating mal: Variable name didn't start with alphanumeric character"},
+		{"Invalid custom varable map", "variable1", "  variable1: \n    value1: s", "cannot unmarshal !!map into string"},
+		{"Invalid version", "version:", "version: 0.1", "Error creating templating mal: Verison format incorrect"},
 	}
 
-	lines := strings.Split(string(file), "\n")
+	for _, testData := range targetLines {
 
-	for i, line := range lines {
-		if strings.Contains(line, "default-template") {
-			restoreLine = lines[i]
-			lines[i] = "Testing"
-		}
+		tt := testData
+
+		t.Run(tt.testName, func(t *testing.T) {
+
+			sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
+			defer cleanup()
+
+			sandbox.ProjectDir = filepath.Join(sandbox.TestDataPath, "starter")
+
+			yamlPath := filepath.Join(sandbox.ProjectDir, "stack.yaml")
+
+			file, err := ioutil.ReadFile(yamlPath)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			lines := strings.Split(string(file), "\n")
+
+			for i, line := range lines {
+				if strings.Contains(line, tt.targetLine) {
+					lines[i] = tt.replacementLine
+				}
+			}
+			output := strings.Join(lines, "\n")
+			err = ioutil.WriteFile(yamlPath, []byte(output), 0644)
+
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			args := []string{"stack", "package"}
+			_, err = cmdtest.RunAppsody(sandbox, args...)
+
+			if err != nil {
+				if !strings.Contains(err.Error(), tt.expectedLog) {
+					t.Errorf("String \""+tt.expectedLog+"\" not found in output: '%v'", err.Error())
+				}
+
+			} else {
+				t.Fatal("Stack package command unexpectedly passed with invalid stack.yaml")
+			}
+		})
 	}
-	output := strings.Join(lines, "\n")
-	err = ioutil.WriteFile(stackYaml, []byte(output), 0644)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// run stack package
-	args := []string{"stack", "package"}
-	_, err = cmdtest.RunAppsody(sandbox, args...)
-
-	if err != nil {
-		if !strings.Contains(err.Error(), "Error parsing the stack.yaml file") {
-			t.Errorf("String \"Error parsing the stack.yaml file\" not found in output: '%v'", err.Error())
-		}
-
-	} else {
-		t.Fatal("Stack package command unexpectedly passed with invalid stack.yaml")
-	}
-
-	for i, line := range lines {
-		if strings.Contains(line, "Testing") {
-			lines[i] = restoreLine
-		}
-	}
-
-	output = strings.Join(lines, "\n")
-	err = ioutil.WriteFile(stackYaml, []byte(output), 0644)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-}
-
-func TestPackageNoTemplates(t *testing.T) {
-
-	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
-	defer cleanup()
-
-	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
-	// folder within the temp directory that has been generated for sandboxing purposes, rather than
-	// the usual core temp directory
-	sandbox.ProjectDir = filepath.Join(sandbox.TestDataPath, "starter")
-
-	// rename templates directory to test
-	stackPath := sandbox.ProjectDir
-	templates := filepath.Join(stackPath, "templates")
-	newTemplates := filepath.Join(stackPath, "test")
-
-	err := os.Rename(templates, newTemplates)
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer func() {
-		err = os.Rename(newTemplates, templates)
-		if err != nil {
-			t.Fatal(err)
-		}
-	}()
-
-	// run stack package
-	args := []string{"stack", "package"}
-	_, err = cmdtest.RunAppsody(sandbox, args...)
-
-	if err != nil {
-		if !strings.Contains(err.Error(), "Unable to reach templates directory. Current directory must be the root of the stack") {
-			t.Errorf("String \"Unable to reach templates directory. Current directory must be the root of the stack\" not found in output: '%v'", err.Error())
-		}
-
-	} else {
-		t.Fatal("Stack package command unexpectedly passed with no templates directory present")
-	}
-
-}
-
-func TestPackageInvalidCustomVars(t *testing.T) {
-
-	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
-	defer cleanup()
-
-	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
-	// folder within the temp directory that has been generated for sandboxing purposes, rather than
-	// the usual core temp directory
-	sandbox.ProjectDir = filepath.Join(sandbox.TestDataPath, "starter")
-
-	stackPath := sandbox.ProjectDir
-	stackYaml := filepath.Join(stackPath, "stack.yaml")
-
-	// change variable to not begin with alphanumeric character
-	restoreLine := ""
-	file, err := ioutil.ReadFile(stackYaml)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	lines := strings.Split(string(file), "\n")
-
-	for i, line := range lines {
-		if strings.Contains(line, "variable1") {
-			restoreLine = lines[i]
-			lines[i] = "  ^variable1: value1"
-		}
-	}
-	output := strings.Join(lines, "\n")
-	err = ioutil.WriteFile(stackYaml, []byte(output), 0644)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// run stack package
-	args := []string{"stack", "package"}
-	_, err = cmdtest.RunAppsody(sandbox, args...)
-
-	if err != nil {
-		if !strings.Contains(err.Error(), "Error creating templating mal: Variable name didn't start with alphanumeric character") {
-			t.Errorf("String \"Error creating templating mal: Variable name didn't start with alphanumeric character\" not found in output: '%v'", err.Error())
-		}
-
-	} else {
-		t.Fatal("Stack package command unexpectedly passed with invalid stack.yaml")
-	}
-
-	for i, line := range lines {
-		if strings.Contains(line, "  ^variable1") {
-			lines[i] = restoreLine
-		}
-	}
-
-	output = strings.Join(lines, "\n")
-	err = ioutil.WriteFile(stackYaml, []byte(output), 0644)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-}
-
-func TestPackageInvalidCustomVarMap(t *testing.T) {
-
-	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
-	defer cleanup()
-
-	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
-	// folder within the temp directory that has been generated for sandboxing purposes, rather than
-	// the usual core temp directory
-	sandbox.ProjectDir = filepath.Join(sandbox.TestDataPath, "starter")
-
-	stackPath := sandbox.ProjectDir
-	stackYaml := filepath.Join(stackPath, "stack.yaml")
-
-	// use invalid formatting for map
-	restoreLine := ""
-	file, err := ioutil.ReadFile(stackYaml)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	lines := strings.Split(string(file), "\n")
-
-	for i, line := range lines {
-		if strings.Contains(line, "variable1") {
-			restoreLine = lines[i]
-			lines[i] = "  variable1: \n    value1: s"
-		}
-	}
-	output := strings.Join(lines, "\n")
-	err = ioutil.WriteFile(stackYaml, []byte(output), 0644)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// run stack package
-	args := []string{"stack", "package"}
-	_, err = cmdtest.RunAppsody(sandbox, args...)
-
-	if err != nil {
-		if !strings.Contains(err.Error(), "cannot unmarshal !!map into string") {
-			t.Errorf("String \"cannot unmarshal !!map into string\" not found in output: '%v'", err.Error())
-		}
-
-	} else {
-		t.Fatal("Stack package command unexpectedly passed with invalid stack.yaml")
-	}
-
-	for i, line := range lines {
-		if strings.Contains(line, "value1:") {
-			lines[i] = restoreLine
-		}
-	}
-
-	output = strings.Join(lines, "\n")
-	err = ioutil.WriteFile(stackYaml, []byte(output), 0644)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-}
-
-func TestPackageInvalidVersion(t *testing.T) {
-
-	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
-	defer cleanup()
-
-	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
-	// folder within the temp directory that has been generated for sandboxing purposes, rather than
-	// the usual core temp directory
-	sandbox.ProjectDir = filepath.Join(sandbox.TestDataPath, "starter")
-
-	stackPath := sandbox.ProjectDir
-	stackYaml := filepath.Join(stackPath, "stack.yaml")
-
-	// change version to only have 2 numbers
-	restoreLine := ""
-	file, err := ioutil.ReadFile(stackYaml)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	lines := strings.Split(string(file), "\n")
-
-	for i, line := range lines {
-		if strings.Contains(line, "version:") {
-			restoreLine = lines[i]
-			lines[i] = "version: 0.1"
-		}
-	}
-	output := strings.Join(lines, "\n")
-	err = ioutil.WriteFile(stackYaml, []byte(output), 0644)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// run stack package
-	args := []string{"stack", "package"}
-	_, err = cmdtest.RunAppsody(sandbox, args...)
-
-	if err != nil {
-		if !strings.Contains(err.Error(), "Error creating templating mal: Verison format incorrect") {
-			t.Errorf("String \"Error creating templating mal: Verison format incorrect\" not found in output: '%v'", err.Error())
-		}
-
-	} else {
-		t.Fatal("Stack package command unexpectedly passed with invalid stack.yaml")
-	}
-
-	for i, line := range lines {
-		if strings.Contains(line, "version:") {
-			lines[i] = restoreLine
-		}
-	}
-
-	output = strings.Join(lines, "\n")
-	err = ioutil.WriteFile(stackYaml, []byte(output), 0644)
-
-	if err != nil {
-		t.Fatal(err)
-	}
-
 }
 
 // function that returns a boolean if the file is writable or not

--- a/cmd/stack_package_test.go
+++ b/cmd/stack_package_test.go
@@ -51,8 +51,6 @@ func TestTemplatingAllVariables(t *testing.T) {
 		t.Fatalf("Error creating templating file: %v", err)
 	}
 
-	defer os.RemoveAll(templatingPath)
-
 	// write some text to file
 	_, err = file.WriteString("{{test}}, id: {{.stack.id}}, name: {{.stack.name}}, version: {{.stack.version}}, description: {{.stack.description}}, tag: {{.stack.tag}}, maintainers: {{.stack.maintainers}}, semver.major: {{.stack.semver.major}}, semver.minor: {{.stack.semver.minor}}, semver.patch: {{.stack.semver.patch}}, semver.majorminor: {{.stack.semver.majorminor}}, image.namespace: {{.stack.image.namespace}}, image.registry: {{.stack.image.registry}}, customvariable1: {{.stack.variable1}}, customvariable2: {{.stack.variable2}}")
 	if err != nil {
@@ -112,8 +110,6 @@ func TestTemplatingWrongVariablesFail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating templating file: %v", err)
 	}
-
-	defer os.RemoveAll(templatingPath)
 
 	// write some text to file
 	_, err = file.WriteString("id: {{.stack.iad}}")
@@ -179,8 +175,6 @@ func TestTemplatingFilePermissionsFail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error creating templating file: %v", err)
 	}
-
-	defer os.RemoveAll(templatingPath)
 
 	// write some text to file
 	_, err = file.WriteString("id: {{.stack.id}}")

--- a/cmd/stack_package_test.go
+++ b/cmd/stack_package_test.go
@@ -15,7 +15,6 @@
 package cmd_test
 
 import (
-	"bytes"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -236,10 +235,6 @@ func TestPackageNoStackYamlFail(t *testing.T) {
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
 
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
-
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than
 	// the usual core temp directory
@@ -285,10 +280,6 @@ func TestPackageInvalidStackYamlFail(t *testing.T) {
 
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
-
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
 
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than
@@ -353,10 +344,6 @@ func TestPackageNoTemplates(t *testing.T) {
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
 
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
-
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than
 	// the usual core temp directory
@@ -397,10 +384,6 @@ func TestPackageInvalidCustomVars(t *testing.T) {
 
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
-
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
 
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than
@@ -465,10 +448,6 @@ func TestPackageInvalidCustomVarMap(t *testing.T) {
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
 
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
-
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than
 	// the usual core temp directory
@@ -531,10 +510,6 @@ func TestPackageInvalidVersion(t *testing.T) {
 
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
-
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
 
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than

--- a/functest/build_test.go
+++ b/functest/build_test.go
@@ -40,10 +40,7 @@ type expectedDeploymentConfig struct {
 // Simple test for appsody build command. A future enhancement would be to verify the image that gets built.
 func TestBuildSimple(t *testing.T) {
 
-	// if stacksList is empty, set to the default
-	if stacksList == "" {
-		stacksList = "incubator/nodejs"
-	}
+	stacksList := cmdtest.GetEnvStacksList()
 
 	// split the appsodyStack env variable
 	stackRaw := strings.Split(stacksList, " ")
@@ -117,7 +114,7 @@ var appsodyCommitLabels = []string{
 }
 
 func TestBuildLabels(t *testing.T) {
-	stacksList = "incubator/nodejs"
+
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, false)
 	defer cleanup()
 
@@ -213,10 +210,7 @@ func deleteImage(imageName string, t *testing.T) {
 
 func TestDeploymentConfig(t *testing.T) {
 
-	// if stacksList is empty, set to the default
-	if stacksList == "" {
-		stacksList = "incubator/nodejs"
-	}
+	stacksList := cmdtest.GetEnvStacksList()
 
 	// split the appsodyStack env variable
 	stackRaw := strings.Split(stacksList, " ")
@@ -278,10 +272,7 @@ var knativeFlagTests = []struct {
 
 func TestKnativeFlagOnBuild(t *testing.T) {
 
-	// if stacksList is empty, set to the default
-	if stacksList == "" {
-		stacksList = "incubator/nodejs"
-	}
+	stacksList := cmdtest.GetEnvStacksList()
 
 	// split the appsodyStack env variable
 	stackRaw := strings.Split(stacksList, " ")

--- a/functest/build_test.go
+++ b/functest/build_test.go
@@ -40,12 +40,9 @@ type expectedDeploymentConfig struct {
 // Simple test for appsody build command. A future enhancement would be to verify the image that gets built.
 func TestBuildSimple(t *testing.T) {
 
-	t.Log("stacksList is: ", stacksList)
-
-	// if stacksList is empty there is nothing to test so return
+	// if stacksList is empty, set to the default
 	if stacksList == "" {
-		t.Log("stacksList is empty, exiting test...")
-		return
+		stacksList = "incubator/nodejs"
 	}
 
 	// split the appsodyStack env variable
@@ -121,7 +118,7 @@ var appsodyCommitLabels = []string{
 
 func TestBuildLabels(t *testing.T) {
 	stacksList = "incubator/nodejs"
-	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
+	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, false)
 	defer cleanup()
 
 	// first add the test repo index
@@ -215,12 +212,10 @@ func deleteImage(imageName string, t *testing.T) {
 }
 
 func TestDeploymentConfig(t *testing.T) {
-	t.Log("stacksList is: ", stacksList)
 
-	// if stacksList is empty there is nothing to test so return
+	// if stacksList is empty, set to the default
 	if stacksList == "" {
-		t.Log("stacksList is empty, exiting test...")
-		return
+		stacksList = "incubator/nodejs"
 	}
 
 	// split the appsodyStack env variable
@@ -282,12 +277,10 @@ var knativeFlagTests = []struct {
 }
 
 func TestKnativeFlagOnBuild(t *testing.T) {
-	t.Log("stacksList is: ", stacksList)
 
-	// if stacksList is empty there is nothing to test so return
+	// if stacksList is empty, set to the default
 	if stacksList == "" {
-		t.Log("stacksList is empty, exiting test...")
-		return
+		stacksList = "incubator/nodejs"
 	}
 
 	// split the appsodyStack env variable

--- a/functest/create_test.go
+++ b/functest/create_test.go
@@ -14,12 +14,10 @@
 package functest
 
 import (
-	"bytes"
 	"path/filepath"
 	"strings"
 	"testing"
 
-	cmd "github.com/appsody/appsody/cmd"
 	"github.com/appsody/appsody/cmd/cmdtest"
 )
 
@@ -27,10 +25,6 @@ func TestStackCreateDevLocal(t *testing.T) {
 
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
-
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
 
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than
@@ -64,10 +58,6 @@ func TestStackCreateCustomRepo(t *testing.T) {
 
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
-
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
 
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than
@@ -118,10 +108,6 @@ func TestStackCreateInvalidStackFail(t *testing.T) {
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
 
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
-
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than
 	// the usual core temp directory
@@ -148,10 +134,6 @@ func TestStackCreateInvalidURLFail(t *testing.T) {
 
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
-
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
 
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than

--- a/functest/debug_test.go
+++ b/functest/debug_test.go
@@ -25,12 +25,9 @@ import (
 // Simple test for appsody debug command. A future enhancement would be to verify the debug output
 func TestDebugSimple(t *testing.T) {
 
-	t.Log("stacksList is: ", stacksList)
-
-	// if stacksList is empty there is nothing to test so return
+	// if stacksList is empty, set to the default
 	if stacksList == "" {
-		t.Log("stacksList is empty, exiting test...")
-		return
+		stacksList = "incubator/nodejs"
 	}
 
 	// split the appsodyStack env variable
@@ -82,7 +79,7 @@ func TestDebugSimple(t *testing.T) {
 		// It will take a while for the container to spin up, so let's use docker ps to wait for it
 		t.Log("calling docker ps to wait for container")
 		containerRunning := false
-		count := 100
+		count := 50
 		for {
 			dockerOutput, dockerErr := cmdtest.RunDockerCmdExec([]string{"ps", "-q", "-f", "name=" + containerName}, t)
 			if dockerErr != nil {

--- a/functest/debug_test.go
+++ b/functest/debug_test.go
@@ -25,10 +25,7 @@ import (
 // Simple test for appsody debug command. A future enhancement would be to verify the debug output
 func TestDebugSimple(t *testing.T) {
 
-	// if stacksList is empty, set to the default
-	if stacksList == "" {
-		stacksList = "incubator/nodejs"
-	}
+	stacksList := cmdtest.GetEnvStacksList()
 
 	// split the appsodyStack env variable
 	stackRaw := strings.Split(stacksList, " ")

--- a/functest/deploy_test.go
+++ b/functest/deploy_test.go
@@ -27,10 +27,7 @@ var deployFile = "app-deploy.yaml"
 // Test parsing environment variable with stack info
 func TestParser(t *testing.T) {
 
-	// if stacksList is empty, set to the default
-	if stacksList == "" {
-		stacksList = "incubator/nodejs"
-	}
+	stacksList := cmdtest.GetEnvStacksList()
 
 	stackRaw := strings.Split(stacksList, " ")
 
@@ -46,10 +43,7 @@ func TestParser(t *testing.T) {
 // Simple test for appsody deploy command. A future enhancement would be to configure a valid deployment environment
 func TestDeploySimple(t *testing.T) {
 
-	// if stacksList is empty, set to the default
-	if stacksList == "" {
-		stacksList = "incubator/nodejs"
-	}
+	stacksList := cmdtest.GetEnvStacksList()
 
 	// split the appsodyStack env variable
 	stackRaw := strings.Split(stacksList, " ")
@@ -89,10 +83,7 @@ func TestDeploySimple(t *testing.T) {
 // Testing generation of app-deploy.yaml
 func TestGenerationDeploymentConfig(t *testing.T) {
 
-	// if stacksList is empty, set to the default
-	if stacksList == "" {
-		stacksList = "incubator/nodejs"
-	}
+	stacksList := cmdtest.GetEnvStacksList()
 
 	// split the appsodyStack env variable
 	stackRaw := strings.Split(stacksList, " ")
@@ -135,11 +126,6 @@ func TestGenerationDeploymentConfig(t *testing.T) {
 }
 
 func TestDeployNoNamespace(t *testing.T) {
-
-	// if stacksList is empty, set to the default
-	if stacksList == "" {
-		stacksList = "incubator/nodejs"
-	}
 
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()

--- a/functest/deploy_test.go
+++ b/functest/deploy_test.go
@@ -135,6 +135,12 @@ func TestGenerationDeploymentConfig(t *testing.T) {
 }
 
 func TestDeployNoNamespace(t *testing.T) {
+
+	// if stacksList is empty, set to the default
+	if stacksList == "" {
+		stacksList = "incubator/nodejs"
+	}
+
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
 

--- a/functest/deploy_test.go
+++ b/functest/deploy_test.go
@@ -27,11 +27,9 @@ var deployFile = "app-deploy.yaml"
 // Test parsing environment variable with stack info
 func TestParser(t *testing.T) {
 
-	stacksList = "incubator/nodejs"
-	t.Log("stacksList is: ", stacksList)
+	// if stacksList is empty, set to the default
 	if stacksList == "" {
-		t.Log("stacksList is empty, exiting test...")
-		return
+		stacksList = "incubator/nodejs"
 	}
 
 	stackRaw := strings.Split(stacksList, " ")
@@ -48,12 +46,9 @@ func TestParser(t *testing.T) {
 // Simple test for appsody deploy command. A future enhancement would be to configure a valid deployment environment
 func TestDeploySimple(t *testing.T) {
 
-	t.Log("stacksList is: ", stacksList)
-
-	// if stacksList is empty there is nothing to test so return
+	// if stacksList is empty, set to the default
 	if stacksList == "" {
-		t.Log("stacksList is empty, exiting test...")
-		return
+		stacksList = "incubator/nodejs"
 	}
 
 	// split the appsodyStack env variable
@@ -93,12 +88,10 @@ func TestDeploySimple(t *testing.T) {
 
 // Testing generation of app-deploy.yaml
 func TestGenerationDeploymentConfig(t *testing.T) {
-	t.Log("stacksList is: ", stacksList)
 
-	// if stacksList is empty there is nothing to test so return
+	// if stacksList is empty, set to the default
 	if stacksList == "" {
-		t.Log("stacksList is empty, exiting test...")
-		return
+		stacksList = "incubator/nodejs"
 	}
 
 	// split the appsodyStack env variable

--- a/functest/extract_test.go
+++ b/functest/extract_test.go
@@ -54,7 +54,6 @@ func TestExtract(t *testing.T) {
 
 		extractDir := parentDir + "/appsody-extract-test-extract-" + strings.ReplaceAll(stackRaw[i], "/", "_")
 
-		defer os.RemoveAll(extractDir)
 		t.Log("Created extraction dir: " + extractDir)
 
 		// appsody init inside projectDir

--- a/functest/extract_test.go
+++ b/functest/extract_test.go
@@ -38,10 +38,7 @@ func TestExtract(t *testing.T) {
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
 
-	// if stacksList is empty, set to the default
-	if stacksList == "" {
-		stacksList = "incubator/nodejs"
-	}
+	stacksList := cmdtest.GetEnvStacksList()
 
 	// split the appsodyStack env variable
 	stackRaw := strings.Split(stacksList, " ")

--- a/functest/extract_test.go
+++ b/functest/extract_test.go
@@ -38,12 +38,9 @@ func TestExtract(t *testing.T) {
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
 
-	t.Log("stacksList is: ", stacksList)
-
-	// if stacksList is empty there is nothing to test so return
+	// if stacksList is empty, set to the default
 	if stacksList == "" {
-		t.Log("stacksList is empty, exiting test...")
-		return
+		stacksList = "incubator/nodejs"
 	}
 
 	// split the appsodyStack env variable

--- a/functest/package_test.go
+++ b/functest/package_test.go
@@ -14,24 +14,18 @@
 package functest
 
 import (
-	"bytes"
 	"io/ioutil"
 	"path/filepath"
 	"runtime"
 	"strings"
 	"testing"
 
-	cmd "github.com/appsody/appsody/cmd"
 	"github.com/appsody/appsody/cmd/cmdtest"
 )
 
 func TestPackage(t *testing.T) {
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
-
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
 
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than
@@ -48,10 +42,6 @@ func TestPackage(t *testing.T) {
 func TestPackageImageTag(t *testing.T) {
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
-
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
 
 	sandbox.ProjectDir = filepath.Join(sandbox.TestDataPath, "starter")
 
@@ -76,9 +66,6 @@ func TestPackageDockerOptions(t *testing.T) {
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
 
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than
 	// the usual core temp directory
@@ -103,10 +90,6 @@ func TestPackageBuildah(t *testing.T) {
 
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
-
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
 
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than
@@ -133,10 +116,6 @@ func TestPackageBuildahWithOptions(t *testing.T) {
 
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
-
-	var outBuffer bytes.Buffer
-	log := &cmd.LoggingConfig{}
-	log.InitLogging(&outBuffer, &outBuffer)
 
 	// Because the 'starter' folder has been copied, the stack.yaml file will be in the 'starter'
 	// folder within the temp directory that has been generated for sandboxing purposes, rather than

--- a/functest/run_test.go
+++ b/functest/run_test.go
@@ -25,7 +25,7 @@ import (
 )
 
 // get the STACKSLIST environment variable
-var stacksList = os.Getenv("STACKSLIST")
+var stacksList = os.Getenv("STACKS_LIST")
 
 // Test appsody run of the nodejs-express stack and check the http://localhost:3000/health endpoint
 func TestRun(t *testing.T) {
@@ -101,12 +101,9 @@ func TestRun(t *testing.T) {
 // Simple test for appsody run command. A future enhancement would be to verify the endpoint or console output if there is no web endpoint
 func TestRunSimple(t *testing.T) {
 
-	t.Log("stacksList is: ", stacksList)
-
-	// if stacksList is empty there is nothing to test so return
+	// if stacksList is empty, set to the default
 	if stacksList == "" {
-		t.Log("stacksList is empty, exiting test...")
-		return
+		stacksList = "incubator/nodejs"
 	}
 
 	// split the appsodyStack env variable

--- a/functest/run_test.go
+++ b/functest/run_test.go
@@ -15,7 +15,6 @@ package functest
 
 import (
 	"net/http"
-	"os"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -23,9 +22,6 @@ import (
 
 	"github.com/appsody/appsody/cmd/cmdtest"
 )
-
-// get the STACKSLIST environment variable
-var stacksList = os.Getenv("STACKS_LIST")
 
 // Test appsody run of the nodejs-express stack and check the http://localhost:3000/health endpoint
 func TestRun(t *testing.T) {
@@ -101,10 +97,7 @@ func TestRun(t *testing.T) {
 // Simple test for appsody run command. A future enhancement would be to verify the endpoint or console output if there is no web endpoint
 func TestRunSimple(t *testing.T) {
 
-	// if stacksList is empty, set to the default
-	if stacksList == "" {
-		stacksList = "incubator/nodejs"
-	}
+	stacksList := cmdtest.GetEnvStacksList()
 
 	// split the appsodyStack env variable
 	stackRaw := strings.Split(stacksList, " ")

--- a/functest/test_test.go
+++ b/functest/test_test.go
@@ -27,10 +27,7 @@ import (
 // Simple test for appsody test command. A future enhancement would be to verify the test output
 func TestTestSimple(t *testing.T) {
 
-	// if stacksList is empty, set to the default
-	if stacksList == "" {
-		stacksList = "incubator/nodejs"
-	}
+	stacksList := cmdtest.GetEnvStacksList()
 
 	// split the appsodyStack env variable
 	stackRaw := strings.Split(stacksList, " ")

--- a/functest/test_test.go
+++ b/functest/test_test.go
@@ -27,12 +27,9 @@ import (
 // Simple test for appsody test command. A future enhancement would be to verify the test output
 func TestTestSimple(t *testing.T) {
 
-	t.Log("stacksList is: ", stacksList)
-
-	// if stacksList is empty there is nothing to test so return
+	// if stacksList is empty, set to the default
 	if stacksList == "" {
-		t.Log("stacksList is empty, exiting test...")
-		return
+		stacksList = "incubator/nodejs"
 	}
 
 	// split the appsodyStack env variable


### PR DESCRIPTION
* Set `stacksList` to be `incubator/nodejs` if `$STACKS_LIST` is empty, rather than skipping over the tests (in various test files) - closes #888 .

* Removed loggingConfig initialisations from cases where they are no longer necessary.

* Removed `RemoveAll()` cases from tests as they're no longer necessary due to Sandboxing.

* Changed the tests in `stack_package_test.go` to be in tables to reduce repeated code.