### PR TITLE
[WIP] Add CRIU support for appsody to create startup optimised images

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -44,6 +44,7 @@ type buildCommandConfig struct {
 	knativeFlagPresent   bool
 	namespaceFlagPresent bool
 	namespace            string
+	criu 				bool
 }
 
 //These are the current supported labels for Kubernetes,
@@ -116,6 +117,7 @@ Run this command from the root directory of your Appsody project.`,
 	buildCmd.PersistentFlags().StringVar(&config.pullURL, "pull-url", "", "Remote repository to pull image from.")
 	buildCmd.PersistentFlags().BoolVar(&config.knative, "knative", false, "Deploy as a Knative Service")
 	buildCmd.PersistentFlags().StringVarP(&config.appDeployFile, "file", "f", "app-deploy.yaml", "The file name to use for the deployment configuration.")
+	buildCmd.PersistentFlags().BoolVar(&config.criu, "criu", false, "Makes appsody to build a startup optimized image")
 
 	buildCmd.AddCommand(newBuildDeleteCmd(config))
 	buildCmd.AddCommand(newSetupCmd(config))
@@ -126,6 +128,11 @@ func build(config *buildCommandConfig) error {
 	// This needs to do:
 	// 1. appsody Extract
 	// 2. docker build -t <project name> -f Dockerfile ./extracted
+
+	if config.criu && config.Buildah {
+		return errors.New("Currently CRIU is not supported with --buildah")
+	} 
+
 	buildOptions := ""
 	if config.dockerBuildOptions != "" {
 		if config.Buildah {
@@ -156,6 +163,10 @@ func build(config *buildCommandConfig) error {
 	dockerfile := filepath.Join(extractDir, "Dockerfile")
 	buildImage := "dev.local/" + projectName //Lowercased
 
+	if config.criu {
+		buildImage = "dev.local/" + projectName + ":to-be-checkpointed"
+	}
+
 	// Regardless of pass or fail, remove the local extracted folder
 	defer os.RemoveAll(extractDir)
 
@@ -165,11 +176,11 @@ func build(config *buildCommandConfig) error {
 	}
 
 	// If a tag is specified, change the buildImage
-	if config.tag != "" {
+	if config.tag != "" && !config.criu {
 		buildImage = config.tag
 	}
 
-	if config.pushURL != "" {
+	if config.pushURL != "" && !config.criu {
 		buildImage = config.pushURL + "/" + buildImage
 	}
 
@@ -196,6 +207,10 @@ func build(config *buildCommandConfig) error {
 		cmdArgs = append(cmdArgs, "--label", label)
 	}
 
+	if config.criu {
+		cmdArgs = append(cmdArgs, "--build-arg", "APPSODY_CRIU_ENABLED=true")
+	}
+
 	cmdArgs = append(cmdArgs, "-f", dockerfile, extractDir)
 	config.Debug.log("final cmd args", cmdArgs)
 	var execError error
@@ -208,6 +223,54 @@ func build(config *buildCommandConfig) error {
 	if execError != nil {
 		return execError
 	}
+
+	if config.criu {
+		createCheckpointErr := RunToCreateCheckpoint(config.RootCommandConfig, buildImage, config.DockerLog)
+		if createCheckpointErr != nil {
+			return createCheckpointErr
+		}
+
+		waitingForCheckpointErr, successfullCheckpoint := WaitAndCheckForSuccessfulCheckpoint (config.RootCommandConfig)
+		if waitingForCheckpointErr != nil {
+			return waitingForCheckpointErr
+		}
+
+		if !successfullCheckpoint {
+			return errors.Errorf("Checkpoint creation failed")
+		}
+
+		tempImage := buildImage
+		checkpointContainerName := projectName + "-criu-checkpoint-runner"
+
+		buildImage = "dev.local/" + projectName //Lowercased
+
+		if config.tag != "" {
+			buildImage = config.tag
+		}
+	
+		if config.pushURL != "" {
+			buildImage = config.pushURL + "/" + buildImage
+		}
+
+		restorableImageCreationErr := CreateRestorableImage (config.RootCommandConfig, buildImage, config.DockerLog)
+
+		if restorableImageCreationErr != nil {
+			return restorableImageCreationErr
+		}
+
+		stopAndRemoveContErr := StopAndRemoveCriuTempContainer (config.RootCommandConfig, checkpointContainerName, config.DockerLog)
+
+		if stopAndRemoveContErr != nil {
+			return stopAndRemoveContErr
+		}
+
+		clearTempImageErr := RemoveDockerImage (config.RootCommandConfig, tempImage, config.DockerLog)
+
+		if clearTempImageErr != nil {
+			return clearTempImageErr
+		}
+	}
+
 	if config.pushURL != "" || config.push {
 		err := ImagePush(config.LoggingConfig, buildImage, config.Buildah, config.Dryrun)
 		if err != nil {

--- a/cmd/criu_commands.go
+++ b/cmd/criu_commands.go
@@ -1,0 +1,94 @@
+package cmd
+
+import (
+	"os/exec"
+	"time"
+	"strings"
+)
+
+func StopAndRemoveCriuTempContainer (config *RootCommandConfig, checkpointContainerName string, logger appsodylogger) error {
+	stoperr := StopDockerContainer(config, checkpointContainerName, logger)
+	if stoperr != nil {
+		return stoperr
+	}
+	removeerr := RemoveDockerContainer(config, checkpointContainerName, logger)
+	if removeerr != nil {
+		return removeerr
+	}
+
+	return nil 
+}
+
+func RunToCreateCheckpoint(config *RootCommandConfig, imageName string, logger appsodylogger) error {
+	projectName, perr := getProjectName(config)
+	checkpointContainerName := projectName + "-criu-checkpoint-runner"
+	if perr != nil {
+		return perr
+	}
+
+	stopAndRemoveContErr := StopAndRemoveCriuTempContainer (config, checkpointContainerName, logger)
+
+	if stopAndRemoveContErr != nil {
+		return stopAndRemoveContErr
+	}
+	
+	capabilities := []string {
+		"--cap-add AUDIT_CONTROL",
+		"--cap-add DAC_READ_SEARCH",
+        "--cap-add NET_ADMIN",
+        "--cap-add SYS_ADMIN",
+        "--cap-add SYS_PTRACE",
+        "--cap-add SYS_RESOURCE",
+	}
+	command_args := []string {"run", "-d", "--name", checkpointContainerName}
+	command_args = append(command_args, capabilities...)
+	command_args = append(command_args, imageName)
+
+	checkpointRunErr := RunDockerCommandAndWait(config, command_args, logger)
+
+	if checkpointRunErr != nil {
+		return checkpointRunErr
+	}
+
+	return nil
+}
+
+func WaitAndCheckForSuccessfulCheckpoint (config *RootCommandConfig) (error, bool) {
+	projectName, perr := getProjectName(config)
+	checkpointContainerName := projectName + "-criu-checkpoint-runner"
+
+	args := []string {"exec", "-u", "0", checkpointContainerName, "cat", "criu-log.txt"}
+	for i := 0; i < 60; i++ { // Wait for 2 mins and check for checkpoint for every 2 secs 
+		out, err := exec.Command("docker", args...).Output()
+
+		if err != nil {
+			return err, false
+		}
+
+		output := string(out[:])
+		if strings.Contains(output, "checkpoint successfull") {
+			return nil, true
+		}
+		time.Sleep(2000 * time.Millisecond)
+	}
+
+	if perr != nil {
+		return perr, false
+	}
+	return nil, false
+}
+
+func CreateRestorableImage (config *RootCommandConfig, buildImageName string, logger appsodylogger) error {
+	projectName, perr := getProjectName(config)
+	checkpointContainerName := projectName + "-criu-checkpoint-runner"
+
+	if perr != nil {
+		return perr
+	}
+	commitErr := CommitDockerContainer(config, checkpointContainerName, buildImageName, logger)
+	if commitErr != nil {
+		return commitErr
+	}
+
+	return nil
+}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -30,6 +30,7 @@ type deployCommandConfig struct {
 	knativeFlagPresent, namespaceFlagPresent                                    bool
 	dockerBuildOptions                                                          string
 	buildahBuildOptions                                                         string
+	criu																		bool
 }
 
 func findNamespaceRepositoryAndTag(image string) string {
@@ -131,6 +132,7 @@ Run this command from the root directory of your Appsody project.`,
 				buildConfig.appDeployFile = configFile
 				buildConfig.namespace = namespace
 				buildConfig.namespaceFlagPresent = config.namespaceFlagPresent
+				buildConfig.criu = config.criu
 
 				buildErr := build(buildConfig)
 				if buildErr != nil {
@@ -211,6 +213,7 @@ Run this command from the root directory of your Appsody project.`,
 	deployCmd.PersistentFlags().StringVar(&config.pullURL, "pull-url", "", "Remote repository to pull image from.")
 	deployCmd.PersistentFlags().BoolVar(&config.noOperatorCheck, "no-operator-check", false, "Do not check whether existing operators are already watching the namespace")
 	deployCmd.PersistentFlags().BoolVar(&config.noOperatorInstall, "no-operator-install", false, "Deploy your application without installing the Appsody operator")
+	deployCmd.PersistentFlags().BoolVar(&config.criu, "criu", false, "Makes appsody to deploy a startup optimized image")
 	deployCmd.AddCommand(newDeleteDeploymentCmd(config))
 
 	return deployCmd

--- a/cmd/docker_commands.go
+++ b/cmd/docker_commands.go
@@ -140,3 +140,27 @@ func RunCommandAndListen(config *RootCommandConfig, commandValue string, args []
 	}
 	return execCmd, err
 }
+
+func StopDockerContainer (config *RootCommandConfig, containerIdOrName string, logger appsodylogger) error {
+	args := []string {"stop"}
+	args = append(args, containerIdOrName)
+	return RunDockerCommandAndWait (config, args, logger)
+}
+
+func RemoveDockerContainer (config *RootCommandConfig, containerIdOrName string, logger appsodylogger) error {
+	args := []string {"rm"}
+	args = append(args, containerIdOrName)
+	return RunDockerCommandAndWait (config, args, logger)
+}
+
+func CommitDockerContainer (config *RootCommandConfig, containerIdOrName string, imageName string, logger appsodylogger) error {
+	args := []string {"commit"}
+	args = append(args, containerIdOrName, imageName)
+	return RunDockerCommandAndWait (config, args, logger)
+}
+
+func RemoveDockerImage (config *RootCommandConfig, imageIdOrName string, logger appsodylogger) error {
+	args := []string {"rmi"}
+	args = append(args, imageIdOrName)
+	return RunDockerCommandAndWait(config, args, logger)
+}


### PR DESCRIPTION
This PR is a work in progress for the CRIU support in appsody

What's `CRIU` ? 
`CRIU` (Checkpoint Restore In Userspace) is a linux tool for checkpointing (freezing) a process and writing all its content to files which were later used to restore the process to its same state where its checkpointed (frozen)

Why `CRIU` in appsody ?
As appsody takes care of the  creation, build and deployment of containerized application CRIU can add a great benefit in terms of improving startup time for the applications.

*Note: To make `CRIU` to be implemented we need [support from stack](https://github.com/bharathappali/spring-criu-stack/blob/master/image/project/java-spring-boot2-build.sh) as well (We should have a mechanism to detect if stack is suitable for CRIU.  it can be like reading the stack metadata or checking for a specific file in stack to ensure that its CRIU suitable)* 

The proposal is to make a test run for the application in build process to start and we poll for a specific trigger (that application is ready to be checkpointed) from its output/logs or wait for certain period of time (say 10-20 secs based on the runtime and application) and checkpoint the application save all its file contents (checkpointed files) and create a image from that container by commiting it and making the launch command of the image to run CRIU restore when its started.

So by this we get the benefit of faster application startup (If we consider tomcat startup it might be like bringing down from 20~40 sec to 1~3 sec)

You can get more details on CRIU from this blog by @ashu-mehra https://openliberty.io/blog/2020/02/12/faster-startup-Java-applications-criu.html 

Sample stack to try CRIU : https://github.com/bharathappali/spring-criu-stack

CRIU can be used for any runtime. currently i'm working to have a `java-spring-boot2` stack CRIU ready, Will port the changes to other stacks as well.

Note: Running the application CRIU image will need some linux capabilities. Currently I'm working on the deployment for OpenShift and kubernetes by adding a `app-criu-deploy.yml` in the stack. Will be posting the updates on issue comments and will remove the `WIP` tag in the PR when its ready for review. 

Would like to have your feedback on this proposal :)

Signed-off-by: bharathappali <bharath.appali@gmail.com>