### PR TITLE
Adding support for kubernetes part-of label

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -54,7 +54,7 @@ var supportedKubeLabels = []string{
 	"image.opencontainers.org/licenses",
 	"stack.appsody.dev/id",
 	"stack.appsody.dev/version",
-	"app.appsody.dev/name",
+	"app.kubernetes.io/part-of",
 }
 
 func checkBuildOptions(options []string) error {
@@ -280,6 +280,9 @@ func convertLabelsToKubeFormat(log *LoggingConfig, labels map[string]string) map
 
 	for key, value := range labels {
 		newKey, err := ConvertLabelToKubeFormat(key)
+		if newKey == "app.appsody.dev/name" {
+			newKey = "app.kubernetes.io/part-of"
+		}
 		if err != nil {
 			log.Debug.logf("Skipping image label \"%s\" - %v", key, err)
 		} else {

--- a/functest/build_test.go
+++ b/functest/build_test.go
@@ -415,6 +415,9 @@ func verifyImageAndConfigLabelsMatch(t *testing.T, appsodyApplication v1beta1.Ap
 
 	for key, value := range imageLabels {
 		key, err = cmd.ConvertLabelToKubeFormat(key)
+		if key == "app.appsody.dev/name" {
+			key = "app.kubernetes.io/part-of"
+		}
 		if err != nil {
 			t.Errorf("Could not convert label to Kubernetes format: %s", err)
 		}


### PR DESCRIPTION
Convert `app.appsody.dev/name` label to `app.kubernetes.io/part-of` for the Kubernetes resource.