### PR TITLE
flags: remove logs from initialising stack registry flag

### DIFF
--- a/cmd/build.go
+++ b/cmd/build.go
@@ -108,6 +108,8 @@ Run this command from the root directory of your Appsody project.`,
 			if err != nil {
 				return err
 			}
+			config.Debug.Log("Default stack registry set to: ", &rootConfig.StackRegistry)
+			config.Debug.log("Project config file set to: ", filepath.Join(projectDir, ConfigFile))
 			config.appDeployFile = filepath.Join(projectDir, config.appDeployFile)
 
 			return build(config)
@@ -248,7 +250,7 @@ func getLabels(config *RootCommandConfig) (map[string]string, error) {
 		return labels, projectConfigErr
 	}
 
-	configLabels, err := getConfigLabels(*projectConfig, ".appsody-config.yaml", config.LoggingConfig)
+	configLabels, err := getConfigLabels(*projectConfig, ConfigFile, config.LoggingConfig)
 	if err != nil {
 		return labels, err
 	}

--- a/cmd/deploy.go
+++ b/cmd/deploy.go
@@ -70,10 +70,12 @@ Run this command from the root directory of your Appsody project.`,
 			if len(args) > 0 {
 				return errors.New("Unexpected argument. Use 'appsody [command] --help' for more information about a command")
 			}
+			config.Debug.Log("Default stack registry set to: ", &config.RootCommandConfig.StackRegistry)
 			projectDir, err := getProjectDir(config.RootCommandConfig)
 			if err != nil {
 				return err
 			}
+			config.Debug.log("Project config file set to: ", filepath.Join(projectDir, ConfigFile))
 			config.knativeFlagPresent = cmd.Flag("knative").Changed
 			config.namespaceFlagPresent = cmd.Flag("namespace").Changed
 

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -20,12 +20,12 @@ import (
 	"os/exec"
 	"os/signal"
 	"os/user"
+	"path/filepath"
 	"regexp"
 	"runtime"
 	"strings"
 	"sync"
 	"syscall"
-	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -82,9 +82,9 @@ func addStackRegistryFlag(cmd *cobra.Command, flagVar *string, config *RootComma
 	stackRegistryInConfigFile, err := getStackRegistryFromConfigFile(config)
 	if err != nil {
 		if _, ok := err.(*NotAnAppsodyProject); ok {
-			
+
 		} else {
-		config.Debug.Logf("Error retrieving the stack registry from config file: %v", err)
+			config.Debug.Logf("Error retrieving the stack registry from config file: %v", err)
 		}
 		cmd.PersistentFlags().StringVar(flagVar, "stack-registry", defaultRegistry, "Specify the URL of the registry that hosts your stack images. [WARNING] Your current settings are incorrect - change your project config or use this flag to override the image registry.")
 	} else if stackRegistryInConfigFile == "" {

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -25,6 +25,7 @@ import (
 	"strings"
 	"sync"
 	"syscall"
+	"path/filepath"
 	"time"
 
 	"github.com/pkg/errors"
@@ -80,7 +81,11 @@ func addStackRegistryFlag(cmd *cobra.Command, flagVar *string, config *RootComma
 	defaultRegistry := getDefaultStackRegistry(config)
 	stackRegistryInConfigFile, err := getStackRegistryFromConfigFile(config)
 	if err != nil {
+		if _, ok := err.(*NotAnAppsodyProject); ok {
+			
+		} else {
 		config.Debug.Logf("Error retrieving the stack registry from config file: %v", err)
+		}
 		cmd.PersistentFlags().StringVar(flagVar, "stack-registry", defaultRegistry, "Specify the URL of the registry that hosts your stack images. [WARNING] Your current settings are incorrect - change your project config or use this flag to override the image registry.")
 	} else if stackRegistryInConfigFile == "" {
 		cmd.PersistentFlags().StringVar(flagVar, "stack-registry", defaultRegistry, "Specify the URL of the registry that hosts your stack images.")
@@ -114,6 +119,7 @@ func addDevCommonFlags(cmd *cobra.Command, config *devCommonConfig) {
 }
 
 func commonCmd(config *devCommonConfig, mode string) error {
+	config.Debug.Log("Default stack registry set to: ", &config.StackRegistry)
 	// Checking whether the controller is being overridden
 	overrideControllerImage := os.Getenv("APPSODY_CONTROLLER_IMAGE")
 	if overrideControllerImage == "" {
@@ -141,6 +147,7 @@ func commonCmd(config *devCommonConfig, mode string) error {
 		return perr
 
 	}
+	config.Debug.log("Project config file set to: ", filepath.Join(projectDir, ConfigFile))
 
 	projectConfig, configErr := getProjectConfig(config.RootCommandConfig)
 	if configErr != nil {

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -81,9 +81,7 @@ func addStackRegistryFlag(cmd *cobra.Command, flagVar *string, config *RootComma
 	defaultRegistry := getDefaultStackRegistry(config)
 	stackRegistryInConfigFile, err := getStackRegistryFromConfigFile(config)
 	if err != nil {
-		if _, ok := err.(*NotAnAppsodyProject); ok {
-
-		} else {
+		if _, ok := err.(*NotAnAppsodyProject); !ok {
 			config.Debug.Logf("Error retrieving the stack registry from config file: %v", err)
 		}
 		cmd.PersistentFlags().StringVar(flagVar, "stack-registry", defaultRegistry, "Specify the URL of the registry that hosts your stack images. [WARNING] Your current settings are incorrect - change your project config or use this flag to override the image registry.")

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -210,7 +210,7 @@ func initAppsody(stack string, template string, config *initCommandConfig) error
 
 		// 1. Check for empty directory
 		dir := config.ProjectDir
-		appsodyConfigFile := filepath.Join(dir, ".appsody-config.yaml")
+		appsodyConfigFile := filepath.Join(dir, ConfigFile)
 
 		_, err = os.Stat(appsodyConfigFile)
 		if err == nil {
@@ -240,6 +240,7 @@ func initAppsody(stack string, template string, config *initCommandConfig) error
 			return errors.New("non-empty directory found with files which may conflict with the template project")
 
 		}
+		config.Debug.log("Project config file set to: ", appsodyConfigFile)
 
 		reqsMap := map[string]string{
 			"Docker":  stackReqs.Docker,
@@ -427,7 +428,7 @@ func initUntar(log *LoggingConfig, file string, noTemplate bool, overwrite bool,
 					}
 				}
 			} else if header.Typeflag == tar.TypeReg {
-				if !noTemplate || (noTemplate && strings.HasSuffix(filename, ".appsody-config.yaml")) {
+				if !noTemplate || (noTemplate && strings.HasSuffix(filename, ConfigFile)) {
 
 					f, err := os.OpenFile(filename, os.O_CREATE|os.O_RDWR, os.FileMode(header.Mode))
 					if err != nil {

--- a/cmd/stack_lint.go
+++ b/cmd/stack_lint.go
@@ -158,7 +158,7 @@ Run this command from the root directory of your stack, or specify the path to y
 
 			templates, _ := ioutil.ReadDir(templatePath)
 			for _, f := range templates {
-				fileCheck, err = Exists(filepath.Join(templatePath, f.Name(), ".appsody-config.yaml"))
+				fileCheck, err = Exists(filepath.Join(templatePath, f.Name(), ConfigFile))
 				if (err != nil) && f.Name() != ".DS_Store" {
 					rootConfig.Error.log("Error attempting to determine file: ", err)
 					stackLintErrorCount++

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -384,7 +384,7 @@ The packaging process builds the stack image, generates the "tar.gz" archive fil
 				newStackStruct.Templates = append(newStackStruct.Templates, newTemplateStruct)
 
 				// create a config yaml file for the tarball
-				configYaml := filepath.Join(templatePath, templates[i], ".appsody-config.yaml")
+				configYaml := filepath.Join(templatePath, templates[i], ConfigFile)
 				log.Debug.Log("configYaml is: ", configYaml)
 
 				g, err := os.Create(configYaml)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -489,10 +489,8 @@ func getProjectName(config *RootCommandConfig) (string, error) {
 func getDefaultStackRegistry(config *RootCommandConfig) string {
 	defaultStackRegistry := config.CliConfig.Get("images").(string)
 	if defaultStackRegistry == "" {
-		config.Debug.Log("Appsody config file does not contain a default stack registry images property - setting it to docker.io")
 		defaultStackRegistry = "docker.io"
 	}
-	config.Debug.Log("Default stack registry set to: ", defaultStackRegistry)
 	return defaultStackRegistry
 }
 
@@ -585,7 +583,6 @@ func getProjectConfigFileContents(config *RootCommandConfig) (*ProjectConfig, er
 
 	v := viper.New()
 	v.SetConfigFile(appsodyConfig)
-	config.Debug.log("Project config file set to: ", appsodyConfig)
 
 	err := v.ReadInConfig()
 
@@ -610,7 +607,6 @@ func getStackRegistryFromConfigFile(config *RootCommandConfig) (string, error) {
 		// stack is in .appsody-config.yaml
 		stackElements := strings.Split(stack, "/")
 		if len(stackElements) == 3 {
-			config.Debug.Log("Stack registry detected in project config file: ", stackElements[0])
 			return stackElements[0], nil
 		}
 		if len(stackElements) < 3 {


### PR DESCRIPTION
When running an appsody command with verbose, cobra creates flags before it knows which command to run, this leads to many repeated logs. The only way (I know) to avoid this, is to avoid creating logs inside the flag initialisation and to bring them outside the `addStackRegistryFlag()` function

Fixes: #882 