### PR TITLE
Only attempt to copy tar data for regular files

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2124,18 +2124,20 @@ func Targz(log *LoggingConfig, source, target, filename string) error {
 			}
 			header, err := tar.FileInfoHeader(info, info.Name())
 			if err != nil {
-				return err
+				return errors.Wrap(err, "tar.FileInfoHeader")
 			}
+
+			log.Debug.logf("FileInfoHeader %s: %+v", info.Name(), header)
 
 			if baseDir != "" {
 				header.Name = "." + strings.TrimPrefix(path, source)
 			}
 
 			if err := tarball.WriteHeader(header); err != nil {
-				return err
+				return errors.Wrap(err, "tarball.WriteHeader")
 			}
 
-			if info.IsDir() {
+			if !info.Mode().IsRegular() {
 				return nil
 			}
 
@@ -2145,7 +2147,7 @@ func Targz(log *LoggingConfig, source, target, filename string) error {
 			}
 			defer file.Close()
 			_, err = io.Copy(tarball, file)
-			return err
+			return errors.Wrap(err, "io.Copy")
 		})
 }
 


### PR DESCRIPTION
Not only Dirs, symlinks as well don't have data to copy, and trying causes

	[Debug] source is: /home/sam/w/cloud/appsody-stacks/incubator/nodejs-kafka
	[Debug] filename is: source
	[Debug] target is: /home/sam/.appsody/stacks/dev.local/nodejs-kafka.v0.4.3.
	[Info] source archive file created at : /home/sam/.appsody/stacks/dev.local/nodejs-kafka.v0.4.3.source.tar.gz
	[Error] Error trying to tar: archive/tar: write too long

Also, wrap errors so that they can be traced to their source.