### PR TITLE
Tests for appsody stack validate

### DIFF
--- a/cmd/stack_validate_test.go
+++ b/cmd/stack_validate_test.go
@@ -1,0 +1,58 @@
+// Copyright © 2019 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package cmd_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/appsody/appsody/cmd/cmdtest"
+)
+
+func TestStackValidateNoLintFlag(t *testing.T) {
+	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
+	defer cleanup()
+	sandbox.ProjectDir = filepath.Join(sandbox.TestDataPath, "starter")
+
+	args := []string{"stack", "validate", "--no-lint"}
+	output, err := cmdtest.RunAppsody(sandbox, args...)
+	if err != nil {
+		t.Fatalf("Stack validate failed unexpectedly: %v", err)
+	}
+	if !strings.Contains(output, "Total PASSED: 5") && !strings.Contains(output, "Total FAILED: 0") {
+		t.Error("Stack validate did not have expected PASS/FAIL amounts")
+	}
+	if strings.Contains(output, "PASSED: Lint for stack") {
+		t.Error("Stack validate --no-package still ran packaging process")
+	}
+}
+
+func TestStackValidateNoPackageFlag(t *testing.T) {
+	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, false)
+	defer cleanup()
+	sandbox.ProjectDir = filepath.Join(sandbox.TestDataPath, "starter")
+
+	args := []string{"stack", "validate", "--no-package"}
+	output, err := cmdtest.RunAppsody(sandbox, args...)
+	if err != nil {
+		t.Fatalf("Stack validate failed unexpectedly: %v", err)
+	}
+	if !strings.Contains(output, "Total PASSED: 5") && !strings.Contains(output, "Total FAILED: 0") {
+		t.Error("Stack validate did not have expected PASS/FAIL amounts")
+	}
+	if strings.Contains(output, "PASSED: Package for stack") {
+		t.Error("Stack validate --no-package still ran packaging process")
+	}
+}

--- a/cmd/stack_validate_utils.go
+++ b/cmd/stack_validate_utils.go
@@ -17,11 +17,12 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
-	"log"
+	"io"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"sync"
 )
 
 // RunAppsodyCmdExec runs the appsody CLI with the given args in a new process
@@ -29,66 +30,38 @@ import (
 // args will be passed to the appsody command
 // workingDir will be the directory the command runs in
 func RunAppsodyCmdExec(args []string, workingDir string, rootConfig *RootCommandConfig) (string, error) {
-	execDir, err := os.Getwd()
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		// replace the original working directory when this function completes
-		err := os.Chdir(execDir)
-		if err != nil {
-			log.Fatal(err)
-		}
-	}()
 
-	// set the working directory
-	if err := os.Chdir(workingDir); err != nil {
-		return "", err
-	}
+	rootConfig.ProjectDir = workingDir
 
-	executable, _ := os.Executable()
-
-	cmdArgs := []string{executable}
-	if rootConfig.Verbose {
-		cmdArgs = append(cmdArgs, "-v")
-	}
-	cmdArgs = append(cmdArgs, args...)
-	fmt.Println(cmdArgs)
-
-	execCmd := exec.Command(cmdArgs[0], cmdArgs[1:]...)
-	outReader, outWriter, err := os.Pipe()
-	if err != nil {
-		return "", err
-	}
-	defer func() {
-		// Make sure to close the writer first or this will hang on Windows
-		outWriter.Close()
-		outReader.Close()
-	}()
-	execCmd.Stdout = outWriter
-	execCmd.Stderr = outWriter
-	outScanner := bufio.NewScanner(outReader)
+	// // Buffer cmd output, to be logged if there is a failure
 	var outBuffer bytes.Buffer
+	// Direct cmd console output to a buffer
+	outReader, outWriter := io.Pipe()
+
+	// copy the output to the buffer, and also to the test log
+	outScanner := bufio.NewScanner(outReader)
+	var wg sync.WaitGroup
+	wg.Add(1)
 	go func() {
 		for outScanner.Scan() {
 			out := outScanner.Bytes()
 			outBuffer.Write(out)
 			outBuffer.WriteByte('\n')
-			fmt.Println(string(out))
 		}
+		wg.Done()
 	}()
 
-	err = execCmd.Start()
+	rootConfig.Info.Log("Running appsody in the test sandbox with args: ", args)
+	err := ExecuteE("vlatest", "latest", rootConfig.ProjectDir, outWriter, outWriter, args)
 	if err != nil {
-		return "", err
+		rootConfig.Error.Log("Error returned from appsody command: ", err)
 	}
 
-	// replace the original working directory when this function completes
-	err = os.Chdir(execDir)
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = execCmd.Wait()
+	// close the writer first, so it sends an EOF to the scanner above,
+	// then wait for the scanner to finish before closing the reader
+	outWriter.Close()
+	wg.Wait()
+	outReader.Close()
 
 	return outBuffer.String(), err
 }


### PR DESCRIPTION
Fixes #747 

* Altered `RunAppsodyCmdExec` to no longer rely on `executable, _ := os.Executable()` for finding the root of the commands execution, because when the function was being called from tests, it was returning the `/usr/local/bin/go` executable rather than `appsody` - instead it now mimics the `RunAppsody` function is `testutils.go`.

* Added tests for `appsody stack validate`, which assert if the `--no-lint`, and `--no-package` flags work as intended.

    Both tests will currently use the `dev.local/appsodyvalidating-starter` docker image, which means only one can be parallel without causing errors. In order to change this, I'd have to rework the `stack validate` command itself