### PR TITLE
support multiple volumes/track projects and their volumes

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -218,6 +218,16 @@
   version = "v1.3.2"
 
 [[projects]]
+  digest = "1:9d5b5d543996dd584da1db1e0de1926f3e4c3a8dba0fa2f8db70f3ebee2342e0"
+  name = "golang.org/x/crypto"
+  packages = [
+    "bcrypt",
+    "blowfish",
+  ]
+  pruneopts = "UT"
+  revision = "78000ba7a073cafc0278790f6bce552a0f25850e"
+
+[[projects]]
   branch = "master"
   digest = "1:69ee2954e0006a4b8907ce5130a2df12195f443a7c570aa3afb98f8aae65ae7a"
   name = "golang.org/x/net"
@@ -337,6 +347,7 @@
     "github.com/spf13/cobra",
     "github.com/spf13/cobra/doc",
     "github.com/spf13/viper",
+    "golang.org/x/crypto/bcrypt",
     "gopkg.in/yaml.v2",
     "k8s.io/apimachinery/pkg/apis/meta/v1",
     "k8s.io/klog",

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -218,6 +218,7 @@
   version = "v1.3.2"
 
 [[projects]]
+  branch = "master"
   digest = "1:9d5b5d543996dd584da1db1e0de1926f3e4c3a8dba0fa2f8db70f3ebee2342e0"
   name = "golang.org/x/crypto"
   packages = [

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -32,7 +32,7 @@
 
 [[constraint]]
   name = "golang.org/x/crypto"
-  revision = "78000ba7a073cafc0278790f6bce552a0f25850e"
+  branch = "master"
 
 [[override]]
   name = "golang.org/x/sys"

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -30,6 +30,10 @@
   name = "github.com/mitchellh/go-spdx"
   version = "0.1.0"
 
+[[constraint]]
+  name = "golang.org/x/crypto"
+  revision = "78000ba7a073cafc0278790f6bce552a0f25850e"
+
 [[override]]
   name = "golang.org/x/sys"
   branch = "master"

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -90,30 +90,29 @@ func addStackRegistryFlag(cmd *cobra.Command, flagVar *string, config *RootComma
 }
 
 func addDevCommonFlags(cmd *cobra.Command, config *devCommonConfig) {
-	projectName, perr := getProjectName(config.RootCommandConfig)
-	if perr != nil {
-		if _, ok := perr.(*NotAnAppsodyProject); ok {
-			// rootConfig.Debug.log("Cannot retrieve the project name - continuing: ", perr)
-		} else {
-			config.Error.logf("Error occurred retrieving project name... exiting: %s", perr)
-			os.Exit(1)
-		}
-	}
-	defaultDepsVolume := projectName + "-deps"
 
 	addNameFlag(cmd, &config.containerName, config.RootCommandConfig)
 	addStackRegistryFlag(cmd, &config.StackRegistry, config.RootCommandConfig)
 	cmd.PersistentFlags().StringVar(&config.dockerNetwork, "network", "", "Specify the network for docker to use.")
-	cmd.PersistentFlags().StringVar(&config.depsVolumeName, "deps-volume", defaultDepsVolume, "Docker volume to use for dependencies. Mounts to APPSODY_DEPS dir.")
 	cmd.PersistentFlags().StringArrayVarP(&config.ports, "publish", "p", nil, "Publish the container's ports to the host. The stack's exposed ports will always be published, but you can publish addition ports or override the host ports with this option.")
 	cmd.PersistentFlags().BoolVarP(&config.publishAllPorts, "publish-all", "P", false, "Publish all exposed ports to random ports")
 	cmd.PersistentFlags().BoolVar(&config.disableWatcher, "no-watcher", false, "Disable file watching, regardless of container environment variable settings.")
 	cmd.PersistentFlags().BoolVarP(&config.interactive, "interactive", "i", false, "Attach STDIN to the container for interactive TTY mode")
 	cmd.PersistentFlags().StringVar(&config.dockerOptions, "docker-options", "", "Specify the docker run options to use.  Value must be in \"\". The following Docker options are not supported:  '--help','-p','--publish-all','-P','-u','-—user','-—name','-—network','-t','-—tty,'—rm','—entrypoint','-v','—volume'.")
-
 }
 
 func commonCmd(config *devCommonConfig, mode string) error {
+	id, err := getIDFromConfig(config.RootCommandConfig)
+	if err != nil {
+		return err
+	}
+	// create id if it does not exist in .appsody-config.yaml and add it to project.yaml
+	if id == "" {
+		err = generateNewProjectAndID(config.RootCommandConfig)
+		if err != nil {
+			return err
+		}
+	}
 	// Checking whether the controller is being overridden
 	overrideControllerImage := os.Getenv("APPSODY_CONTROLLER_IMAGE")
 	if overrideControllerImage == "" {
@@ -147,7 +146,7 @@ func commonCmd(config *devCommonConfig, mode string) error {
 		return configErr
 	}
 
-	err := CheckPrereqs(config.RootCommandConfig)
+	err = CheckPrereqs(config.RootCommandConfig)
 	if err != nil {
 		config.Warning.logf("Failed to check prerequisites: %v\n", err)
 	}
@@ -166,15 +165,26 @@ func commonCmd(config *devCommonConfig, mode string) error {
 	if volumeErr != nil {
 		return volumeErr
 	}
+
 	// Mount the APPSODY_DEPS cache volume if it exists
-	depsEnvVar, envErr := GetEnvVar("APPSODY_DEPS", config.RootCommandConfig)
+	depsEnvVars, envErr := getDepVolumeArgs(config.RootCommandConfig)
 	if envErr != nil {
 		return envErr
 	}
-	if depsEnvVar != "" {
-		depsMount := config.depsVolumeName + ":" + depsEnvVar
-		config.Debug.log("Adding dependency cache to volume mounts: ", depsMount)
-		volumeMaps = append(volumeMaps, "-v", depsMount)
+
+	if depsEnvVars != nil {
+		id, err = getIDFromConfig(config.RootCommandConfig)
+		if err != nil {
+			return err
+		}
+
+		var project ProjectFile
+
+		//add volumes to project entry of current Appsody project
+		volumeMaps, err = project.addDepsVolumesToProjectEntry(depsEnvVars, id, volumeMaps, config.RootCommandConfig)
+		if err != nil {
+			return err
+		}
 	}
 
 	// Mount the controller

--- a/cmd/init.go
+++ b/cmd/init.go
@@ -304,6 +304,12 @@ func initAppsody(stack string, template string, config *initCommandConfig) error
 	if err != nil {
 		return err
 	}
+
+	err = generateNewProjectAndID(config.RootCommandConfig)
+	if err != nil {
+		return err
+	}
+
 	if template == "" {
 		config.Info.logf("Successfully initialized Appsody project with the %s stack and the default template.", stack)
 	} else if template != "none" {
@@ -673,7 +679,7 @@ func defaultProjectName(config *RootCommandConfig) string {
 	}
 	return projectName
 }
+
 func addStackRegistryFlagInit(cmd *cobra.Command, flagVar *string, config *RootCommandConfig) {
 	cmd.PersistentFlags().StringVar(flagVar, "stack-registry", "", "Specify the URL of the registry that hosts your stack images.")
-
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -152,12 +152,35 @@ func setupConfig(args []string, config *RootCommandConfig) error {
 	if err != nil {
 		return err
 	}
+	// ensure project.yaml file exists
+	err = ensureProjectConfig(config)
+	if err != nil {
+		return err
+	}
 
 	checkTime(config)
 	setNewIndexURL(config)
 	setNewRepoName(config)
 	config.setupConfigRun = true
 	return nil
+}
+
+// create project.yaml if it does not exist
+func ensureProjectConfig(config *RootCommandConfig) error {
+	projectFile := getProjectYamlFile(config)
+	if _, err := os.Stat(projectFile); err != nil {
+		project := NewProjectFile()
+		if err := project.writeFile(projectFile); err != nil {
+			return errors.Errorf("Error writing %s file: %s ", projectFile, err)
+		}
+	}
+	return nil
+}
+
+func NewProjectFile() *ProjectFile {
+	return &ProjectFile{
+		Projects: []*ProjectEntry{},
+	}
 }
 
 func InitConfig(config *RootCommandConfig) error {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -70,7 +70,7 @@ type ProjectEntry struct {
 	Volumes []*Volume `yaml:"volumes,omitempty"`
 }
 type Volume struct {
-	VolumeName, VolumePath string
+	Name, Path string
 }
 
 type NotAnAppsodyProject string
@@ -2649,8 +2649,8 @@ func (p *ProjectFile) addDepsVolumesToProjectEntry(depsEnvVars []string, ID stri
 			volumeMaps = append(volumeMaps, "-v", depsMount)
 
 			var v *Volume = new(Volume)
-			v.VolumeName = volName
-			v.VolumePath = volume
+			v.Name = volName
+			v.Path = volume
 			project.Volumes = append(project.Volumes, v)
 		}
 
@@ -2659,7 +2659,7 @@ func (p *ProjectFile) addDepsVolumesToProjectEntry(depsEnvVars []string, ID stri
 		}
 	} else { // else if project entry has existing dependency volumes, loop through volumes in the current project entry, and add each volume mount to volumeMaps
 		for _, v := range project.Volumes {
-			depsMount := v.VolumeName + ":" + v.VolumePath
+			depsMount := v.Name + ":" + v.Path
 			rootConfig.Debug.log("Adding dependency cache to volume mounts: ", depsMount)
 			volumeMaps = append(volumeMaps, "-v", depsMount)
 		}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2508,8 +2508,13 @@ func generateIDHash(config *RootCommandConfig) string {
 	var password = time.Now().Format("2006-01-02 15:04:05 -0700 MST")
 	hash, _ := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
 
-	config.Debug.Logf("Successfully generated ID: %s", hex.EncodeToString(hash))
-	return hex.EncodeToString(hash)
+	id := hex.EncodeToString(hash)
+	if len(id) > 100 {
+		config.Debug.Logf("Successfully generated ID: %s", id[0:100])
+		return id[0:100]
+	}
+	config.Debug.Logf("Successfully generated ID: %s", id)
+	return id
 }
 
 // add new project entry to ~/.appsody/project.yaml

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -19,11 +19,10 @@ import (
 	"bytes"
 	"compress/gzip"
 
-	//"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 
-	//"hash"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -40,6 +39,7 @@ import (
 	"github.com/mitchellh/go-spdx"
 	"github.com/pkg/errors"
 	"github.com/spf13/viper"
+	"golang.org/x/crypto/bcrypt"
 
 	"gopkg.in/yaml.v2"
 )
@@ -60,6 +60,17 @@ type OwnerReference struct {
 	Controller         bool   `yaml:"controller"`
 	Name               string `yaml:"name"`
 	UID                string `yaml:"uid"`
+}
+type ProjectFile struct {
+	Projects []*ProjectEntry `yaml:"projects"`
+}
+type ProjectEntry struct {
+	ID      string    `yaml:"id"`
+	Path    string    `yaml:"path"`
+	Volumes []*Volume `yaml:"volumes,omitempty"`
+}
+type Volume struct {
+	VolumeName, VolumePath string
 }
 
 type NotAnAppsodyProject string
@@ -2438,4 +2449,216 @@ func generateCodewindJSON(log *LoggingConfig, indexYaml IndexYaml, indexFilePath
 
 	log.Info.logf("Succesfully generated file: %s", indexFilePath)
 	return nil
+}
+
+func getProjectYamlFile(rootConfig *RootCommandConfig) string {
+	return filepath.Join(getHome(rootConfig), "project.yaml")
+}
+
+// add a new project entry to the project.yaml file
+func (p *ProjectFile) add(pe ...*ProjectEntry) {
+	p.Projects = append(p.Projects, pe...)
+}
+
+// write to the project.yaml file
+func (p *ProjectFile) writeFile(path string) error {
+	data, err := yaml.Marshal(p)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile(path, data, 0644)
+}
+
+// check if project.yaml file had a project with given id
+func (p *ProjectFile) hasID(id string) bool {
+	for _, pf := range p.Projects {
+		if id == pf.ID {
+			return true
+		}
+	}
+	return false
+}
+
+// get project from project.yaml with given id
+func (p *ProjectFile) getProject(id string) *ProjectEntry {
+	for _, pf := range p.Projects {
+		if id == pf.ID {
+			return pf
+		}
+	}
+	return nil
+}
+
+// get all project entries from project.yaml
+func (p *ProjectFile) getProjects(rootConfig *RootCommandConfig) (*ProjectFile, error) {
+	var fileLocation = getProjectYamlFile(rootConfig)
+	projectReader, err := ioutil.ReadFile(fileLocation)
+	if err != nil {
+		return nil, err
+	}
+	err = yaml.Unmarshal(projectReader, p)
+	if err != nil {
+		return nil, errors.Errorf("Failed to parse project file %v", err)
+	}
+	return p, nil
+}
+
+// create unique project id for .appsody-config.yaml
+func generateIDHash(config *RootCommandConfig) string {
+	var password = time.Now().Format("2006-01-02 15:04:05 -0700 MST")
+	hash, _ := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
+
+	config.Debug.Logf("Successfully generated ID: %s", hex.EncodeToString(hash))
+	return hex.EncodeToString(hash)
+}
+
+// add new project entry to ~/.appsody/project.yaml
+func addNewProject(ID string, config *RootCommandConfig) error {
+	projectDir, err := getProjectDir(config)
+	if err != nil {
+		return err
+	}
+	var projectFile ProjectFile
+	fileLocation := getProjectYamlFile(config)
+
+	_, err = projectFile.getProjects(config)
+	if err != nil {
+		return err
+	}
+
+	var newEntry = ProjectEntry{
+		ID:   ID,
+		Path: projectDir,
+	}
+	projectFile.add(&newEntry)
+	err = projectFile.writeFile(fileLocation)
+	if err != nil {
+		return errors.Errorf("Failed to write file to repository location: %v", err)
+	}
+	config.Info.Logf("Successfully added your project to %s", getProjectYamlFile(config))
+	return nil
+}
+
+// get APPSODY_DEPS environment variable and split it into and array
+func getDepVolumeArgs(config *RootCommandConfig) ([]string, error) {
+	stackDeps, envErr := GetEnvVar("APPSODY_DEPS", config)
+	if envErr != nil {
+		return nil, envErr
+	}
+	if stackDeps == "" {
+		config.Warning.log("The stack image does not contain APPSODY_DEPS")
+		return nil, nil
+	}
+	volumeArgs := strings.Split(stackDeps, ";")
+	return volumeArgs, nil
+}
+
+// create unique name for APPSODY_DEPS volumes
+func generateVolumeName(config *RootCommandConfig) string {
+	projectName, perr := getProjectName(config)
+	if perr != nil {
+		if _, ok := perr.(*NotAnAppsodyProject); !ok {
+			config.Error.logf("Error occurred retrieving project name... exiting: %s", perr)
+			os.Exit(1)
+		}
+	}
+	ID := generateIDHash(config)
+	volumeName := "appsody-" + projectName + "-" + ID
+
+	if len(volumeName) > 100 {
+		config.Debug.Logf("Using docker volume name: %s", volumeName[0:100])
+		return volumeName[0:100]
+	}
+	config.Debug.Logf("Using docker volume name: %s", volumeName)
+	return volumeName
+}
+
+// save project id to .appsody-config.yaml
+func saveIDToConfig(ID string, config *RootCommandConfig) error {
+	appsodyConfig := filepath.Join(config.ProjectDir, ConfigFile)
+	v := viper.New()
+	v.SetConfigFile(appsodyConfig)
+	err := v.ReadInConfig()
+	if err != nil {
+		return err
+	}
+	v.Set("id", ID)
+	err = v.WriteConfig()
+	if err != nil {
+		return err
+	}
+
+	config.Info.log("Your Appsody project ID has been set to ", ID)
+	return nil
+}
+
+// get project id from .appsody-config.yaml
+func getIDFromConfig(config *RootCommandConfig) (string, error) {
+	appsodyConfig := filepath.Join(config.ProjectDir, ConfigFile)
+	v := viper.New()
+	v.SetConfigFile(appsodyConfig)
+	err := v.ReadInConfig()
+	if err != nil {
+		return "", err
+	}
+	id := v.GetString("id")
+	return id, nil
+}
+
+// create new project entry in ~/.appsody/project.yaml and add id to .appsody-config.yaml
+func generateNewProjectAndID(config *RootCommandConfig) error {
+	ID := generateIDHash(config)
+	addNewProject(ID, config)
+
+	err := saveIDToConfig(ID, config)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+// create docker volume names for every path in APPSODY_DEPS and put it in project.yaml
+func (p *ProjectFile) addDepsVolumesToProjectEntry(depsEnvVars []string, ID string, volumeMaps []string, rootConfig *RootCommandConfig) ([]string, error) {
+	_, err := p.getProjects(rootConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	// if id exists in .appsody-config.yaml but not in project.yaml, add a new project entry in project.yaml with that id, and get projects again
+	if !p.hasID(ID) {
+		addNewProject(ID, rootConfig)
+		_, err := p.getProjects(rootConfig)
+		if err != nil {
+			return nil, err
+		}
+	}
+	project := p.getProject(ID)
+
+	// if the project entry does not have existing dependency volumes, for every path in APPSODY_DEPS, generate a new volume name, assign it to that path, and write it to the current project entry in project.yaml
+	if project.Volumes == nil {
+		for _, volume := range depsEnvVars {
+			volName := generateVolumeName(rootConfig)
+			depsMount := volName + ":" + volume
+			rootConfig.Debug.log("Adding dependency cache to volume mounts: ", depsMount)
+			// add the volume mounts to volumeMaps
+			volumeMaps = append(volumeMaps, "-v", depsMount)
+
+			var v *Volume = new(Volume)
+			v.VolumeName = volName
+			v.VolumePath = volume
+			project.Volumes = append(project.Volumes, v)
+		}
+
+		if err := p.writeFile(getProjectYamlFile(rootConfig)); err != nil {
+			return volumeMaps, err
+		}
+	} else { // else if project entry has existing dependency volumes, loop through volumes in the current project entry, and add each volume mount to volumeMaps
+		for _, v := range project.Volumes {
+			depsMount := v.VolumeName + ":" + v.VolumePath
+			rootConfig.Debug.log("Adding dependency cache to volume mounts: ", depsMount)
+			volumeMaps = append(volumeMaps, "-v", depsMount)
+		}
+	}
+
+	return volumeMaps, nil
 }

--- a/vendor/github.com/spf13/afero/go.mod
+++ b/vendor/github.com/spf13/afero/go.mod
@@ -1,5 +1,3 @@
 module github.com/spf13/afero
 
 require golang.org/x/text v0.3.0
-
-go 1.13


### PR DESCRIPTION
 - Allows `APPSODY_DEPS` to have multiple docker volumes
- On `appsody init`, `id` will be added to `.appsody-config.yaml`, and the project's `id` and `path` will be added to `~/.appsody/project.yaml`. 
- On `appsody <run|test|debug>`, check `id` exists in `.appsody-config.yaml`. If it doesn't, `id` is added to `.appsody-config.yaml` and `~/.appsody/project.yaml`. If it exists in `.appsody-config.yaml` but not in `project.yaml`, add it to `project.yaml`. 
  - If no volume information exists in the current project entry, add it to `project,yaml` (create new volumes)
  - If volume information exists, use the docker volumes specified in the `project.yaml` (use pre-existing volumes)

Format of `~/.appsody/project.yaml`:
```
projects:
- id: 24326124303424732f6776664c31684a6d6b6c66666b415a4947675a2e796738494c54513336534a3639624b445a794c5a4e
  path: /Users/sandy.koh@ibm.com/tmp/nodejs
  volumes:
  - name: appsody-nodejs-2432612430342468796e78417a654b2e6a4946682e5642486b5a4266652f44516d2f50467258506755477
    path: /project/user-app/node_modules
  - name: appsody-nodejs-243261243034245555577a4d623638626d754867525254636a416a6d4f625344633958684b3135714e6d6
    path: /project/node_modules
```

Fixes: #934 and #938 

There is no cleanup for `~/.appsody/project.yaml` or docker volumes in this PR. https://github.com/appsody/appsody/issues/926 will be fixed in a separate PR.