### PR TITLE
Report stderr when kubectl fails

### DIFF
--- a/cmd/operator_utils.go
+++ b/cmd/operator_utils.go
@@ -55,13 +55,19 @@ func RunKube(log *LoggingConfig, kargs []string, dryrun bool) (string, error) {
 	}
 	log.Info.log("Running command: ", kcmd, " ", ArgsToString(kargs))
 	execCmd := exec.Command(kcmd, kargs...)
-	kout, kerr := execCmd.Output()
+	kout, err := execCmd.Output()
 
-	if kerr != nil {
-		return "", errors.Errorf("kubectl command failed: %s", string(kout[:]))
+	if err != nil {
+		kerr := kout
+
+		// On failure, stderr is most likely to have the diagnostics.
+		if ee, ok := err.(*exec.ExitError); ok && len(ee.Stderr) > 0 {
+			kerr = ee.Stderr
+		}
+		return "", errors.Errorf("kubectl command failed: %s", kerr)
 	}
 	log.Debug.log("Command successful...")
-	return string(kout[:]), nil
+	return string(kout), nil
 }
 
 /*


### PR DESCRIPTION
With an (inadvertent) bad config (before this):

    % appsody version; appsody operator install
    appsody 0.5.8
    Attempting to get resource from Kubernetes ...
    Running command: kubectl get deployments -o=jsonpath='{.items[?(@.metadata.name=="appsody-operator")].metadata.namespace}' -n default
    [Error] kubectl command failed:
    %

This isn't so helpful, kubectl reports useful diagnostics to stderr
(after this):

    % ./build/appsody-0.0.0-linux-amd64 operator install
    Attempting to get resource from Kubernetes ...
    Running command: kubectl get deployments "-o=jsonpath='{.items[?(@.metadata.name==\"appsody-operator\")].metadata.namespace}'" -n default
    [Error] kubectl command failed: Unable to connect to the server: x509: certificate signed by unknown authority