### PR TITLE
init: cleanup unused docker volumes

### DIFF
--- a/cmd/init.go
+++ b/cmd/init.go
@@ -300,6 +300,19 @@ func initAppsody(stack string, template string, config *initCommandConfig) error
 		return err
 	}
 
+	var p ProjectFile
+	fileLocation := getProjectYamlPath(config.RootCommandConfig)
+
+	_, err = p.GetProjects(fileLocation)
+	if err != nil {
+		return err
+	}
+
+	err = p.cleanupDockerVolumes(config.RootCommandConfig)
+	if err != nil {
+		return err
+	}
+
 	if template == "" {
 		config.Info.logf("Successfully initialized Appsody project with the %s stack and the default template.", stack)
 	} else if template != "none" {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2886,13 +2886,15 @@ func (p *ProjectFile) cleanupDockerVolumes(config *RootCommandConfig) error {
 	id := ""
 	removeVolumes := []string{"volume", "rm"}
 	for _, project := range p.Projects {
-		configPath := filepath.Join(project.Path, ".appsody-config.yaml")
-		configExists, err := Exists(configPath)
+		projectConfig := RootCommandConfig{}
+		projectConfig.ProjectDir = project.Path
+		projectConfigPath := filepath.Join(projectConfig.ProjectDir, ".appsody-config.yaml")
+		projectConfigExists, err := Exists(projectConfigPath)
 		if err != nil {
 			return err
 		}
-		if configExists {
-			id, err = GetIDFromConfig(config)
+		if projectConfigExists {
+			id, err = GetIDFromConfig(&projectConfig)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
Cleanup unused docker volumes during init.
This should be rebased on top of https://github.com/appsody/appsody/pull/946, once it goes into master.

Fixes: #926 
