### PR TITLE
[WIP] dev_common.go: allow user specified mounts

### DIFF
--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -255,7 +255,7 @@ func commonCmd(config *devCommonConfig, mode string) error {
 		if updateController {
 			config.Debug.Logf("Controller volume not found or version is latest - launching the %s image to populate it", controllerImageName)
 			downloaderArgs := []string{"--rm", "-v", controllerVolumeMount, controllerImageName}
-			controllerDownloader, err := DockerRunAndListen(config.RootCommandConfig, downloaderArgs, config.Verbose, config.Info, false)
+			controllerDownloader, err := DockerRunAndListen(config.RootCommandConfig, downloaderArgs, config.Info, false)
 			if config.Dryrun {
 				config.Info.log("Dry Run - Skipping execCmd.Wait")
 			} else {
@@ -334,6 +334,9 @@ func commonCmd(config *devCommonConfig, mode string) error {
 	}
 
 	cmdArgs = append(cmdArgs, "-t", "--entrypoint", "/.appsody/appsody-controller", platformDefinition, "--mode="+mode)
+	if config.Verbose {
+		cmdArgs = append(cmdArgs, "-v")
+	}
 	if config.disableWatcher {
 		cmdArgs = append(cmdArgs, "--no-watcher")
 	}
@@ -342,7 +345,7 @@ func commonCmd(config *devCommonConfig, mode string) error {
 	}
 	if !config.Buildah {
 		config.Debug.logf("Attempting to start image %s with container name %s", platformDefinition, config.containerName)
-		execCmd, err := DockerRunAndListen(config.RootCommandConfig, cmdArgs, config.Verbose, config.Container, config.interactive)
+		execCmd, err := DockerRunAndListen(config.RootCommandConfig, cmdArgs, config.Container, config.interactive)
 		if config.Dryrun {
 			config.Info.log("Dry Run - Skipping execCmd.Wait")
 		} else {

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -44,6 +44,8 @@ type devCommonConfig struct {
 	dockerOptions   string
 }
 
+var defaultVolumesPath = []string{"/.appsody", "/.appsody/appsody-controller"}
+
 func checkDockerRunOptions(options []string, config *RootCommandConfig) error {
 	runOptionsTest := "(^((--help)|(-p)|(--publish)|(--publish-all)|(-P)|(-u)|(--user)|(--name)|(--network)|(-t)|(--tty)|(--rm)|(--entrypoint))((=?$)|(=.*)))"
 	blackListedRunOptionsRegexp := regexp.MustCompile(runOptionsTest)
@@ -59,10 +61,43 @@ func checkDockerRunOptions(options []string, config *RootCommandConfig) error {
 			if err != nil {
 				return err
 			}
+
+			if ind+1 == len(options) {
+				return errors.Errorf("-v or --volume flag passed without associated fields. Options passed: %s", options)
+			}
+
+			userSpecifiedMount := options[ind+1]
+			userSpecifiedMountSplit := strings.Split(userSpecifiedMount, ":")
+			if len(userSpecifiedMountSplit) != 2 {
+				return errors.Errorf("User specified mount %s is not in the correct format.", userSpecifiedMount)
+			}
+			userSpecifiedMountPath := userSpecifiedMountSplit[1]
+
+			if strings.HasPrefix(userSpecifiedMountPath, "/.appsody") {
+				return errors.Errorf("User specified mount %s cannot override /.appsody folder.", userSpecifiedMount)
+			}
+
+			stackMounts, err := getStackMounts(config)
+			if err != nil {
+				return err
+			}
+
+			// Checking against mounts specified in APPSODY_MOUNTS
+			for _, mount := range stackMounts {
+				mountSplit := strings.Split(mount, ":")
+				if len(mountSplit) != 2 {
+					return errors.Errorf("Stack specified mount %s is not in the correct format.", mount)
+				}
+				mountPath := mountSplit[1]
+				if userSpecifiedMountPath == mountPath {
+					return errors.Errorf("User specified mount path %s is not allowed in --docker-options, as it interferes with the default specified mount path %s", userSpecifiedMountPath, mountPath)
+				}
+			}
+
+			// Checking against volume specified in APPSODY_DEPS which are store in the project.yaml
 			for _, volume := range project.Volumes {
-				userSpecifiedMount := options[ind+1]
-				if strings.Contains(userSpecifiedMount, volume.Path) {
-					return errors.Errorf("User specified mount %s is not allowed in --docker-options, as it interferes with the stack specified mount %s", userSpecifiedMount, volume.Path)
+				if userSpecifiedMountPath == volume.Path {
+					return errors.Errorf("User specified mount path %s is not allowed in --docker-options, as it interferes with the stack specified mount path %s", userSpecifiedMountPath, volume.Path)
 				}
 			}
 		}
@@ -108,7 +143,7 @@ func addDevCommonFlags(cmd *cobra.Command, config *devCommonConfig) {
 	cmd.PersistentFlags().BoolVarP(&config.publishAllPorts, "publish-all", "P", false, "Publish all exposed ports to random ports")
 	cmd.PersistentFlags().BoolVar(&config.disableWatcher, "no-watcher", false, "Disable file watching, regardless of container environment variable settings.")
 	cmd.PersistentFlags().BoolVarP(&config.interactive, "interactive", "i", false, "Attach STDIN to the container for interactive TTY mode")
-	cmd.PersistentFlags().StringVar(&config.dockerOptions, "docker-options", "", "Specify the docker run options to use.  Value must be in \"\". The following Docker options are not supported:  '--help','-p','--publish-all','-P','-u','-—user','-—name','-—network','-t','-—tty,'—rm','—entrypoint','-v','—volume'.")
+	cmd.PersistentFlags().StringVar(&config.dockerOptions, "docker-options", "", "Specify the docker run options to use.  Value must be in \"\". The following Docker options are not supported:  '--help','-p','--publish-all','-P','-u','-—user','-—name','-—network','-t','-—tty,'—rm','—entrypoint', '--mount'.")
 }
 
 func commonCmd(config *devCommonConfig, mode string) error {
@@ -302,7 +337,7 @@ func commonCmd(config *devCommonConfig, mode string) error {
 
 	cmdArgs = append(cmdArgs, "-t", "--entrypoint", "/.appsody/appsody-controller", platformDefinition, "--mode="+mode)
 	if config.Verbose {
-		cmdArgs = append(cmdArgs, "-v")
+		cmdArgs = append(cmdArgs, "-l debug")
 	}
 	if config.disableWatcher {
 		cmdArgs = append(cmdArgs, "--no-watcher")

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -255,7 +255,7 @@ func commonCmd(config *devCommonConfig, mode string) error {
 		if updateController {
 			config.Debug.Logf("Controller volume not found or version is latest - launching the %s image to populate it", controllerImageName)
 			downloaderArgs := []string{"--rm", "-v", controllerVolumeMount, controllerImageName}
-			controllerDownloader, err := DockerRunAndListen(config.RootCommandConfig, downloaderArgs, config.Info, false)
+			controllerDownloader, err := DockerRunAndListen(config.RootCommandConfig, downloaderArgs, config.Verbose, config.Info, false)
 			if config.Dryrun {
 				config.Info.log("Dry Run - Skipping execCmd.Wait")
 			} else {
@@ -334,9 +334,6 @@ func commonCmd(config *devCommonConfig, mode string) error {
 	}
 
 	cmdArgs = append(cmdArgs, "-t", "--entrypoint", "/.appsody/appsody-controller", platformDefinition, "--mode="+mode)
-	if config.Verbose {
-		cmdArgs = append(cmdArgs, "-l debug")
-	}
 	if config.disableWatcher {
 		cmdArgs = append(cmdArgs, "--no-watcher")
 	}
@@ -345,7 +342,7 @@ func commonCmd(config *devCommonConfig, mode string) error {
 	}
 	if !config.Buildah {
 		config.Debug.logf("Attempting to start image %s with container name %s", platformDefinition, config.containerName)
-		execCmd, err := DockerRunAndListen(config.RootCommandConfig, cmdArgs, config.Container, config.interactive)
+		execCmd, err := DockerRunAndListen(config.RootCommandConfig, cmdArgs, config.Verbose, config.Container, config.interactive)
 		if config.Dryrun {
 			config.Info.log("Dry Run - Skipping execCmd.Wait")
 		} else {

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -44,8 +44,6 @@ type devCommonConfig struct {
 	dockerOptions   string
 }
 
-var defaultVolumesPath = []string{"/.appsody", "/.appsody/appsody-controller"}
-
 func checkDockerRunOptions(options []string, config *RootCommandConfig) error {
 	runOptionsTest := "(^((--help)|(-p)|(--publish)|(--publish-all)|(-P)|(-u)|(--user)|(--name)|(--network)|(-t)|(--tty)|(--rm)|(--entrypoint))((=?$)|(=.*)))"
 	blackListedRunOptionsRegexp := regexp.MustCompile(runOptionsTest)

--- a/cmd/docker_commands.go
+++ b/cmd/docker_commands.go
@@ -10,12 +10,8 @@ import (
 
 //DockerRunAndListen runs a Docker command with arguments in args
 //This function does NOT override the image registry (uses args as is)
-func DockerRunAndListen(config *RootCommandConfig, args []string, verbose bool, logger appsodylogger, interactive bool) (*exec.Cmd, error) {
-	var runArgs = []string{}
-	if verbose {
-		runArgs = []string{"--log-level", "debug"}
-	}
-	runArgs = append(runArgs, "run")
+func DockerRunAndListen(config *RootCommandConfig, args []string, logger appsodylogger, interactive bool) (*exec.Cmd, error) {
+	var runArgs = []string{"run"}
 	runArgs = append(runArgs, args...)
 	return RunDockerCommandAndListen(config, runArgs, logger, interactive)
 }

--- a/cmd/docker_commands.go
+++ b/cmd/docker_commands.go
@@ -10,8 +10,12 @@ import (
 
 //DockerRunAndListen runs a Docker command with arguments in args
 //This function does NOT override the image registry (uses args as is)
-func DockerRunAndListen(config *RootCommandConfig, args []string, logger appsodylogger, interactive bool) (*exec.Cmd, error) {
-	var runArgs = []string{"run"}
+func DockerRunAndListen(config *RootCommandConfig, args []string, verbose bool, logger appsodylogger, interactive bool) (*exec.Cmd, error) {
+	var runArgs = []string{}
+	if verbose {
+		runArgs = []string{"--log-level", "debug"}
+	}
+	runArgs = append(runArgs, "run")
 	runArgs = append(runArgs, args...)
 	return RunDockerCommandAndListen(config, runArgs, logger, interactive)
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -282,17 +282,27 @@ func getExtractDir(config *RootCommandConfig) (string, error) {
 	return extractDir, nil
 }
 
-func getVolumeArgs(config *RootCommandConfig) ([]string, error) {
-	volumeArgs := []string{}
+func getStackMounts(config *RootCommandConfig) ([]string, error) {
+	stackMountList := []string{}
 	stackMounts, envErr := GetEnvVar("APPSODY_MOUNTS", config)
 	if envErr != nil {
 		return nil, envErr
 	}
 	if stackMounts == "" {
 		config.Warning.log("The stack image does not contain APPSODY_MOUNTS")
-		return volumeArgs, nil
+		return stackMountList, nil
 	}
-	stackMountList := strings.Split(stackMounts, ";")
+	stackMountList = strings.Split(stackMounts, ";")
+	return stackMountList, nil
+}
+
+func getVolumeArgs(config *RootCommandConfig) ([]string, error) {
+	volumeArgs := []string{}
+	stackMountList, err := getStackMounts(config)
+	if err != nil {
+		return stackMountList, err
+	}
+
 	homeDir := UserHomeDir(config.LoggingConfig)
 	homeDirOverride := os.Getenv("APPSODY_MOUNT_HOME")
 	homeDirOverridden := false

--- a/functest/docker_options_test.go
+++ b/functest/docker_options_test.go
@@ -43,8 +43,7 @@ func TestRunWithDockerOptionsRegex(t *testing.T) {
 		"-t",
 		"--tty",
 		"--rm",
-		"--entrypoint",
-		"-v", "--volume"}
+		"--entrypoint"}
 
 	for _, value := range testOptions {
 		t.Log("Option is", value)

--- a/functest/run_test.go
+++ b/functest/run_test.go
@@ -366,7 +366,7 @@ func TestRunUserSpecifiedVolumesStack(t *testing.T) {
 
 	userSpecifiedMount := "volume:/project/user-app/node_modules"
 	userSpecifiedMountSplit := strings.Split(userSpecifiedMount, ":")
-	args = []string{"run", "--docker-options", "-v " + userSpecifiedMount}
+	args = []string{"run", "--docker-options", "-v " + userSpecifiedMount, "--dryrun"}
 	output, err := cmdtest.RunAppsody(sandbox, args...)
 	if err == nil {
 		t.Fatal("Expected non-zero exit code")
@@ -392,7 +392,7 @@ func TestRunUserSpecifiedVolumesDefault(t *testing.T) {
 
 	userSpecifiedMount := "volume:/project/user-app"
 	userSpecifiedMountSplit := strings.Split(userSpecifiedMount, ":")
-	args = []string{"run", "--docker-options", "-v " + userSpecifiedMount}
+	args = []string{"run", "--docker-options", "-v " + userSpecifiedMount, "--dryrun"}
 	output, err := cmdtest.RunAppsody(sandbox, args...)
 	if err == nil {
 		t.Fatal("Expected non-zero exit code")
@@ -418,7 +418,7 @@ func TestRunUserSpecifiedVolumesSimilar(t *testing.T) {
 
 	userSpecifiedMount := "volume:/project/user-app/node_modules2"
 	userSpecifiedMountSplit := strings.Split(userSpecifiedMount, ":")
-	args = []string{"run", "--docker-options", "-v " + userSpecifiedMount}
+	args = []string{"run", "--docker-options", "-v " + userSpecifiedMount, "--dryrun"}
 	output, err := cmdtest.RunAppsody(sandbox, args...)
 	if err != nil {
 		unexpectedError := "User specified mount path " + userSpecifiedMountSplit[1] + " is not allowed in --docker-options, as it interferes with the stack specified mount path /project/user-app/node_modules2"


### PR DESCRIPTION
Allow user specified mounts in `appsody <run|debug|test> --docker-options`, but throw an error if the user mount interferes with the stack mounts
This should be rebased on top of #946, once it goes into master.

Fixes: #509 