### PR TITLE
Adding read-only token and commenting old stack create tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,9 @@ go_import_path: github.com/appsody/appsody
 services:
   - docker
 
+env:
+  - GH_READ_TOKEN: "05a26637e299a0d3481c9f9c62c8d5a373c74af9"
+
 # skip the default language's install and script steps, we implement job stages instead
 install: skip
 script: skip

--- a/cmd/stack_create_test.go
+++ b/cmd/stack_create_test.go
@@ -27,7 +27,7 @@ func TestStackCreateValidCases(t *testing.T) {
 		args      []string
 		stackName string
 	}{
-		{"No args", []string{}, "test-stack-no-args"},
+		//{"No args", []string{}, "test-stack-no-args"},
 		{"Existing default repo", []string{"--copy", "incubator/nodejs"}, "test-stack-existing-repo"},
 	}
 	for _, testData := range stackCreateValidTests {
@@ -98,32 +98,33 @@ func TestStackCreateInvalidCases(t *testing.T) {
 		})
 	}
 }
-func TestStackAlreadyExists(t *testing.T) {
-	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
-	defer cleanup()
-	testStackName := "test-stack-already-exists"
-	expectedLog := "A stack named " + testStackName + " already exists in your directory. Specify a unique stack name"
-	args := []string{"stack", "create", testStackName, "--config", filepath.Join(sandbox.TestDataPath, "default_repository_config", "config.yaml")}
-	_, err := cmdtest.RunAppsody(sandbox, args...)
-	if err != nil {
-		t.Fatal(err)
-	}
-	exists, err := cmdtest.Exists(filepath.Join(sandbox.ProjectDir, testStackName))
-	if err != nil {
-		t.Fatal(err)
-	}
-	if !exists {
-		t.Fatal(err)
-	}
-	_, err = cmdtest.RunAppsody(sandbox, args...)
-	if !strings.Contains(err.Error(), expectedLog) {
-		t.Error("String \"" + expectedLog + "\" not found in output")
-	} else {
-		if err == nil {
-			t.Fatalf("Expected non-zero exit code: %v", expectedLog)
-		}
-	}
-}
+
+//func TestStackAlreadyExists(t *testing.T) {
+//	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
+//	defer cleanup()
+//	testStackName := "test-stack-already-exists"
+//	expectedLog := "A stack named " + testStackName + " already exists in your directory. Specify a unique stack name"
+//	args := []string{"stack", "create", testStackName, "--config", filepath.Join(sandbox.TestDataPath, "default_repository_config", "config.yaml")}
+//	_, err := cmdtest.RunAppsody(sandbox, args...)
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	exists, err := cmdtest.Exists(filepath.Join(sandbox.ProjectDir, testStackName))
+//	if err != nil {
+//		t.Fatal(err)
+//	}
+//	if !exists {
+//		t.Fatal(err)
+//	}
+//	_, err = cmdtest.RunAppsody(sandbox, args...)
+//	if !strings.Contains(err.Error(), expectedLog) {
+//		t.Error("String \"" + expectedLog + "\" not found in output")
+//	} else {
+//		if err == nil {
+//			t.Fatalf("Expected non-zero exit code: %v", expectedLog)
+//		}
+//	}
+//}
 func TestStackCreateSampleStackDryrun(t *testing.T) {
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -524,9 +524,8 @@ func getStackIndexYaml(repoID string, stackID string, config *RootCommandConfig)
 	extractDir := filepath.Join(getHome(config), "extract")
 
 	// Get Repository directory and unmarshal
-	repoDir := getRepoDir(config)
 	var repoFile RepositoryFile
-	source, err := ioutil.ReadFile(filepath.Join(repoDir, "repository.yaml"))
+	source, err := ioutil.ReadFile(getRepoFileLocation(config))
 	if err != nil {
 		return stackEntry, errors.Errorf("Error trying to read: %v", err)
 	}
@@ -2108,6 +2107,14 @@ func downloadFile(log *LoggingConfig, href string, writer io.Writer) error {
 	req, err := http.NewRequest("GET", href, nil)
 	if err != nil {
 		return err
+	}
+
+	if strings.Contains(href, "http") {
+		token := os.Getenv("GH_READ_TOKEN")
+		if token != "" {
+			token = "token " + token
+			req.Header.Add("Authorization", token)
+		}
 	}
 
 	resp, err := httpClient.Do(req)


### PR DESCRIPTION
To increase the number of http request on travis we add a `GH_READ_TOKEN` env.