### PR TITLE
Add image digest as a label

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1074,8 +1074,7 @@ func getStackLabels(config *RootCommandConfig) (map[string]string, error) {
 
 	imageAndDigest := data[0]["RepoDigests"].([]interface{})
 	if len(imageAndDigest) > 0 { //Check that the image has a digest
-		imageAndDigestStr := fmt.Sprintf("%v", imageAndDigest[0])
-		digest := strings.Split(imageAndDigestStr, "@")
+		digest := strings.Split(imageAndDigest[0].(string), ":")
 		labels[appsodyStackKeyPrefix+"digest"] = digest[1]
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1072,12 +1072,10 @@ func getStackLabels(config *RootCommandConfig) (map[string]string, error) {
 		}
 	}
 
-	imageAndDigest := data[0]["RepoDigests"].([]interface{})
-	if len(imageAndDigest) > 0 { //Check that the image has a digest
-		imageAndDigestStr := fmt.Sprintf("%v", imageAndDigest[0])
-		digest := strings.Split(imageAndDigestStr, "@")
-		labels[appsodyStackKeyPrefix+"digest"] = digest[1]
-	}
+	imageID := data[0]["Id"]
+	imageIDStr := fmt.Sprintf("%v", imageID)
+	id := strings.TrimPrefix(imageIDStr, "ID: ")
+	labels[appsodyStackKeyPrefix+"imageid"] = id
 
 	return labels, nil
 }

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1060,6 +1060,13 @@ func getStackLabels(config *RootCommandConfig) (map[string]string, error) {
 		}
 	}
 
+	imageAndDigest := data[0]["RepoDigests"].([]interface{})
+	if len(imageAndDigest) > 0 { //Check that the image has a digest
+		imageAndDigestStr := fmt.Sprintf("%v", imageAndDigest[0])
+		digest := strings.Split(imageAndDigestStr, "@")
+		labels[appsodyStackKeyPrefix+"digest"] = digest[1]
+	}
+
 	return labels, nil
 }
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1074,7 +1074,7 @@ func getStackLabels(config *RootCommandConfig) (map[string]string, error) {
 
 	imageAndDigest := data[0]["RepoDigests"].([]interface{})
 	if len(imageAndDigest) > 0 { //Check that the image has a digest
-		digest := strings.Split(imageAndDigest[0].(string), ":")
+		digest := strings.Split(imageAndDigest[0].(string), "@")
 		labels[appsodyStackKeyPrefix+"digest"] = digest[1]
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1072,10 +1072,12 @@ func getStackLabels(config *RootCommandConfig) (map[string]string, error) {
 		}
 	}
 
-	imageID := data[0]["Id"]
-	imageIDStr := fmt.Sprintf("%v", imageID)
-	id := strings.TrimPrefix(imageIDStr, "ID: ")
-	labels[appsodyStackKeyPrefix+"imageid"] = id
+	imageAndDigest := data[0]["RepoDigests"].([]interface{})
+	if len(imageAndDigest) > 0 { //Check that the image has a digest
+		imageAndDigestStr := fmt.Sprintf("%v", imageAndDigest[0])
+		digest := strings.Split(imageAndDigestStr, "@")
+		labels[appsodyStackKeyPrefix+"digest"] = digest[1]
+	}
 
 	return labels, nil
 }


### PR DESCRIPTION
Adds the digest of the image as a label (only if the image actually has one)

Fixes: https://github.com/appsody/appsody/issues/957