### PR TITLE
Skip verification of server certificates

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -18,6 +18,7 @@ import (
 	"bufio"
 	"bytes"
 	"compress/gzip"
+	"crypto/tls"
 	"unicode"
 
 	"encoding/json"
@@ -2182,6 +2183,17 @@ func downloadFile(log *LoggingConfig, href string, writer io.Writer) error {
 		Proxy: http.ProxyFromEnvironment,
 	}
 	log.Debug.log("Proxy function for HTTP transport set to: ", &t.Proxy)
+
+	// set skipCertVerification to true to work with secured endpoints
+	// We will need to fully support secure endpoints (with authentication) in the future
+	// So this will need to be removed and possibly set as an external property
+	skipCertVerification := true
+
+	if skipCertVerification {
+		tlsConf := &tls.Config{InsecureSkipVerify: skipCertVerification}
+		t.TLSClientConfig = tlsConf
+	}
+
 	if runtime.GOOS == "windows" {
 		// For Windows, remove the root url. It seems to work fine with an empty string.
 		t.RegisterProtocol("file", http.NewFileTransport(http.Dir("")))


### PR DESCRIPTION
Signed-off-by: Steven Groeger <groeges@uk.ibm.com>

This PR is the first step in supporting accessing secure endpoints. 

This change will allow the index.yaml and templates to be retrieved from a secured endpoint.

The change doesn't support accessing docker images that are in a secured private registry. 
In order to access the secure private registry the use may need to do a `docker login` and / or copy yhe certificates into their local certificate store so that docker can use it.