### PR TITLE
remove personal data from stack image labels and annotations

### DIFF
--- a/cmd/git_utils.go
+++ b/cmd/git_utils.go
@@ -24,16 +24,12 @@ import (
 )
 
 type CommitInfo struct {
-	Author         string
-	AuthorEmail    string
-	Committer      string
-	CommitterEmail string
-	SHA            string
-	Date           string
-	URL            string
-	Message        string
-	contextDir     string
-	Pushed         bool
+	SHA        string
+	Date       string
+	URL        string
+	Message    string
+	contextDir string
+	Pushed     bool
 }
 
 type GitInfo struct {
@@ -289,7 +285,7 @@ func (commitInfo *CommitInfo) setURL(URL string) {
 //RunGitLog issues git log
 func RunGitGetLastCommit(config *RootCommandConfig) (CommitInfo, error) {
 	//git log -n 1 --pretty=format:"{"author":"%cn","sha":"%h","date":"%cd”,}”
-	kargs := []string{"log", "-n", "1", "--pretty=format:'{\"author\":\"%an\", \"authoremail\":\"%ae\", \"sha\":\"%H\", \"date\":\"%cd\", \"committer\":\"%cn\", \"committeremail\":\"%ce\", \"message\":\"%s\"}'"}
+	kargs := []string{"log", "-n", "1", "--pretty=format:'{\"sha\":\"%H\", \"date\":\"%cd\", \"message\":\"%s\"}'"}
 	var commitInfo CommitInfo
 	commitStringInfo, gitErr := RunGit(config.LoggingConfig, config.ProjectDir, kargs, config.Dryrun)
 	if gitErr != nil {

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -614,6 +614,16 @@ func CreateTemplateMap(labels map[string]string, stackYaml StackYaml, imageNames
 	templateMetadata["created"] = labels[ociKeyPrefix+"created"]
 	templateMetadata["tag"] = labels[appsodyStackKeyPrefix+"tag"]
 
+	var maintainers string
+	for index, maintainer := range stackYaml.Maintainers {
+		maintainers += maintainer.Name + " <" + maintainer.Email + ">"
+		if index < len(stackYaml.Maintainers)-1 {
+			maintainers += ", "
+		}
+	}
+
+	templateMetadata["maintainers"] = maintainers
+
 	// create version map and add to templateMetadata map
 	var semver = make(map[string]string)
 	semver["major"] = versionFull[0]

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -613,16 +613,7 @@ func CreateTemplateMap(labels map[string]string, stackYaml StackYaml, imageNames
 	templateMetadata["description"] = labels[ociKeyPrefix+"description"]
 	templateMetadata["created"] = labels[ociKeyPrefix+"created"]
 	templateMetadata["tag"] = labels[appsodyStackKeyPrefix+"tag"]
-
-	var maintainers string
-	for index, maintainer := range stackYaml.Maintainers {
-		maintainers += maintainer.Name + " <" + maintainer.Email + ">"
-		if index < len(stackYaml.Maintainers)-1 {
-			maintainers += ", "
-		}
-	}
-
-	templateMetadata["maintainers"] = maintainers
+	templateMetadata["maintainers"] = labels[ociKeyPrefix+"authors"]
 
 	// create version map and add to templateMetadata map
 	var semver = make(map[string]string)

--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -613,7 +613,6 @@ func CreateTemplateMap(labels map[string]string, stackYaml StackYaml, imageNames
 	templateMetadata["description"] = labels[ociKeyPrefix+"description"]
 	templateMetadata["created"] = labels[ociKeyPrefix+"created"]
 	templateMetadata["tag"] = labels[appsodyStackKeyPrefix+"tag"]
-	templateMetadata["maintainers"] = labels[ociKeyPrefix+"authors"]
 
 	// create version map and add to templateMetadata map
 	var semver = make(map[string]string)

--- a/cmd/stack_package_test.go
+++ b/cmd/stack_package_test.go
@@ -82,7 +82,7 @@ func TestTemplatingAllVariables(t *testing.T) {
 	}
 	s := string(b)
 	t.Log(s)
-	if !strings.Contains(s, "{{test}}, id: starter, name: Starter Sample, version: 0.1.1, description: Runnable starter stack, copy to create a new stack, tag: appsody/starter:SNAPSHOT, maintainers: Henry Nash <henry.nash@uk.ibm.com>, semver.major: 0, semver.minor: 1, semver.patch: 1, semver.majorminor: 0.1, image.namespace: appsody, image.registry: dev.local, customvariable1: value1, customvariable2: value2") {
+	if !strings.Contains(s, "{{test}}, id: starter, name: Starter Sample, version: 0.1.1, description: Runnable starter stack, copy to create a new stack, tag: appsody/starter:SNAPSHOT, maintainers: Henry Nash <henrynash>, semver.major: 0, semver.minor: 1, semver.patch: 1, semver.majorminor: 0.1, image.namespace: appsody, image.registry: dev.local, customvariable1: value1, customvariable2: value2") {
 		t.Fatal("Templating text did not match expected values")
 	}
 

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -931,18 +931,6 @@ func getConfigLabels(projectConfig ProjectConfig, filename string, log *LoggingC
 
 	labels[ociKeyPrefix+"created"] = t.Format(time.RFC3339)
 
-	var maintainersString string
-	for index, maintainer := range projectConfig.Maintainers {
-		maintainersString += maintainer.Name + " <" + maintainer.Email + ">"
-		if index < len(projectConfig.Maintainers)-1 {
-			maintainersString += ", "
-		}
-	}
-
-	if maintainersString != "" {
-		labels[ociKeyPrefix+"authors"] = maintainersString
-	}
-
 	if projectConfig.Version != "" {
 		if valid, err := IsValidKubernetesLabelValue(projectConfig.Version); !valid {
 			return labels, errors.Errorf("%s version value is invalid. %v", ConfigFile, err)
@@ -1009,22 +997,6 @@ func getGitLabels(config *RootCommandConfig) (map[string]string, error) {
 		if !gitInfo.Commit.Pushed {
 			labels[revisionKey] += "-not-pushed"
 		}
-	}
-
-	if commitInfo.Author != "" {
-		labels[appsodyImageCommitKeyPrefix+"author"] = commitInfo.Author
-	}
-
-	if commitInfo.AuthorEmail != "" {
-		labels[appsodyImageCommitKeyPrefix+"author"] += " <" + commitInfo.AuthorEmail + ">"
-	}
-
-	if commitInfo.Committer != "" {
-		labels[appsodyImageCommitKeyPrefix+"committer"] = commitInfo.Committer
-	}
-
-	if commitInfo.CommitterEmail != "" {
-		labels[appsodyImageCommitKeyPrefix+"committer"] += " <" + commitInfo.CommitterEmail + ">"
 	}
 
 	if commitInfo.Date != "" {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -931,6 +931,18 @@ func getConfigLabels(projectConfig ProjectConfig, filename string, log *LoggingC
 
 	labels[ociKeyPrefix+"created"] = t.Format(time.RFC3339)
 
+	var maintainersString string
+	for index, maintainer := range projectConfig.Maintainers {
+		maintainersString += maintainer.Name + " <" + maintainer.GithubID + ">"
+		if index < len(projectConfig.Maintainers)-1 {
+			maintainersString += ", "
+		}
+	}
+
+	if maintainersString != "" {
+		labels[ociKeyPrefix+"authors"] = maintainersString
+	}
+
 	if projectConfig.Version != "" {
 		if valid, err := IsValidKubernetesLabelValue(projectConfig.Version); !valid {
 			return labels, errors.Errorf("%s version value is invalid. %v", ConfigFile, err)

--- a/functest/build_test.go
+++ b/functest/build_test.go
@@ -111,7 +111,6 @@ func TestSimpleBuildCases(t *testing.T) {
 var ociPrefixKey = "org.opencontainers.image."
 var openContainerLabels = []string{
 	"created",
-	"authors",
 	"version",
 	"licenses",
 	"title",
@@ -131,8 +130,6 @@ var appsodyCommitKey = "dev.appsody.image.commit."
 var appsodyCommitLabels = []string{
 	"message",
 	"date",
-	"committer",
-	"author",
 }
 
 func TestBuildLabels(t *testing.T) {

--- a/functest/build_test.go
+++ b/functest/build_test.go
@@ -414,36 +414,79 @@ func verifyImageAndConfigLabelsMatch(t *testing.T, deploymentManifest cmd.Deploy
 			t.Errorf("Mismatch of %s annotation between built image and deployment config. Expected %s but found %s", key, value, annotation)
 		}
 	}
-
 }
 
-func TestBuildMissingTagFail(t *testing.T) {
+func TestInvalidBuild(t *testing.T) {
+
+	var knativeFlagTests = []struct {
+		testName    string
+		args        []string
+		expectedLog string
+	}{
+		{"Missing Tag ", []string{"--push"}, "Cannot specify --push or --push-url without a --tag"},
+		{"Invalid Tag with Push URL", []string{"--push-url", "i.am.not.a.real.url", "--tag", "£"}, "invalid argument \"i.am.not.a.real.url/£\" for \"-t, --tag"},
+		// Temporary expected return code, until new check is added
+		{"Invalid Push URL", []string{"--push-url", "i.am.not.a.real.url", "--tag", "notgonna/work"}, "Could not push the docker image"},
+	}
+	for _, testData := range knativeFlagTests {
+		tt := testData
+		// call t.Run so that we can name and report on individual tests
+		t.Run(tt.testName, func(t *testing.T) {
+			sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
+			defer cleanup()
+
+			// appsody init
+			t.Log("Running appsody init...")
+			_, err := cmdtest.RunAppsody(sandbox, "init", "starter")
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// set push flag to true with no tag
+			args := append([]string{"build"}, tt.args...)
+			output, err := cmdtest.RunAppsody(sandbox, args...)
+			if err != nil {
+
+				// As tag is missing, appsody verifies user input and shows error
+				if !strings.Contains(output, tt.expectedLog) {
+					t.Errorf("String \""+tt.expectedLog+"\" not found in output: %v", err)
+				}
+
+				// If an error is not returned, the test should fail
+			} else {
+				t.Error("Build with missing tag did not fail as expected")
+			}
+		})
+	}
+}
+
+func TestBuildDeploymentConfigAlreadyExists(t *testing.T) {
 
 	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, true)
 	defer cleanup()
 
-	// appsody init
 	t.Log("Running appsody init...")
 	_, err := cmdtest.RunAppsody(sandbox, "init", "starter")
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	// set push flag to true with no tag
-	args := []string{"build", "--push"}
+	configFile := filepath.Join(sandbox.ProjectDir, "app-deploy.yaml")
+	err = ioutil.WriteFile(configFile, []byte("Created for testing"), 0755)
+	if err != nil {
+		fmt.Printf("Unable to write file: %v", err)
+	}
+
+	args := []string{"build"}
 	output, err := cmdtest.RunAppsody(sandbox, args...)
 	if err != nil {
 
-		// As tag is missing, appsody verifies user input and shows error
-		if !strings.Contains(output, "Cannot specify --push or --push-url without a --tag") {
-			t.Errorf("String \"Cannot specify --push or --push-url without a --tag\" not found in output: %v", err)
+		if !strings.Contains(output, "Found existing deployment manifest "+configFile) {
+			t.Errorf("String \"Found existing deployment manifest "+configFile+"\" not found in output: %v", err)
 		}
-
-		// If an error is not returned, the test should fail
 	} else {
 		t.Error("Build with missing tag did not fail as expected")
 	}
-
 }
 
 func TestOpenLibertyDeploymentConfig(t *testing.T) {

--- a/functest/stack_package_test.go
+++ b/functest/stack_package_test.go
@@ -1,0 +1,69 @@
+// Copyright © 2019 IBM Corporation and others.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package functest
+
+import (
+	"encoding/json"
+	"path/filepath"
+	"testing"
+
+	"github.com/appsody/appsody/cmd/cmdtest"
+)
+
+var packageStackLabels = []string{
+	"id",
+	"tag",
+}
+
+func TestStackPackageLabels(t *testing.T) {
+	sandbox, cleanup := cmdtest.TestSetupWithSandbox(t, false)
+	defer cleanup()
+
+	sandbox.ProjectDir = filepath.Join(sandbox.TestDataPath, "starter")
+	_, err := cmdtest.RunAppsody(sandbox, "stack", "package")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	image := "dev.local/appsody/starter:latest"
+	inspectOutput, inspectErr := cmdtest.RunCmdExec("docker", []string{"inspect", image}, t)
+	if inspectErr != nil {
+		t.Fatal(inspectErr)
+	}
+
+	var inspect []map[string]interface{}
+
+	err = json.Unmarshal([]byte(inspectOutput), &inspect)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	config := inspect[0]["Config"].(map[string]interface{})
+	labelsMap := config["Labels"].(map[string]interface{})
+
+	for _, label := range packageStackLabels {
+		if labelsMap[appsodyPrefixKey+label] == nil {
+			t.Errorf("Could not find %s%s label in Docker image!", appsodyPrefixKey, label)
+		}
+	}
+
+	for _, label := range openContainerLabels {
+		if labelsMap[ociPrefixKey+label] == nil {
+			t.Errorf("Could not find %s%s label in Docker image!", ociPrefixKey, label)
+		}
+	}
+
+	//delete the image
+	deleteImage(image, "docker", t)
+}

--- a/functest/stack_package_test.go
+++ b/functest/stack_package_test.go
@@ -58,7 +58,7 @@ func TestStackPackageLabels(t *testing.T) {
 		}
 	}
 
-	for _, label := range openContainerLabels {
+	for _, label := range append(openContainerLabels, "authors") {
 		if labelsMap[ociPrefixKey+label] == nil {
 			t.Errorf("Could not find %s%s label in Docker image!", ociPrefixKey, label)
 		}


### PR DESCRIPTION
Pair programmed with @CameronMcWilliam!

Removed the following labels/annotations being added to the stack image/`app-deploy.yaml`:
- `dev.appsody.image.commit.author` 
- `dev.appsody.image.commit.committer`
- `dev.appsody.stack.authors`
- `dev.appsody.stack.commit.author`
- `dev.appsody.stack.commit.committer`
-  `org.opencontainers.image.authors`

Fixes: #987 