### PR TITLE
indicate a deprecated stack in the generated codewind index

### DIFF
--- a/cmd/stack_package.go
+++ b/cmd/stack_package.go
@@ -92,6 +92,7 @@ type IndexJSONStack struct {
 	ProjectStyle string `json:"projectStyle"`
 	Location     string `json:"location"`
 	Links        Link   `json:"links"`
+	Deprecated   string `json:"deprecated,omitempty"`
 }
 
 type Link struct {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2628,7 +2628,7 @@ func generateCodewindJSON(log *LoggingConfig, indexYaml IndexYaml, indexFilePath
 			stackJSON := IndexJSONStack{}
 			if stack.Deprecated != "" {
 				stackJSON.DisplayName = "[Deprecated] "
-				stackJSON.Deprecated = "true"
+				stackJSON.Deprecated = stack.Deprecated
 			}
 
 			stackJSON.DisplayName = stackJSON.DisplayName + prefixName + " " + stack.Name + " " + template.ID + " template"

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2626,7 +2626,12 @@ func generateCodewindJSON(log *LoggingConfig, indexYaml IndexYaml, indexFilePath
 	for _, stack := range indexYaml.Stacks {
 		for _, template := range stack.Templates {
 			stackJSON := IndexJSONStack{}
-			stackJSON.DisplayName = prefixName + " " + stack.Name + " " + template.ID + " template"
+			if stack.Deprecated != "" {
+				stackJSON.DisplayName = "[Deprecated] "
+				stackJSON.Deprecated = "true"
+			}
+
+			stackJSON.DisplayName = stackJSON.DisplayName + prefixName + " " + stack.Name + " " + template.ID + " template"
 			stackJSON.Description = stack.Description
 			stackJSON.Language = stack.Language
 			stackJSON.ProjectType = "appsodyExtension"


### PR DESCRIPTION
Indicate this by appending a new field `deprecated: reason` and prepending `[Deprecated] ` to the displayName field in the Codewind json if the stack is deprecated
Sample `appsody stack package` output: 
```
{
		"displayName": "[Deprecated] Local Node.js simple template",
		"description": "Runtime for Node.js applications",
		"language": "nodejs",
		"projectType": "appsodyExtension",
		"projectStyle": "Appsody",
		"location": "file:///Users/sandy.koh@ibm.com/.appsody/stacks/dev.local/nodejs.v0.3.5.templates.simple.tar.gz",
		"links": {
			"self": "/devfiles/nodejs/devfile.yaml"
		},
		"deprecated": "65/65/65 - for some reason"
	}
```

Fixes: #983 