### PR TITLE
Don't expose debug port when running in k8s

### DIFF
--- a/cmd/cmdtest/testutils.go
+++ b/cmd/cmdtest/testutils.go
@@ -27,7 +27,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/appsody/appsody/cmd"
+	cmd "github.com/appsody/appsody/cmd"
 	"gopkg.in/yaml.v2"
 )
 
@@ -49,14 +49,6 @@ type TestSandbox struct {
 	Verbose      bool
 }
 
-func inArray(haystack []string, needle string) bool {
-	for _, value := range haystack {
-		if needle == value {
-			return true
-		}
-	}
-	return false
-}
 func TestSetup(t *testing.T, parallel bool) {
 	if parallel {
 		t.Parallel()
@@ -185,12 +177,11 @@ func (s *TestSandbox) SetConfigInTestData(pathUnderTestdata string) {
 // The stdout and stderr are captured, printed and returned
 // args will be passed to the appsody command
 func RunAppsody(t *TestSandbox, args ...string) (string, error) {
-
-	if t.Verbose && !(inArray(args, "-v") || inArray(args, "--verbose")) {
+	if t.Verbose && !(cmd.InArray(args, "-v") || cmd.InArray(args, "--verbose")) {
 		args = append(args, "-v")
 	}
 
-	if !inArray(args, "--config") {
+	if !cmd.InArray(args, "--config") {
 		// Set appsody args to use custom home directory.
 		args = append(args, "--config", t.ConfigFile)
 	}

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -379,9 +379,12 @@ func commonCmd(config *devCommonConfig, mode string) error {
 			return portsErr
 		}
 
-		debugPort, debugPortErr := GetEnvVar("APPSODY_DEBUG_PORT", config.RootCommandConfig)
-		if debugPortErr != nil || debugPort == "" {
+		var debugPortArray []string
+		debugPorts, debugPortErr := GetEnvVar("APPSODY_DEBUG_PORT", config.RootCommandConfig)
+		if debugPortErr != nil || debugPorts == "" {
 			config.Debug.log("No debug port found. Continuing...")
+		} else {
+			debugPortArray = strings.Split(debugPorts, " ")
 		}
 
 		projectDir, err := getProjectDir(config.RootCommandConfig)
@@ -402,7 +405,7 @@ func commonCmd(config *devCommonConfig, mode string) error {
 			return err
 		}
 		config.Debug.Logf("Docker env vars extracted from docker options: %v", dockerEnvVars)
-		deploymentYaml, err := GenDeploymentYaml(config.LoggingConfig, config.containerName, platformDefinition, controllerImageName, portList, debugPort, projectDir, dockerMounts, dockerEnvVars, depsMount, dryrun)
+		deploymentYaml, err := GenDeploymentYaml(config.LoggingConfig, config.containerName, platformDefinition, controllerImageName, portList, debugPortArray, projectDir, dockerMounts, dockerEnvVars, depsMount, dryrun)
 		if err != nil {
 			return err
 		}
@@ -413,7 +416,7 @@ func commonCmd(config *devCommonConfig, mode string) error {
 		if err != nil {
 			return err
 		}
-		serviceYaml, err := GenServiceYaml(config.LoggingConfig, config.containerName, portList, debugPort, projectDir, dryrun)
+		serviceYaml, err := GenServiceYaml(config.LoggingConfig, config.containerName, portList, debugPortArray, projectDir, dryrun)
 		if err != nil {
 			return err
 		}

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -379,6 +379,11 @@ func commonCmd(config *devCommonConfig, mode string) error {
 			return portsErr
 		}
 
+		debugPort, debugPortErr := GetEnvVar("APPSODY_DEBUG_PORT", config.RootCommandConfig)
+		if debugPortErr != nil || debugPort == "" {
+			config.Debug.log("No debug port found. Continuing...")
+		}
+
 		projectDir, err := getProjectDir(config.RootCommandConfig)
 		if err != nil {
 			return err
@@ -397,7 +402,7 @@ func commonCmd(config *devCommonConfig, mode string) error {
 			return err
 		}
 		config.Debug.Logf("Docker env vars extracted from docker options: %v", dockerEnvVars)
-		deploymentYaml, err := GenDeploymentYaml(config.LoggingConfig, config.containerName, platformDefinition, controllerImageName, portList, projectDir, dockerMounts, dockerEnvVars, depsMount, dryrun)
+		deploymentYaml, err := GenDeploymentYaml(config.LoggingConfig, config.containerName, platformDefinition, controllerImageName, portList, debugPort, projectDir, dockerMounts, dockerEnvVars, depsMount, dryrun)
 		if err != nil {
 			return err
 		}
@@ -408,7 +413,7 @@ func commonCmd(config *devCommonConfig, mode string) error {
 		if err != nil {
 			return err
 		}
-		serviceYaml, err := GenServiceYaml(config.LoggingConfig, config.containerName, portList, projectDir, dryrun)
+		serviceYaml, err := GenServiceYaml(config.LoggingConfig, config.containerName, portList, debugPort, projectDir, dryrun)
 		if err != nil {
 			return err
 		}

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -384,7 +384,13 @@ func commonCmd(config *devCommonConfig, mode string) error {
 		if debugPortErr != nil || debugPorts == "" {
 			config.Debug.log("No debug port found. Continuing...")
 		} else {
-			debugPortArray = strings.Split(debugPorts, " ")
+			debugPortArray = strings.Split(debugPorts, " ") //Split the string if multiple debug ports exist
+			for _, debugPort := range debugPortArray {
+				debugPortExists := FindElement(portList, debugPort) //Determine whether all ports specified in env var have actually been exposed
+				if !debugPortExists {
+					return errors.Errorf("Port: %s specified in APPSODY_DEBUG_PORT could not be found in ports list", debugPort)
+				}
+			}
 		}
 
 		projectDir, err := getProjectDir(config.RootCommandConfig)

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -379,11 +379,11 @@ func commonCmd(config *devCommonConfig, mode string) error {
 			return portsErr
 		}
 
-		var debugPort string
 		codeWindProjectID := os.Getenv("CODEWIND_PROJECT_ID")
-
+		var debugPort string
+		var debugPortErr error
 		if codeWindProjectID != "" && mode == "debug" {
-			debugPort, debugPortErr := GetEnvVar("APPSODY_DEBUG_PORT", config.RootCommandConfig)
+			debugPort, debugPortErr = GetEnvVar("APPSODY_DEBUG_PORT", config.RootCommandConfig)
 			if debugPortErr != nil || debugPort == "" {
 				config.Debug.log("No debug port found. Continuing...")
 			} else {

--- a/cmd/dev_common.go
+++ b/cmd/dev_common.go
@@ -384,9 +384,9 @@ func commonCmd(config *devCommonConfig, mode string) error {
 		if debugPortErr != nil || debugPorts == "" {
 			config.Debug.log("No debug port found. Continuing...")
 		} else {
-			debugPortArray = strings.Split(debugPorts, " ") //Split the string if multiple debug ports exist
+			debugPortArray = strings.Split(debugPorts, ", ") //Split the string if multiple debug ports exist
 			for _, debugPort := range debugPortArray {
-				debugPortExists := FindElement(portList, debugPort) //Determine whether all ports specified in env var have actually been exposed
+				debugPortExists := InArray(portList, debugPort) //Determine whether all ports specified in env var have actually been exposed
 				if !debugPortExists {
 					return errors.Errorf("Port: %s specified in APPSODY_DEBUG_PORT could not be found in ports list", debugPort)
 				}

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1173,7 +1173,7 @@ func getExposedPorts(config *RootCommandConfig) ([]string, error) {
 }
 
 //GenDeploymentYaml generates a simple yaml for a plaing K8S deployment
-func GenDeploymentYaml(log *LoggingConfig, appName string, imageName string, controllerImageName string, ports []string, debugPort string, pdir string, dockerMounts []string, dockerEnvVars map[string]string, depsMount string, dryrun bool) (fileName string, err error) {
+func GenDeploymentYaml(log *LoggingConfig, appName string, imageName string, controllerImageName string, ports []string, debugPortArray []string, pdir string, dockerMounts []string, dockerEnvVars map[string]string, depsMount string, dryrun bool) (fileName string, err error) {
 
 	// Codewind workspace root dir constant
 	codeWindWorkspace := "/"
@@ -1306,7 +1306,8 @@ func GenDeploymentYaml(log *LoggingConfig, appName string, imageName string, con
 	//Set the containerPort
 	containerPorts := make([]*Port, 0)
 	for i, port := range ports {
-		if port == debugPort {
+		portFound := findElement(debugPortArray, port)
+		if portFound {
 			log.Debug.log("Debug port found. Skipping addition to the deployment file...")
 		} else {
 			//KNative only allows a single port entry
@@ -1395,6 +1396,16 @@ func GenDeploymentYaml(log *LoggingConfig, appName string, imageName string, con
 	}
 	return yamlFile, nil
 }
+
+func findElement(slice []string, value string) bool {
+	for _, item := range slice {
+		if item == value {
+			return true
+		}
+	}
+	return false
+}
+
 func getDeploymentTemplate() string {
 	yamltempl := `
 apiVersion: apps/v1
@@ -1436,7 +1447,7 @@ spec:
 }
 
 //GenServiceYaml returns the file name of a generated K8S Service yaml
-func GenServiceYaml(log *LoggingConfig, appName string, ports []string, debugPort string, pdir string, dryrun bool) (fileName string, err error) {
+func GenServiceYaml(log *LoggingConfig, appName string, ports []string, debugPortArray []string, pdir string, dryrun bool) (fileName string, err error) {
 
 	type Port struct {
 		Name       string `yaml:"name,omitempty"`
@@ -1495,8 +1506,9 @@ func GenServiceYaml(log *LoggingConfig, appName string, ports []string, debugPor
 	service.Spec.ServiceType = "NodePort"
 	service.Spec.Ports = make([]Port, len(ports))
 	for i, port := range ports {
-		if port == debugPort {
-			log.Debug.log("Debug port found. Skipping addition to the service file...")
+		portFound := findElement(debugPortArray, port)
+		if portFound {
+			log.Debug.log("Debug port found. Skipping addition to the deployment file...")
 		} else {
 			service.Spec.Ports[i].Name = fmt.Sprintf("port-%d", i)
 			iPort, err := strconv.Atoi(port)

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1306,7 +1306,7 @@ func GenDeploymentYaml(log *LoggingConfig, appName string, imageName string, con
 	//Set the containerPort
 	containerPorts := make([]*Port, 0)
 	for i, port := range ports {
-		portFound := findElement(debugPortArray, port)
+		portFound := FindElement(debugPortArray, port)
 		if portFound {
 			log.Debug.log("Debug port found. Skipping addition to the deployment file...")
 		} else {
@@ -1397,7 +1397,8 @@ func GenDeploymentYaml(log *LoggingConfig, appName string, imageName string, con
 	return yamlFile, nil
 }
 
-func findElement(slice []string, value string) bool {
+//FindElement returns true if an element is in an array, and false otherwise
+func FindElement(slice []string, value string) bool {
 	for _, item := range slice {
 		if item == value {
 			return true
@@ -1504,9 +1505,9 @@ func GenServiceYaml(log *LoggingConfig, appName string, ports []string, debugPor
 	service.Spec.Selector = make(map[string]string, 1)
 	service.Spec.Selector["app"] = appName
 	service.Spec.ServiceType = "NodePort"
-	service.Spec.Ports = make([]Port, len(ports))
+	service.Spec.Ports = make([]Port, len(ports)-len(debugPortArray))
 	for i, port := range ports {
-		portFound := findElement(debugPortArray, port)
+		portFound := FindElement(debugPortArray, port)
 		if portFound {
 			log.Debug.log("Debug port found. Skipping addition to the deployment file...")
 		} else {

--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -1306,7 +1306,7 @@ func GenDeploymentYaml(log *LoggingConfig, appName string, imageName string, con
 	//Set the containerPort
 	containerPorts := make([]*Port, 0)
 	for i, port := range ports {
-		portFound := FindElement(debugPortArray, port)
+		portFound := InArray(debugPortArray, port)
 		if portFound {
 			log.Debug.log("Debug port found. Skipping addition to the deployment file...")
 		} else {
@@ -1397,10 +1397,10 @@ func GenDeploymentYaml(log *LoggingConfig, appName string, imageName string, con
 	return yamlFile, nil
 }
 
-//FindElement returns true if an element is in an array, and false otherwise
-func FindElement(slice []string, value string) bool {
-	for _, item := range slice {
-		if item == value {
+//InArray returns true if an element is in an array, and false otherwise
+func InArray(haystack []string, needle string) bool {
+	for _, value := range haystack {
+		if needle == value {
 			return true
 		}
 	}
@@ -1507,7 +1507,7 @@ func GenServiceYaml(log *LoggingConfig, appName string, ports []string, debugPor
 	service.Spec.ServiceType = "NodePort"
 	service.Spec.Ports = make([]Port, len(ports)-len(debugPortArray))
 	for i, port := range ports {
-		portFound := FindElement(debugPortArray, port)
+		portFound := InArray(debugPortArray, port)
 		if portFound {
 			log.Debug.log("Debug port found. Skipping addition to the deployment file...")
 		} else {


### PR DESCRIPTION
Fixes: https://github.com/appsody/appsody/issues/993

To utilise this, the stack must have an `APPSODY_DEBUG_PORT` environment variable defined in the `Dockerfile-stack` e.g. for the `nodejs-express` stack `APPSODY_DEBUG_PORT=9229`.

To test the changes (since stacks don't currently have this defined)
- Clone appsody/stacks repo or run e.g. `appsody stack create nodejs-express --copy nodejs-express`
- Add `ENV APPSODY_DEBUG_PORT=9229` to the `Dockerfile-stack`
- Run `appsody stack package`
- `export APPSODY_K8S_EXPERIMENTAL=TRUE`
- `appsody init` the newly packaged stack and `appsody run` (Ensure you've built the CLI locally and are using that instead of your installed version of Appsody)