### PR TITLE
Make appsody stack lint more forgiving

### DIFF
--- a/cmd/stack_lint_dockerfile_stack.go
+++ b/cmd/stack_lint_dockerfile_stack.go
@@ -58,8 +58,7 @@ func getENVDockerfile(log *LoggingConfig, stackPath string) (dockerfileStack map
 }
 
 func lintDockerFileStack(log *LoggingConfig, stackPath string) (int, int) {
-	mendatoryEnvironmentVariables := [...]string{"APPSODY_MOUNTS", "APPSODY_RUN"}
-	optionalEnvironmentVariables := [...]string{"APPSODY_DEBUG", "APPSODY_TEST", "APPSODY_DEPS", "APPSODY_PROJECT_DIR"}
+	optionalEnvironmentVariables := [...]string{"APPSODY_DEBUG", "APPSODY_TEST", "APPSODY_DEPS", "APPSODY_PROJECT_DIR", "APPSODY_MOUNTS", "APPSODY_RUN"}
 
 	stackLintErrorCount := 0
 	stackLintWarningCount := 0
@@ -71,22 +70,6 @@ func lintDockerFileStack(log *LoggingConfig, stackPath string) (int, int) {
 
 	variableFound := false
 	variable := ""
-
-	for i := 0; i < len(mendatoryEnvironmentVariables); i++ {
-		variable = mendatoryEnvironmentVariables[i]
-		for k := range dockerfileStack {
-			if k == mendatoryEnvironmentVariables[i] {
-				variableFound = true
-			}
-		}
-		if !variableFound {
-			log.Error.log("Missing ", variable)
-			stackLintErrorCount++
-		}
-		variableFound = false
-	}
-
-	variableFound = false
 
 	for i := 0; i < len(optionalEnvironmentVariables); i++ {
 		variable = optionalEnvironmentVariables[i]
@@ -119,13 +102,13 @@ func lintDockerFileStack(log *LoggingConfig, stackPath string) (int, int) {
 	}
 
 	if count == len(dockerfileStack) && !onChangeFound {
-		log.Error.log("APPSODY_WATCH_DIR is defined, but no ON_CHANGE variable is defined")
-		stackLintErrorCount++
+		log.Warning.log("APPSODY_WATCH_DIR is defined, but no ON_CHANGE variable is defined")
+		stackLintWarningCount++
 	}
 
 	for k, v := range dockerfileStack {
 		if strings.Contains(k, "APPSODY_INSTALL") {
-			log.Warning.log("APPSODY_INSTALL should be deprecated and APPSODY_PREP should be used instead")
+			log.Warning.log("APPSODY_INSTALL has been deprecated. Please use APPSODY_PREP instead")
 			stackLintWarningCount++
 		}
 
@@ -155,8 +138,8 @@ func lintDockerFileStack(log *LoggingConfig, stackPath string) (int, int) {
 func lintMountVar(mountListSource string, log *LoggingConfig, stackPath string) (int, int) {
 
 	if mountListSource == "" {
-		log.Error.log("No APPSODY MOUNTS exists, mount paths can not be validated.")
-		return 0, 1
+		log.Warning.log("No APPSODY MOUNTS exists, mount paths can not be validated.")
+		return 1, 0
 	}
 	errCount := 0
 	warningCount := 0

--- a/cmd/stack_lint_dockerfile_stack.go
+++ b/cmd/stack_lint_dockerfile_stack.go
@@ -136,13 +136,14 @@ func lintDockerFileStack(log *LoggingConfig, stackPath string) (int, int) {
 }
 
 func lintMountVar(mountListSource string, log *LoggingConfig, stackPath string) (int, int) {
+	errCount := 0
+	warningCount := 0
 
 	if mountListSource == "" {
 		log.Warning.log("No APPSODY MOUNTS exists, mount paths can not be validated.")
-		return 1, 0
+		warningCount++
+		return warningCount, errCount
 	}
-	errCount := 0
-	warningCount := 0
 	mountList := strings.Split(mountListSource, ";")
 
 	templatePath := filepath.Join(stackPath, "templates")
@@ -151,15 +152,18 @@ func lintMountVar(mountListSource string, log *LoggingConfig, stackPath string) 
 	log.Debug.log("Template path exists: ", fileCheck)
 	if err != nil {
 		log.Error.log("Error attempting to determine if template path exists: ", err)
-		return 0, 1
+		errCount++
+		return warningCount, errCount
 	}
 	if !fileCheck {
 		log.Error.log("Missing template directory in: ", stackPath)
-		return 0, 1
+		errCount++
+		return warningCount, errCount
 	}
 	if IsEmptyDir(templatePath) {
 		log.Error.log("No templates found in: ", templatePath)
-		return 0, 1
+		errCount++
+		return warningCount, errCount
 	}
 	templates, _ := ioutil.ReadDir(templatePath)
 

--- a/cmd/stack_lint_test.go
+++ b/cmd/stack_lint_test.go
@@ -103,7 +103,6 @@ func TestLinterWarnings(t *testing.T) {
 	}{
 		{"Invalid Run Value", dockerfilePath, "APPSODY_RUN", "Testing", "Missing APPSODY_RUN"},
 		{"Invalid Watch Dir", dockerfilePath, "_ON_CHANGE", "Testing", "APPSODY_WATCH_DIR is defined, but no ON_CHANGE variable is defined"},
-		// Fails unmarshalling the file when searching for "name" - searching for "sample stack" instead
 		{"Invalid License Field", "stack.yaml", "license: ", "license: invalidLicense", "The stack.yaml SPDX license ID is invalid"},
 	}
 	for _, testData := range linterInvalidValues {

--- a/cmd/stack_yaml_lint.go
+++ b/cmd/stack_yaml_lint.go
@@ -27,6 +27,7 @@ import (
 
 func (stackDetails *StackYaml) validateYaml(rootConfig *RootCommandConfig, stackPath string) (int, int) {
 	stackLintErrorCount := 0
+	stackLintWarningCount := 0
 	arg := filepath.Join(stackPath, "/stack.yaml")
 
 	rootConfig.Info.log("LINTING stack.yaml: ", arg)
@@ -51,11 +52,12 @@ func (stackDetails *StackYaml) validateYaml(rootConfig *RootCommandConfig, stack
 	}
 
 	stackLintErrorCount += stackDetails.checkDescLength(rootConfig.LoggingConfig)
-	stackLintErrorCount += stackDetails.checkLicense(rootConfig.LoggingConfig)
+	stackLintWarningCount += stackDetails.checkLicense(rootConfig.LoggingConfig)
 	stackLintErrorCount += stackDetails.checkRequirements(rootConfig.LoggingConfig)
 	templateErrorCount, templateWarningCount := stackDetails.checkTemplatingData(rootConfig.LoggingConfig)
 	stackLintErrorCount += templateErrorCount
-	return stackLintErrorCount, templateWarningCount
+	stackLintWarningCount += templateWarningCount
+	return stackLintErrorCount, stackLintWarningCount
 }
 
 func (stackDetails *StackYaml) validateFields(rootConfig *RootCommandConfig) int {
@@ -130,16 +132,16 @@ func (stackDetails *StackYaml) checkTemplatingData(log *LoggingConfig) (int, int
 }
 
 func (stackDetails *StackYaml) checkLicense(log *LoggingConfig) int {
-	stackLintErrorCount := 0
+	stackLintWarningCount := 0
 
 	if err := checkValidLicense(log, stackDetails.License); err != nil {
-		stackLintErrorCount++
-		log.Error.logf("The stack.yaml SPDX license ID is invalid: %v.", err)
+		stackLintWarningCount++
+		log.Warning.logf("The stack.yaml SPDX license ID is invalid: %v.", err)
 	}
 	if valid, err := IsValidKubernetesLabelValue(stackDetails.License); !valid {
-		log.Error.logf("The stack.yaml SPDX license ID is invalid: %v.", err)
+		log.Warning.logf("The stack.yaml SPDX license ID is invalid: %v.", err)
 	}
-	return stackLintErrorCount
+	return stackLintWarningCount
 }
 
 func (stackDetails *StackYaml) checkRequirements(log *LoggingConfig) int {

--- a/cmd/stack_yaml_lint.go
+++ b/cmd/stack_yaml_lint.go
@@ -139,6 +139,7 @@ func (stackDetails *StackYaml) checkLicense(log *LoggingConfig) int {
 		log.Warning.logf("The stack.yaml SPDX license ID is invalid: %v.", err)
 	}
 	if valid, err := IsValidKubernetesLabelValue(stackDetails.License); !valid {
+		stackLintWarningCount++
 		log.Warning.logf("The stack.yaml SPDX license ID is invalid: %v.", err)
 	}
 	return stackLintWarningCount


### PR DESCRIPTION
Makes `appsody stack lint` much more forgiving. It will no longer error out for missing variables in the `Dockerfile-stack`. This has caused problems for stacks that inherit from a parent failing due to missing variables. It also changes the license checker to a warning too.

Fixes: https://github.com/appsody/appsody/issues/995
Fixes: https://github.com/appsody/appsody/issues/996