### PR TITLE
Lint APPSODY_DEBUG_PORT environment variable

### DIFF
--- a/cmd/stack_lint_dockerfile_stack.go
+++ b/cmd/stack_lint_dockerfile_stack.go
@@ -69,6 +69,7 @@ func lintDockerFileStack(log *LoggingConfig, stackPath string) (int, int) {
 	dockerfileStack := getENVDockerfile(log, stackPath)
 
 	variableFound := false
+	appsodyDebugFound := false
 	variable := ""
 
 	for i := 0; i < len(optionalEnvironmentVariables); i++ {
@@ -77,14 +78,17 @@ func lintDockerFileStack(log *LoggingConfig, stackPath string) (int, int) {
 			if k == optionalEnvironmentVariables[i] {
 				variableFound = true
 			}
+			if k == "APPSODY_DEBUG" {
+				appsodyDebugFound = true
+			}
 		}
 		if !variableFound {
-			if optionalEnvironmentVariables[i] == "APPSODY_DEBUG_PORT" {
-				log.Warning.log("Missing APPSODY_DEBUG_PORT. If your stack supports the appsody debug command, please define this variable.")
-			} else {
-				log.Warning.log("Missing ", variable)
-				stackLintWarningCount++
+			errMsg := ""
+			if appsodyDebugFound == true && optionalEnvironmentVariables[i] == "APPSODY_DEBUG_PORT" {
+				errMsg = ". The APPSODY_DEBUG environment variable was found but no APPSODY_DEBUG_PORT."
 			}
+			log.Warning.log("Missing ", variable, errMsg)
+			stackLintWarningCount++
 		}
 		variableFound = false
 	}

--- a/cmd/stack_lint_dockerfile_stack.go
+++ b/cmd/stack_lint_dockerfile_stack.go
@@ -58,7 +58,7 @@ func getENVDockerfile(log *LoggingConfig, stackPath string) (dockerfileStack map
 }
 
 func lintDockerFileStack(log *LoggingConfig, stackPath string) (int, int) {
-	optionalEnvironmentVariables := [...]string{"APPSODY_DEBUG", "APPSODY_TEST", "APPSODY_DEPS", "APPSODY_PROJECT_DIR", "APPSODY_MOUNTS", "APPSODY_RUN"}
+	optionalEnvironmentVariables := [...]string{"APPSODY_DEBUG", "APPSODY_TEST", "APPSODY_DEPS", "APPSODY_PROJECT_DIR", "APPSODY_MOUNTS", "APPSODY_RUN", "APPSODY_DEBUG_PORT"}
 
 	stackLintErrorCount := 0
 	stackLintWarningCount := 0
@@ -79,8 +79,12 @@ func lintDockerFileStack(log *LoggingConfig, stackPath string) (int, int) {
 			}
 		}
 		if !variableFound {
-			log.Warning.log("Missing ", variable)
-			stackLintWarningCount++
+			if optionalEnvironmentVariables[i] == "APPSODY_DEBUG_PORT" {
+				log.Warning.log("Missing APPSODY_DEBUG_PORT. If your stack supports the appsody debug command, please define this variable.")
+			} else {
+				log.Warning.log("Missing ", variable)
+				stackLintWarningCount++
+			}
 		}
 		variableFound = false
 	}

--- a/cmd/stack_lint_dockerfile_stack.go
+++ b/cmd/stack_lint_dockerfile_stack.go
@@ -84,7 +84,7 @@ func lintDockerFileStack(log *LoggingConfig, stackPath string) (int, int) {
 		}
 		if !variableFound {
 			errMsg := ""
-			if appsodyDebugFound == true && optionalEnvironmentVariables[i] == "APPSODY_DEBUG_PORT" {
+			if appsodyDebugFound && optionalEnvironmentVariables[i] == "APPSODY_DEBUG_PORT" {
 				errMsg = ". The APPSODY_DEBUG environment variable was found but no APPSODY_DEBUG_PORT."
 			}
 			log.Warning.log("Missing ", variable, errMsg)


### PR DESCRIPTION
Adds the `APPSODY_DEBUG_PORT` variable to the linter as a warning.