### PR TITLE
Use format option to extract docker version

### DIFF
--- a/cmd/utils.go
+++ b/cmd/utils.go
@@ -2401,7 +2401,12 @@ func CheckStackRequirements(log *LoggingConfig, requirementArray map[string]stri
 			}
 			runVersionCmd = VERSION
 		} else {
-			cmd := exec.Command(strings.ToLower(technology), "version")
+			var cmd *exec.Cmd
+			if strings.ToLower(technology) == "docker" {
+				cmd = exec.Command(strings.ToLower(technology), "version", "--format", "{{.Client.Version}}")
+			} else {
+				cmd = exec.Command(strings.ToLower(technology), "version")
+			}
 			runVersionCmd, err = SeparateOutput(cmd)
 			if err != nil {
 				log.Error.log(err, " - Are you sure ", technology, " is installed?")


### PR DESCRIPTION
The current code to extract and check the minimum docker version is unsafe, since it assumes that the version is the first x.y.z sequence to appear in the output of the `docker version` command. This is no longer true, for instance with docker 19.03.12 on macOS (where the first version listed in the output turns our to be the Azure integration version!). This causes all `appsody init` commands to fail if the stack in question specifies a minimal Docker version in its stack.yaml.

While there is perhaps a larger conversation to be had about whether the correct goal is to check the client or server version of docker (or both?), this fix simply makes the current attempt to check the docker client version safe.

Fixes #1008 